### PR TITLE
Start fixing CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         group:
           - Core
-          - Downstream
         version:
           - '1'
           - '1.6'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ const is_APPVEYOR = Sys.iswindows() && haskey(ENV, "APPVEYOR")
 
 @time begin
 
-if GROUP == "All" || GROUP == "Interface"
+if GROUP == "All" || GROUP == "Core" || GROUP == "Downstream" || GROUP == "Interface"
     #@time @safetestset "Linear Solver Tests" begin include("interface/linear_solver_test.jl") end
     @time @safetestset "Basic Tests + Some AD" begin include("basictests.jl") end
 end end


### PR DESCRIPTION
The CI in some of the repos does not do anything, e.g.
https://github.com/SciML/SciMLOperators.jl/actions/runs/3119548680/jobs/5059578239#step:6:194
This is because there is insufficient control flow for `GROUP`.

It is not clear to me how _interface_ differs from _downstream_.