### PR TITLE
Bug fix for TrustRegion when iip=true.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,10 @@ docs/site/
 # environment.
 Manifest.toml
 docs/src/assets/Project.toml
+
+.vscode
+TEST1.jl
+TEST2.jl
+TEST3.jl
+trustRegion copy.jl
+trustRegionHOLDER.jl

--- a/.gitignore
+++ b/.gitignore
@@ -23,10 +23,3 @@ docs/site/
 # environment.
 Manifest.toml
 docs/src/assets/Project.toml
-
-.vscode
-TEST1.jl
-TEST2.jl
-TEST3.jl
-trustRegion copy.jl
-trustRegionHOLDER.jl

--- a/src/trustRegion.jl
+++ b/src/trustRegion.jl
@@ -307,7 +307,6 @@ function trust_region_step!(cache::TrustRegionCache)
         cache.shrink_counter = 0
     end
     if r > alg.step_threshold
-
         take_step!(cache)
         cache.loss = cache.loss_new
 

--- a/src/trustRegion.jl
+++ b/src/trustRegion.jl
@@ -242,7 +242,7 @@ function SciMLBase.__init(prob::NonlinearProblem{uType, iip}, alg::TrustRegion,
     return TrustRegionCache{iip}(f, alg, u, fu, p, uf, linsolve, J, jac_config,
                                  1, false, maxiters, internalnorm,
                                  ReturnCode.Default, abstol, prob, initial_trust_radius,
-                                 max_trust_radius, loss, loss, H, fu, 0, u, u_tmp, fu, true,
+                                 max_trust_radius, loss, loss, H, zero(fu), 0, zero(u), u_tmp, zero(fu), true,
                                  loss)
 end
 

--- a/src/trustRegion.jl
+++ b/src/trustRegion.jl
@@ -355,8 +355,8 @@ function dogleg!(cache::TrustRegionCache)
 end
 
 function take_step!(cache::TrustRegionCache{true})
-    cache.u = copy(cache.u_tmp)
-    cache.fu = copy(cache.fu_new)
+    cache.u .= cache.u_tmp
+    cache.fu .= cache.fu_new
 end
 
 function take_step!(cache::TrustRegionCache{false})

--- a/src/trustRegion.jl
+++ b/src/trustRegion.jl
@@ -242,7 +242,8 @@ function SciMLBase.__init(prob::NonlinearProblem{uType, iip}, alg::TrustRegion,
     return TrustRegionCache{iip}(f, alg, u, fu, p, uf, linsolve, J, jac_config,
                                  1, false, maxiters, internalnorm,
                                  ReturnCode.Default, abstol, prob, initial_trust_radius,
-                                 max_trust_radius, loss, loss, H, zero(fu), 0, zero(u), u_tmp, zero(fu), true,
+                                 max_trust_radius, loss, loss, H, zero(fu), 0, zero(u),
+                                 u_tmp, zero(fu), true,
                                  loss)
 end
 

--- a/src/trustRegion.jl
+++ b/src/trustRegion.jl
@@ -309,8 +309,8 @@ function trust_region_step!(cache::TrustRegionCache)
     if r > alg.step_threshold
 
         # Take the step.
-        cache.u = u_tmp
-        cache.fu = fu_new
+        cache.u = copy(u_tmp)
+        cache.fu = copy(fu_new)
         cache.loss = cache.loss_new
 
         # Update the trust region radius.
@@ -324,7 +324,7 @@ function trust_region_step!(cache::TrustRegionCache)
         cache.make_new_J = false
     end
 
-    if iszero(cache.fu) || cache.internalnorm(cache.step_size) < cache.abstol
+    if iszero(cache.fu) || cache.internalnorm(cache.fu) < cache.abstol
         cache.force_stop = true
     end
 end

--- a/src/trustRegion.jl
+++ b/src/trustRegion.jl
@@ -309,8 +309,8 @@ function trust_region_step!(cache::TrustRegionCache)
     if r > alg.step_threshold
 
         # Take the step.
-        cache.u = copy(u_tmp)
-        cache.fu = copy(fu_new)
+        take_step!(cache)
+
         cache.loss = cache.loss_new
 
         # Update the trust region radius.
@@ -354,6 +354,16 @@ function dogleg!(cache::TrustRegionCache)
     fact = dot_sd_N_sd^2 - dot_N_sd * (dot_sd - trust_r^2)
     τ = (-dot_sd_N_sd + sqrt(fact)) / dot_N_sd
     cache.step_size = δsd + τ * N_sd
+end
+
+function take_step!(cache::TrustRegionCache{true})
+    cache.u = copy(cache.u_tmp)
+    cache.fu = copy(cache.fu_new)
+end
+
+function take_step!(cache::TrustRegionCache{false})
+    cache.u = cache.u_tmp
+    cache.fu = cache.fu_new
 end
 
 function SciMLBase.solve!(cache::TrustRegionCache)

--- a/src/trustRegion.jl
+++ b/src/trustRegion.jl
@@ -308,9 +308,7 @@ function trust_region_step!(cache::TrustRegionCache)
     end
     if r > alg.step_threshold
 
-        # Take the step.
         take_step!(cache)
-
         cache.loss = cache.loss_new
 
         # Update the trust region radius.

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -34,13 +34,13 @@ u0 = [1.0, 1.0]
 
 sol = benchmark_immutable(ff, cu0)
 @test sol.retcode === ReturnCode.Success
-@test all(sol.u .* sol.u .- 2 .< 1e-9)
+@test all(abs.(sol.u .* sol.u .- 2) .< 1e-9)
 sol = benchmark_mutable(ff, u0)
 @test sol.retcode === ReturnCode.Success
-@test all(sol.u .* sol.u .- 2 .< 1e-9)
+@test all(abs.(sol.u .* sol.u .- 2) .< 1e-9)
 sol = benchmark_scalar(sf, csu0)
 @test sol.retcode === ReturnCode.Success
-@test sol.u * sol.u - 2 < 1e-9
+@test abs(sol.u * sol.u - 2) < 1e-9
 
 # @test (@ballocated benchmark_immutable(ff, cu0)) < 200
 # @test (@ballocated benchmark_mutable(ff, cu0)) < 200
@@ -59,7 +59,7 @@ u0 = [1.0, 1.0]
 
 sol = benchmark_inplace(ffiip, u0)
 @test sol.retcode === ReturnCode.Success
-@test all(sol.u .* sol.u .- 2 .< 1e-9)
+@test all(abs.(sol.u .* sol.u .- 2) .< 1e-9)
 
 u0 = [1.0, 1.0]
 probN = NonlinearProblem{true}(ffiip, u0)
@@ -160,13 +160,13 @@ u0 = [1.0, 1.0]
 
 sol = benchmark_immutable(ff, cu0)
 @test sol.retcode === ReturnCode.Success
-@test all(sol.u .* sol.u .- 2 .< 1e-9)
+@test all(abs.(sol.u .* sol.u .- 2) .< 1e-9)
 sol = benchmark_mutable(ff, u0)
 @test sol.retcode === ReturnCode.Success
-@test all(sol.u .* sol.u .- 2 .< 1e-9)
+@test all(abs.(sol.u .* sol.u .- 2) .< 1e-9)
 sol = benchmark_scalar(sf, csu0)
 @test sol.retcode === ReturnCode.Success
-@test sol.u * sol.u - 2 < 1e-9
+@test abs(sol.u * sol.u - 2) < 1e-9
 
 function benchmark_inplace(f, u0)
     probN = NonlinearProblem{true}(f, u0)
@@ -181,7 +181,7 @@ u0 = [1.0, 1.0]
 
 sol = benchmark_inplace(ffiip, u0)
 @test sol.retcode === ReturnCode.Success
-@test all(sol.u .* sol.u .- 2 .< 1e-9)
+@test all(abs.(sol.u .* sol.u .- 2) .< 1e-9)
 
 u0 = [1.0, 1.0]
 probN = NonlinearProblem{true}(ffiip, u0)
@@ -263,7 +263,7 @@ f = (u, p) -> 0.010000000000000002 .+
               0.0011552453009332421u .- p
 g = function (p)
     probN = NonlinearProblem{false}(f, u0, p)
-    sol = solve(probN, TrustRegion())
+    sol = solve(probN, TrustRegion(), abstol = 1e-10)
     return sol.u
 end
 p = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
@@ -295,7 +295,7 @@ for options in list_of_options
                       expand_factor = options[7],
                       max_shrink_times = options[8])
 
-    probN = NonlinearProblem(f, u0, p)
-    sol = solve(probN, alg)
-    @test all(f(u, p) .< 1e-10)
+    probN = NonlinearProblem{false}(f, u0, p)
+    sol = solve(probN, alg, abstol = 1e-10)
+    @test all(abs.(f(u, p)) .< 1e-10)
 end


### PR DESCRIPTION
This is an attempt to fix the bug that currently exists in the `TrustRegion` solver when `iip=true` #124.
The bug went trough testing because the tests did not take the absolute value, allowing all negative values to pass, i.e. `@test all(sol.u .* sol.u .- 2 .< 1e-9)` and not `@test all(abs.(sol.u .* sol.u .- 2) .< 1e-9)` as it should be.

The bug is due to that `cache.u` and `cache.fu` points to the same vector as `cache.u_tmp` and `cache.fu_new` respectively, and then both of them get changed at unwanted places.