### PR TITLE
Implementation of a Levenberg–Marquardt algorithm

### DIFF
--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -41,7 +41,7 @@ SnoopPrecompile.@precompile_all_calls begin for T in (Float32, Float64)
     prob = NonlinearProblem{false}((u, p) -> u .* u .- p, T(0.1), T(2))
 
     precompile_algs = if VERSION >= v"1.7"
-        (NewtonRaphson(),)
+        (NewtonRaphson(), LevenbergMarquardt())
     else
         (NewtonRaphson(),)
     end

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -41,7 +41,7 @@ SnoopPrecompile.@precompile_all_calls begin for T in (Float32, Float64)
     prob = NonlinearProblem{false}((u, p) -> u .* u .- p, T(0.1), T(2))
 
     precompile_algs = if VERSION >= v"1.7"
-        (NewtonRaphson(), TrustRegion(), LevenbergMarquardt())
+        (NewtonRaphson(),)
     else
         (NewtonRaphson(),)
     end

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -41,7 +41,7 @@ SnoopPrecompile.@precompile_all_calls begin for T in (Float32, Float64)
     prob = NonlinearProblem{false}((u, p) -> u .* u .- p, T(0.1), T(2))
 
     precompile_algs = if VERSION >= v"1.7"
-        (NewtonRaphson(), LevenbergMarquardt())
+        (NewtonRaphson(),)
     else
         (NewtonRaphson(),)
     end

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -41,7 +41,7 @@ SnoopPrecompile.@precompile_all_calls begin for T in (Float32, Float64)
     prob = NonlinearProblem{false}((u, p) -> u .* u .- p, T(0.1), T(2))
 
     precompile_algs = if VERSION >= v"1.7"
-        (NewtonRaphson(), TrustRegion())
+        (NewtonRaphson(), TrustRegion(), LevenbergMarquardt())
     else
         (NewtonRaphson(),)
     end

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -32,6 +32,7 @@ include("utils.jl")
 include("jacobian.jl")
 include("raphson.jl")
 include("trustRegion.jl")
+include("levenberg.jl")
 include("ad.jl")
 
 import SnoopPrecompile
@@ -48,6 +49,6 @@ SnoopPrecompile.@precompile_all_calls begin for T in (Float32, Float64)
     end
 end end
 
-export NewtonRaphson, TrustRegion
+export NewtonRaphson, TrustRegion, LevenbergMarquardt
 
 end # module

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -41,7 +41,7 @@ SnoopPrecompile.@precompile_all_calls begin for T in (Float32, Float64)
     prob = NonlinearProblem{false}((u, p) -> u .* u .- p, T(0.1), T(2))
 
     precompile_algs = if VERSION >= v"1.7"
-        (NewtonRaphson(),)
+        (NewtonRaphson(), TrustRegion(), LevenbergMarquardt())
     else
         (NewtonRaphson(),)
     end

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -26,7 +26,7 @@ end
 function SciMLBase.solve(prob::NonlinearProblem{<:Union{Number, StaticArraysCore.SVector},
                                                 iip,
                                                 <:Dual{T, V, P}},
-                         alg::Union{NewtonRaphson, TrustRegion},
+                         alg::Union{NewtonRaphson, TrustRegion, LevenbergMarquardt},
                          args...; kwargs...) where {iip, T, V, P}
     sol, partials = scalar_nlsolve_ad(prob, alg, args...; kwargs...)
     return SciMLBase.build_solution(prob, alg, Dual{T, V, P}(sol.u, partials), sol.resid;
@@ -35,7 +35,8 @@ end
 function SciMLBase.solve(prob::NonlinearProblem{<:Union{Number, StaticArraysCore.SVector},
                                                 iip,
                                                 <:AbstractArray{<:Dual{T, V, P}}},
-                         alg::Union{NewtonRaphson, TrustRegion}, args...;
+                         alg::Union{NewtonRaphson, TrustRegion, LevenbergMarquardt},
+                         args...;
                          kwargs...) where {iip, T, V, P}
     sol, partials = scalar_nlsolve_ad(prob, alg, args...; kwargs...)
     return SciMLBase.build_solution(prob, alg, Dual{T, V, P}(sol.u, partials), sol.resid;

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -26,7 +26,7 @@ end
 function SciMLBase.solve(prob::NonlinearProblem{<:Union{Number, StaticArraysCore.SVector},
                                                 iip,
                                                 <:Dual{T, V, P}},
-                         alg::Union{NewtonRaphson, TrustRegion, LevenbergMarquardt},
+                         alg::AbstractNewtonAlgorithm,
                          args...; kwargs...) where {iip, T, V, P}
     sol, partials = scalar_nlsolve_ad(prob, alg, args...; kwargs...)
     return SciMLBase.build_solution(prob, alg, Dual{T, V, P}(sol.u, partials), sol.resid;
@@ -35,7 +35,7 @@ end
 function SciMLBase.solve(prob::NonlinearProblem{<:Union{Number, StaticArraysCore.SVector},
                                                 iip,
                                                 <:AbstractArray{<:Dual{T, V, P}}},
-                         alg::Union{NewtonRaphson, TrustRegion, LevenbergMarquardt},
+                         alg::AbstractNewtonAlgorithm,
                          args...;
                          kwargs...) where {iip, T, V, P}
     sol, partials = scalar_nlsolve_ad(prob, alg, args...; kwargs...)

--- a/src/levenberg.jl
+++ b/src/levenberg.jl
@@ -1,13 +1,27 @@
 """
 ```julia
-LevenbergMarquardt(; chunk_size = Val{0}(), autodiff = Val{true}(),
-                standardtag = Val{true}(), concrete_jac = nothing,
-                diff_type = Val{:forward}, linsolve = nothing, precs = DEFAULT_PRECS)
+LevenbergMarquardt(; chunk_size = Val{0}(),
+                    autodiff = Val{true}(),
+                    standardtag = Val{true}(),
+                    concrete_jac = nothing,
+                    diff_type = Val{:forward},
+                    linsolve = nothing, precs = DEFAULT_PRECS,
+                    damping_initial::Real = 1.0,
+                    damping_increase_factor::Real = 2.0,
+                    damping_decrease_factor::Real = 3.0,
+                    finite_diff_step_geodesic::Real = 0.1,
+                    α_geodesic::Real = 0.75,
+                    b_uphill::Real = 1.0,
+                    min_damping_D::AbstractFloat = 1e-8)
 ```
 
-An advanced LevenbergMarquardt implementation with support for efficient handling of sparse
-matrices via colored automatic differentiation and preconditioned linear solvers. Designed
-for large-scale and numerically-difficult nonlinear systems.
+An advanced Levenberg-Marquardt implementation with the improvements suggested in the
+[paper](https://arxiv.org/abs/1201.5885) "Improvements to the Levenberg-Marquardt
+algorithm for nonlinear least-squares minimization". This implementation is designed with
+support for efficient handling of sparse matrices via colored automatic differentiation and
+preconditioned linear solvers. Designed for large-scale and numerically-difficult nonlinear
+systems.
+
 
 ### Keyword Arguments
 
@@ -42,6 +56,32 @@ for large-scale and numerically-difficult nonlinear systems.
   preconditioners. For more information on specifying preconditioners for LinearSolve
   algorithms, consult the
   [LinearSolve.jl documentation](https://docs.sciml.ai/LinearSolve/stable/).
+- `damping_initial`: the initial damping factor. The damping is proportional to the inverse
+  of the step size and is changed dynamically in each iteration. Defaults to `1.0`. For more
+  details, see section 2.1 of [this paper](https://arxiv.org/abs/1201.5885).
+- `damping_increase_factor`: the factor by which the damping is increased if a step isn't
+  accepted i.e. how much smaller the next step size should be if a step is rejected.
+  Defaults to `2.0`. For more details, see section 2.1 of
+  [this paper](https://arxiv.org/abs/1201.5885).
+- `damping_decrease_factor`: the factor by which the damping is decreased if a step is
+  accepted i.e. how much larger the next step size should be if a step is accepted.
+  Defaults to `3.0`. For more details, see section 2.1 of
+  [this paper](https://arxiv.org/abs/1201.5885).
+- `finite_diff_step_geodesic`: the finite differencing step size used for the geodesic
+  acceleration method. Defaults to `0.1` which means thats the step is about 10% of the
+  first order step. For more details, see section 3 of
+  [this paper](https://arxiv.org/abs/1201.5885).
+- `α_geodesic`: a factor that determines if a step is accepted or rejected.
+  In order to utilize the geodesic acceleration as an addition to the Levenberg-Marquardt
+  algorithm, it is necessary to make one small addition. To require acceptable steps to
+  satisfy the condition ... continue to document this...
+
+# TODO documentation and cleanup of code & che
+
+  α_geodesic::Real = 0.75,
+  b_uphill::Real = 1.0,
+  min_damping_D::AbstractFloat = 1e-8
+
 
 !!! note
 
@@ -57,13 +97,16 @@ struct LevenbergMarquardt{CS, AD, FDT, L, P, ST, CJ, T} <:
     damping_decrease_factor::T
     finite_diff_step_geodesic::T
     α_geodesic::T
-    b_uphill::T  # TODO test what happens if the input to this in an Interger, but Float to the others
+    b_uphill::T
     min_damping_D::T
 end
 
-function LevenbergMarquardt(; chunk_size = Val{0}(), autodiff = Val{true}(),
-                            standardtag = Val{true}(), concrete_jac = nothing,
-                            diff_type = Val{:forward}, linsolve = nothing,
+function LevenbergMarquardt(; chunk_size = Val{0}(),
+                            autodiff = Val{true}(),
+                            standardtag = Val{true}(),
+                            concrete_jac = nothing,
+                            diff_type = Val{:forward},
+                            linsolve = nothing,
                             precs = DEFAULT_PRECS,
                             damping_initial::Real = 1.0,
                             damping_increase_factor::Real = 2.0,
@@ -71,17 +114,17 @@ function LevenbergMarquardt(; chunk_size = Val{0}(), autodiff = Val{true}(),
                             finite_diff_step_geodesic::Real = 0.1,
                             α_geodesic::Real = 0.75,
                             b_uphill::Real = 1.0,
-                            min_damping_D::Real = 1e-6)
+                            min_damping_D::AbstractFloat = 1e-8)
     LevenbergMarquardt{_unwrap_val(chunk_size), _unwrap_val(autodiff), diff_type,
                        typeof(linsolve), typeof(precs), _unwrap_val(standardtag),
-                       _unwrap_val(concrete_jac), typeof(damping_initial)}(linsolve, precs,
-                                                                           damping_initial,
-                                                                           damping_increase_factor,
-                                                                           damping_decrease_factor,
-                                                                           finite_diff_step_geodesic,
-                                                                           α_geodesic,
-                                                                           b_uphill,
-                                                                           min_damping_D)
+                       _unwrap_val(concrete_jac), typeof(min_damping_D)}(linsolve, precs,
+                                                                         damping_initial,
+                                                                         damping_increase_factor,
+                                                                         damping_decrease_factor,
+                                                                         finite_diff_step_geodesic,
+                                                                         α_geodesic,
+                                                                         b_uphill,
+                                                                         min_damping_D)
 end
 
 mutable struct LevenbergMarquardtCache{iip, fType, algType, uType, duType, resType, pType,
@@ -97,7 +140,7 @@ mutable struct LevenbergMarquardtCache{iip, fType, algType, uType, duType, resTy
     uf::ufType
     linsolve::L
     J::jType
-    du1::duType
+    du_tmp::duType
     jac_config::JC
     iter::Int
     force_stop::Bool
@@ -109,7 +152,7 @@ mutable struct LevenbergMarquardtCache{iip, fType, algType, uType, duType, resTy
     DᵀD::DᵀDType
     JᵀJ::jType
     λ::floatType
-    λ_factor::floatType         # TODO test if this handles interger inputs. (test to input damp_init::float and damp_inc::int)
+    λ_factor::floatType
     v::uType
     a::uType
     tmp_vec::uType
@@ -117,60 +160,36 @@ mutable struct LevenbergMarquardtCache{iip, fType, algType, uType, duType, resTy
     norm_v_old::floatType
     δ::uType
     loss_old::floatType
+    make_new_J::Bool
+    fu_tmp::resType
 
     function LevenbergMarquardtCache{iip}(f::fType, alg::algType, u::uType, fu::resType,
-                                          p::pType,
-                                          uf::ufType, linsolve::L, J::jType, du1::duType,
-                                          jac_config::JC, iter::Int,
+                                          p::pType, uf::ufType, linsolve::L, J::jType,
+                                          du_tmp::duType, jac_config::JC, iter::Int,
                                           force_stop::Bool, maxiters::Int,
                                           internalnorm::INType,
                                           retcode::SciMLBase.ReturnCode.T, abstol::tolType,
                                           prob::probType, DᵀD::DᵀDType, JᵀJ::jType,
                                           λ::floatType, λ_factor::floatType, v::uType,
-                                          a::uType, tmp_vec::uType,
-                                          v_old::uType, norm_v_old::floatType, δ::uType,
-                                          loss_old::floatType) where {
-                                                                      iip, fType, algType,
-                                                                      uType,
-                                                                      duType, resType,
-                                                                      pType,
-                                                                      INType,
-                                                                      tolType,
-                                                                      probType, ufType, L,
-                                                                      jType, JC,
-                                                                      DᵀDType,
-                                                                      floatType
-                                                                      }
+                                          a::uType, tmp_vec::uType, v_old::uType,
+                                          norm_v_old::floatType, δ::uType,
+                                          loss_old::floatType,
+                                          make_new_J::Bool,
+                                          fu_tmp::resType) where {
+                                                                  iip, fType, algType,
+                                                                  uType, duType, resType,
+                                                                  pType, INType, tolType,
+                                                                  probType, ufType, L,
+                                                                  jType, JC, DᵀDType,
+                                                                  floatType
+                                                                  }
         new{iip, fType, algType, uType, duType, resType,
             pType, INType, tolType, probType, ufType, L,
-            jType, JC, DᵀDType, floatType}(f,
-                                                                   alg,
-                                                                   u,
-                                                                   fu,
-                                                                   p,
-                                                                   uf,
-                                                                   linsolve,
-                                                                   J,
-                                                                   du1,
-                                                                   jac_config,
-                                                                   iter,
-                                                                   force_stop,
-                                                                   maxiters,
-                                                                   internalnorm,
-                                                                   retcode,
-                                                                   abstol,
-                                                                   prob,
-                                                                   DᵀD,
-                                                                   JᵀJ,
-                                                                   λ,
-                                                                   λ_factor,
-                                                                   v,
-                                                                   a,
-                                                                   tmp_vec,
-                                                                   v_old,
-                                                                   norm_v_old,
-                                                                   δ,
-                                                                   loss_old)
+            jType, JC, DᵀDType, floatType}(f, alg, u, fu, p, uf, linsolve, J, du_tmp,
+                                           jac_config, iter, force_stop, maxiters,
+                                           internalnorm, retcode, abstol, prob, DᵀD,
+                                           JᵀJ, λ, λ_factor, v, a, tmp_vec, v_old,
+                                           norm_v_old, δ, loss_old, make_new_J, fu_tmp)
     end
 end
 
@@ -219,16 +238,16 @@ function SciMLBase.__init(prob::NonlinearProblem{uType, iip}, alg::LevenbergMarq
     else
         fu = f(u, p)
     end
-    uf, linsolve, J, du1, jac_config = jacobian_caches(alg, f, u, p, Val(iip))
+    uf, linsolve, J, du_tmp, jac_config = jacobian_caches(alg, f, u, p, Val(iip))
 
-    # "A good compromise is to specify a minimum value of the damping terms in DᵀD".
     if u isa Number
-        DᵀD = alg.min_damping_D # TODO check if type is correct.
+        DᵀD = alg.min_damping_D
     else
-        d = d = similar(u)
+        d = similar(u)
         d .= alg.min_damping_D
         DᵀD = Diagonal(d)
     end
+
     loss = internalnorm(fu)
     JᵀJ = zero(J)
     v = zero(u)
@@ -236,82 +255,91 @@ function SciMLBase.__init(prob::NonlinearProblem{uType, iip}, alg::LevenbergMarq
     tmp_vec = zero(u)
     v_old = zero(u)
     δ = zero(u)
+    make_new_J = true
+    fu_tmp = zero(fu)
 
-    return LevenbergMarquardtCache{iip}(f, alg, u, fu, p, uf, linsolve, J, du1, jac_config,
+    return LevenbergMarquardtCache{iip}(f, alg, u, fu, p, uf, linsolve, J, du_tmp,
+                                        jac_config,
                                         1, false, maxiters, internalnorm,
                                         ReturnCode.Default, abstol, prob, DᵀD, JᵀJ,
                                         alg.damping_initial, alg.damping_increase_factor,
-                                        v, a, tmp_vec, v_old, loss, δ, loss)
+                                        v, a, tmp_vec, v_old, loss, δ, loss, make_new_J,
+                                        fu_tmp)
 end
-
 function perform_step!(cache::LevenbergMarquardtCache{true})
-    # TODO implement for in-place...
-    # @unpack fu, f = cache
-    # if iszero(fu)
-    #     cache.force_stop = true
-    #     return nothing
-    # end
-
-    # cache.J = jacobian(cache, f)
-    # @unpack u, f, p, λ, J = cache
-    # mul!(cache.JᵀJ, J', J)
-    # cache.DᵀD .= max.(cache.DᵀD, Diagonal(cache.JᵀJ))
-
-    # # Usual Levenberg-Marquardt step ("velocity").
-    # cache.v = -(cache.JᵀJ + λ * cache.DᵀD) \ (J' * fu)
-
-    # @unpack v, alg = cache
-    # h = alg.finite_diff_step_geodesic
-    # # Geodesic acceleration (step_size = v + a / 2).
-    # cache.a = -J \ ((2 / h) .* ((f(u .+ h * v, p) .- fu) ./ h .- mul!(cache.Jv, J, v)))
-
-    # # Require acceptable steps to satisfy the following condition.
-    # norm_v = norm(v)
-    # if (2 * norm(cache.a) / norm_v) < alg.α_geodesic
-    #     cache.δ = v + cache.a / 2
-    #     @unpack δ, loss_old, norm_v_old, v_old = cache
-    #     fu_new = f(u .+ δ, p)
-    #     loss = cache.internalnorm(fu_new)
-
-    #     # Condition to accept uphill steps (evaluates to `loss ≤ loss_old` in iteration 1).
-    #     β = dot(v, v_old) / (norm_v * norm_v_old)
-    #     if (1 - β)^alg.b_uphill * loss ≤ loss_old
-    #         # Accept step.
-    #         cache.u += δ
-    #         if loss < cache.abstol
-    #             cache.force_stop = true
-    #             return nothing
-    #         end
-    #         cache.fu = fu_new
-    #         cache.v_old = v
-    #         cache.norm_v_old = norm_v
-    #         cache.loss_old = loss
-    #         cache.λ_factor = 1 / alg.damping_decrease_factor
-    #     end
-    # end
-    # cache.λ *= cache.λ_factor
-    # cache.λ_factor = alg.damping_increase_factor
-    return nothing
-end
-
-function perform_step!(cache::LevenbergMarquardtCache{false})
-    @unpack fu, f = cache
+    @unpack fu, f, make_new_J = cache
     if iszero(fu)
         cache.force_stop = true
         return nothing
     end
-
-    J = jacobian(cache, f)
-    @unpack u, f, p, λ = cache
-    cache.JᵀJ = J' * J
-    if cache.DᵀD isa Number
-        cache.DᵀD = max(cache.DᵀD, cache.JᵀJ)
-    else
+    if make_new_J
+        jacobian!(cache.J, cache)
+        mul!(cache.JᵀJ, cache.J', cache.J)
         cache.DᵀD .= max.(cache.DᵀD, Diagonal(cache.JᵀJ))
+        cache.make_new_J = false
     end
+    @unpack u, p, λ, JᵀJ, DᵀD, J = cache
 
     # Usual Levenberg-Marquardt step ("velocity").
-    cache.v = -(cache.JᵀJ + λ * cache.DᵀD) \ (J' * fu)
+    cache.v = -(JᵀJ .+ λ .* DᵀD) \ mul!(cache.du_tmp, J', fu)
+
+    @unpack v, alg = cache
+    h = alg.finite_diff_step_geodesic
+    # Geodesic acceleration (step_size = v + a / 2).
+    f(cache.fu_tmp, u .+ h .* v, p)
+    cache.a = -J \ ((2 / h) .*
+                    ((cache.fu_tmp .- fu) ./ h .- mul!(cache.du_tmp, J, v)))
+
+    # Require acceptable steps to satisfy the following condition.
+    norm_v = norm(v)
+    if (2 * norm(cache.a) / norm_v) < alg.α_geodesic
+        @. cache.δ = v + cache.a / 2
+        @unpack δ, loss_old, norm_v_old, v_old = cache
+        f(cache.fu_tmp, u .+ δ, p)
+        loss = cache.internalnorm(cache.fu_tmp)
+
+        # Condition to accept uphill steps (evaluates to `loss ≤ loss_old` in iteration 1).
+        β = dot(v, v_old) / (norm_v * norm_v_old)
+        if (1 - β)^alg.b_uphill * loss ≤ loss_old
+            # Accept step.
+            cache.u .+= δ
+            if loss < cache.abstol
+                cache.force_stop = true
+                return nothing
+            end
+            cache.fu .= cache.fu_tmp
+            cache.v_old .= v
+            cache.norm_v_old = norm_v
+            cache.loss_old = loss
+            cache.λ_factor = 1 / alg.damping_decrease_factor
+            cache.make_new_J = true
+        end
+    end
+    cache.λ *= cache.λ_factor
+    cache.λ_factor = alg.damping_increase_factor
+    return nothing
+end
+
+function perform_step!(cache::LevenbergMarquardtCache{false})
+    @unpack fu, f, make_new_J = cache
+    if iszero(fu)
+        cache.force_stop = true
+        return nothing
+    end
+    if make_new_J
+        cache.J = jacobian(cache, f)
+        cache.JᵀJ = cache.J' * cache.J
+        if cache.JᵀJ isa Number
+            cache.DᵀD = max(cache.DᵀD, cache.JᵀJ)
+        else
+            cache.DᵀD .= max.(cache.DᵀD, Diagonal(cache.JᵀJ))
+        end
+        cache.make_new_J = false
+    end
+    @unpack u, p, λ, JᵀJ, DᵀD, J = cache
+
+    # Usual Levenberg-Marquardt step ("velocity").
+    cache.v = -(JᵀJ + λ * DᵀD) \ (J' * fu)
 
     @unpack v, alg = cache
     h = alg.finite_diff_step_geodesic
@@ -340,6 +368,7 @@ function perform_step!(cache::LevenbergMarquardtCache{false})
             cache.norm_v_old = norm_v
             cache.loss_old = loss
             cache.λ_factor = 1 / alg.damping_decrease_factor
+            cache.make_new_J = true
         end
     end
     cache.λ *= cache.λ_factor

--- a/src/levenberg.jl
+++ b/src/levenberg.jl
@@ -306,7 +306,7 @@ function perform_step!(cache::LevenbergMarquardtCache{true})
     linres = dolinsolve(alg.precs, linsolve, A = cache.mat_tmp, b = _vec(cache.fu_tmp),
                         linu = _vec(cache.du_tmp), p = p, reltol = cache.abstol)
     cache.linsolve = linres.cache
-    cache.v .= -cache.du_tmp
+    @. cache.v = -cache.du_tmp
 
     # Geodesic acceleration (step_size = v + a / 2).
     @unpack v, alg = cache
@@ -319,7 +319,7 @@ function perform_step!(cache::LevenbergMarquardtCache{true})
     linres = dolinsolve(alg.precs, linsolve, A = J, b = _vec(cache.fu_tmp),
                         linu = _vec(cache.du_tmp), p = p, reltol = cache.abstol)
     cache.linsolve = linres.cache
-    cache.a .= -cache.du_tmp
+    @. cache.a = -cache.du_tmp
 
     # Require acceptable steps to satisfy the following condition.
     norm_v = norm(v)

--- a/src/levenberg.jl
+++ b/src/levenberg.jl
@@ -314,7 +314,8 @@ function perform_step!(cache::LevenbergMarquardtCache{true})
     f(cache.fu_tmp, u .+ h .* v, p)
 
     # The following lines do: cache.a = -J \ cache.fu_tmp
-    cache.fu_tmp .= (2 / h) .* ((cache.fu_tmp .- fu) ./ h .- mul!(cache.du_tmp, J, v))
+    mul!(cache.du_tmp, J, v)
+    cache.fu_tmp .= (2 / h) .* ((cache.fu_tmp .- fu) ./ h .- cache.du_tmp)
     linres = dolinsolve(alg.precs, linsolve, A = J, b = _vec(cache.fu_tmp),
                         linu = _vec(cache.du_tmp), p = p, reltol = cache.abstol)
     cache.linsolve = linres.cache

--- a/src/levenberg.jl
+++ b/src/levenberg.jl
@@ -315,7 +315,7 @@ function perform_step!(cache::LevenbergMarquardtCache{true})
 
     # The following lines do: cache.a = -J \ cache.fu_tmp
     mul!(cache.du_tmp, J, v)
-    cache.fu_tmp .= (2 / h) .* ((cache.fu_tmp .- fu) ./ h .- cache.du_tmp)
+    @. cache.fu_tmp = (2 / h) * ((cache.fu_tmp - fu) / h - cache.du_tmp)
     linres = dolinsolve(alg.precs, linsolve, A = J, b = _vec(cache.fu_tmp),
                         linu = _vec(cache.du_tmp), p = p, reltol = cache.abstol)
     cache.linsolve = linres.cache

--- a/src/levenberg.jl
+++ b/src/levenberg.jl
@@ -1,0 +1,364 @@
+"""
+```julia
+LevenbergMarquardt(; chunk_size = Val{0}(), autodiff = Val{true}(),
+                standardtag = Val{true}(), concrete_jac = nothing,
+                diff_type = Val{:forward}, linsolve = nothing, precs = DEFAULT_PRECS)
+```
+
+An advanced LevenbergMarquardt implementation with support for efficient handling of sparse
+matrices via colored automatic differentiation and preconditioned linear solvers. Designed
+for large-scale and numerically-difficult nonlinear systems.
+
+### Keyword Arguments
+
+- `chunk_size`: the chunk size used by the internal ForwardDiff.jl automatic differentiation
+  system. This allows for multiple derivative columns to be computed simultaneously,
+  improving performance. Defaults to `0`, which is equivalent to using ForwardDiff.jl's
+  default chunk size mechanism. For more details, see the documentation for
+  [ForwardDiff.jl](https://juliadiff.org/ForwardDiff.jl/stable/).
+- `autodiff`: whether to use forward-mode automatic differentiation for the Jacobian.
+  Note that this argument is ignored if an analytical Jacobian is passed, as that will be
+  used instead. Defaults to `Val{true}`, which means ForwardDiff.jl via
+  SparseDiffTools.jl is used by default. If `Val{false}`, then FiniteDiff.jl is used for
+  finite differencing.
+- `standardtag`: whether to use a standardized tag definition for the purposes of automatic
+  differentiation. Defaults to true, which thus uses the `NonlinearSolveTag`. If `Val{false}`,
+  then ForwardDiff's default function naming tag is used, which results in larger stack
+  traces.
+- `concrete_jac`: whether to build a concrete Jacobian. If a Krylov-subspace method is used,
+  then the Jacobian will not be constructed and instead direct Jacobian-vector products
+  `J*v` are computed using forward-mode automatic differentiation or finite differencing
+  tricks (without ever constructing the Jacobian). However, if the Jacobian is still needed,
+  for example for a preconditioner, `concrete_jac = true` can be passed in order to force
+  the construction of the Jacobian.
+- `diff_type`: the type of finite differencing used if `autodiff = false`. Defaults to
+  `Val{:forward}` for forward finite differences. For more details on the choices, see the
+  [FiniteDiff.jl](https://github.com/JuliaDiff/FiniteDiff.jl) documentation.
+- `linsolve`: the [LinearSolve.jl](https://github.com/SciML/LinearSolve.jl) used for the
+  linear solves within the Newton method. Defaults to `nothing`, which means it uses the
+  LinearSolve.jl default algorithm choice. For more information on available algorithm
+  choices, see the [LinearSolve.jl documentation](https://docs.sciml.ai/LinearSolve/stable/).
+- `precs`: the choice of preconditioners for the linear solver. Defaults to using no
+  preconditioners. For more information on specifying preconditioners for LinearSolve
+  algorithms, consult the
+  [LinearSolve.jl documentation](https://docs.sciml.ai/LinearSolve/stable/).
+
+!!! note
+
+    Currently, the linear solver and chunk size choice only applies to in-place defined
+    `NonlinearProblem`s. That is expected to change in the future.
+"""
+struct LevenbergMarquardt{CS, AD, FDT, L, P, ST, CJ, T} <:
+       AbstractNewtonAlgorithm{CS, AD, FDT, ST, CJ}
+    linsolve::L
+    precs::P
+    damping_initial::T
+    damping_increase_factor::T
+    damping_decrease_factor::T
+    finite_diff_step_geodesic::T
+    α_geodesic::T
+    b_uphill::T  # TODO test what happens if the input to this in an Interger, but Float to the others
+    min_damping_D::T
+end
+
+function LevenbergMarquardt(; chunk_size = Val{0}(), autodiff = Val{true}(),
+                            standardtag = Val{true}(), concrete_jac = nothing,
+                            diff_type = Val{:forward}, linsolve = nothing,
+                            precs = DEFAULT_PRECS,
+                            damping_initial::Real = 1.0,
+                            damping_increase_factor::Real = 2.0,
+                            damping_decrease_factor::Real = 3.0,
+                            finite_diff_step_geodesic::Real = 0.1,
+                            α_geodesic::Real = 0.75,
+                            b_uphill::Real = 1.0,
+                            min_damping_D::Real = 1e-6)
+    LevenbergMarquardt{_unwrap_val(chunk_size), _unwrap_val(autodiff), diff_type,
+                       typeof(linsolve), typeof(precs), _unwrap_val(standardtag),
+                       _unwrap_val(concrete_jac), typeof(damping_initial)}(linsolve, precs,
+                                                                           damping_initial,
+                                                                           damping_increase_factor,
+                                                                           damping_decrease_factor,
+                                                                           finite_diff_step_geodesic,
+                                                                           α_geodesic,
+                                                                           b_uphill,
+                                                                           min_damping_D)
+end
+
+mutable struct LevenbergMarquardtCache{iip, fType, algType, uType, duType, resType, pType,
+                                       INType, tolType,
+                                       probType, ufType, L, jType, JC, DᵀDType,
+                                       floatType
+                                       }
+    f::fType
+    alg::algType
+    u::uType
+    fu::resType
+    p::pType
+    uf::ufType
+    linsolve::L
+    J::jType
+    du1::duType
+    jac_config::JC
+    iter::Int
+    force_stop::Bool
+    maxiters::Int
+    internalnorm::INType
+    retcode::SciMLBase.ReturnCode.T
+    abstol::tolType
+    prob::probType
+    DᵀD::DᵀDType
+    JᵀJ::jType
+    λ::floatType
+    λ_factor::floatType         # TODO test if this handles interger inputs. (test to input damp_init::float and damp_inc::int)
+    v::uType
+    a::uType
+    tmp_vec::uType
+    v_old::uType
+    norm_v_old::floatType
+    δ::uType
+    loss_old::floatType
+
+    function LevenbergMarquardtCache{iip}(f::fType, alg::algType, u::uType, fu::resType,
+                                          p::pType,
+                                          uf::ufType, linsolve::L, J::jType, du1::duType,
+                                          jac_config::JC, iter::Int,
+                                          force_stop::Bool, maxiters::Int,
+                                          internalnorm::INType,
+                                          retcode::SciMLBase.ReturnCode.T, abstol::tolType,
+                                          prob::probType, DᵀD::DᵀDType, JᵀJ::jType,
+                                          λ::floatType, λ_factor::floatType, v::uType,
+                                          a::uType, tmp_vec::uType,
+                                          v_old::uType, norm_v_old::floatType, δ::uType,
+                                          loss_old::floatType) where {
+                                                                      iip, fType, algType,
+                                                                      uType,
+                                                                      duType, resType,
+                                                                      pType,
+                                                                      INType,
+                                                                      tolType,
+                                                                      probType, ufType, L,
+                                                                      jType, JC,
+                                                                      DᵀDType,
+                                                                      floatType
+                                                                      }
+        new{iip, fType, algType, uType, duType, resType,
+            pType, INType, tolType, probType, ufType, L,
+            jType, JC, DᵀDType, floatType}(f,
+                                                                   alg,
+                                                                   u,
+                                                                   fu,
+                                                                   p,
+                                                                   uf,
+                                                                   linsolve,
+                                                                   J,
+                                                                   du1,
+                                                                   jac_config,
+                                                                   iter,
+                                                                   force_stop,
+                                                                   maxiters,
+                                                                   internalnorm,
+                                                                   retcode,
+                                                                   abstol,
+                                                                   prob,
+                                                                   DᵀD,
+                                                                   JᵀJ,
+                                                                   λ,
+                                                                   λ_factor,
+                                                                   v,
+                                                                   a,
+                                                                   tmp_vec,
+                                                                   v_old,
+                                                                   norm_v_old,
+                                                                   δ,
+                                                                   loss_old)
+    end
+end
+
+function jacobian_caches(alg::LevenbergMarquardt, f, u, p, ::Val{true})
+    uf = JacobianWrapper(f, p)
+    J = ArrayInterfaceCore.undefmatrix(u)
+
+    linprob = LinearProblem(J, _vec(zero(u)); u0 = _vec(zero(u)))
+    weight = similar(u)
+    recursivefill!(weight, false)
+
+    Pl, Pr = wrapprecs(alg.precs(J, nothing, u, p, nothing, nothing, nothing, nothing,
+                                 nothing)..., weight)
+    linsolve = init(linprob, alg.linsolve, alias_A = true, alias_b = true,
+                    Pl = Pl, Pr = Pr)
+
+    du1 = zero(u)
+    du2 = zero(u)
+    tmp = zero(u)
+    jac_config = build_jac_config(alg, f, uf, du1, u, tmp, du2)
+
+    uf, linsolve, J, du1, jac_config
+end
+
+function jacobian_caches(alg::LevenbergMarquardt, f, u, p, ::Val{false})
+    JacobianWrapper(f, p), nothing, ArrayInterfaceCore.undefmatrix(u), nothing, nothing
+end
+
+function SciMLBase.__init(prob::NonlinearProblem{uType, iip}, alg::LevenbergMarquardt,
+                          args...;
+                          alias_u0 = false,
+                          maxiters = 1000,
+                          abstol = 1e-6,
+                          internalnorm = DEFAULT_NORM,
+                          kwargs...) where {uType, iip}
+    if alias_u0
+        u = prob.u0
+    else
+        u = deepcopy(prob.u0)
+    end
+    f = prob.f
+    p = prob.p
+    if iip
+        fu = zero(u)
+        f(fu, u, p)
+    else
+        fu = f(u, p)
+    end
+    uf, linsolve, J, du1, jac_config = jacobian_caches(alg, f, u, p, Val(iip))
+
+    # "A good compromise is to specify a minimum value of the damping terms in DᵀD".
+    if u isa Number
+        DᵀD = alg.min_damping_D # TODO check if type is correct.
+    else
+        d = d = similar(u)
+        d .= alg.min_damping_D
+        DᵀD = Diagonal(d)
+    end
+    loss = internalnorm(fu)
+    JᵀJ = zero(J)
+    v = zero(u)
+    a = zero(u)
+    tmp_vec = zero(u)
+    v_old = zero(u)
+    δ = zero(u)
+
+    return LevenbergMarquardtCache{iip}(f, alg, u, fu, p, uf, linsolve, J, du1, jac_config,
+                                        1, false, maxiters, internalnorm,
+                                        ReturnCode.Default, abstol, prob, DᵀD, JᵀJ,
+                                        alg.damping_initial, alg.damping_increase_factor,
+                                        v, a, tmp_vec, v_old, loss, δ, loss)
+end
+
+function perform_step!(cache::LevenbergMarquardtCache{true})
+    # TODO implement for in-place...
+    # @unpack fu, f = cache
+    # if iszero(fu)
+    #     cache.force_stop = true
+    #     return nothing
+    # end
+
+    # cache.J = jacobian(cache, f)
+    # @unpack u, f, p, λ, J = cache
+    # mul!(cache.JᵀJ, J', J)
+    # cache.DᵀD .= max.(cache.DᵀD, Diagonal(cache.JᵀJ))
+
+    # # Usual Levenberg-Marquardt step ("velocity").
+    # cache.v = -(cache.JᵀJ + λ * cache.DᵀD) \ (J' * fu)
+
+    # @unpack v, alg = cache
+    # h = alg.finite_diff_step_geodesic
+    # # Geodesic acceleration (step_size = v + a / 2).
+    # cache.a = -J \ ((2 / h) .* ((f(u .+ h * v, p) .- fu) ./ h .- mul!(cache.Jv, J, v)))
+
+    # # Require acceptable steps to satisfy the following condition.
+    # norm_v = norm(v)
+    # if (2 * norm(cache.a) / norm_v) < alg.α_geodesic
+    #     cache.δ = v + cache.a / 2
+    #     @unpack δ, loss_old, norm_v_old, v_old = cache
+    #     fu_new = f(u .+ δ, p)
+    #     loss = cache.internalnorm(fu_new)
+
+    #     # Condition to accept uphill steps (evaluates to `loss ≤ loss_old` in iteration 1).
+    #     β = dot(v, v_old) / (norm_v * norm_v_old)
+    #     if (1 - β)^alg.b_uphill * loss ≤ loss_old
+    #         # Accept step.
+    #         cache.u += δ
+    #         if loss < cache.abstol
+    #             cache.force_stop = true
+    #             return nothing
+    #         end
+    #         cache.fu = fu_new
+    #         cache.v_old = v
+    #         cache.norm_v_old = norm_v
+    #         cache.loss_old = loss
+    #         cache.λ_factor = 1 / alg.damping_decrease_factor
+    #     end
+    # end
+    # cache.λ *= cache.λ_factor
+    # cache.λ_factor = alg.damping_increase_factor
+    return nothing
+end
+
+function perform_step!(cache::LevenbergMarquardtCache{false})
+    @unpack fu, f = cache
+    if iszero(fu)
+        cache.force_stop = true
+        return nothing
+    end
+
+    J = jacobian(cache, f)
+    @unpack u, f, p, λ = cache
+    cache.JᵀJ = J' * J
+    if cache.DᵀD isa Number
+        cache.DᵀD = max(cache.DᵀD, cache.JᵀJ)
+    else
+        cache.DᵀD .= max.(cache.DᵀD, Diagonal(cache.JᵀJ))
+    end
+
+    # Usual Levenberg-Marquardt step ("velocity").
+    cache.v = -(cache.JᵀJ + λ * cache.DᵀD) \ (J' * fu)
+
+    @unpack v, alg = cache
+    h = alg.finite_diff_step_geodesic
+    # Geodesic acceleration (step_size = v + a / 2).
+    cache.a = -J \ ((2 / h) .* ((f(u .+ h * v, p) .- fu) ./ h .- J * v))
+
+    # Require acceptable steps to satisfy the following condition.
+    norm_v = norm(v)
+    if (2 * norm(cache.a) / norm_v) < alg.α_geodesic
+        cache.δ = v + cache.a / 2
+        @unpack δ, loss_old, norm_v_old, v_old = cache
+        fu_new = f(u .+ δ, p)
+        loss = cache.internalnorm(fu_new)
+
+        # Condition to accept uphill steps (evaluates to `loss ≤ loss_old` in iteration 1).
+        β = dot(v, v_old) / (norm_v * norm_v_old)
+        if (1 - β)^alg.b_uphill * loss ≤ loss_old
+            # Accept step.
+            cache.u += δ
+            if loss < cache.abstol
+                cache.force_stop = true
+                return nothing
+            end
+            cache.fu = fu_new
+            cache.v_old = v
+            cache.norm_v_old = norm_v
+            cache.loss_old = loss
+            cache.λ_factor = 1 / alg.damping_decrease_factor
+        end
+    end
+    cache.λ *= cache.λ_factor
+    cache.λ_factor = alg.damping_increase_factor
+    return nothing
+end
+
+function SciMLBase.solve!(cache::LevenbergMarquardtCache)
+    while !cache.force_stop && cache.iter < cache.maxiters
+        perform_step!(cache)
+        cache.iter += 1
+    end
+
+    if cache.iter == cache.maxiters
+        cache.retcode = ReturnCode.MaxIters
+    else
+        cache.retcode = ReturnCode.Success
+    end
+
+    SciMLBase.build_solution(cache.prob, cache.alg, cache.u, cache.fu;
+                             retcode = cache.retcode)
+end

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -456,15 +456,14 @@ list_of_options = zip(damping_initial, damping_increase_factor, damping_decrease
 for options in list_of_options
     local probN, sol, alg
     alg = LevenbergMarquardt(damping_initial = options[1],
-                      damping_increase_factor = options[2],
-                      damping_decrease_factor = options[3],
-                      finite_diff_step_geodesic = options[4],
-                      α_geodesic = options[5],
-                      b_uphill = options[6],
-                      min_damping_D = options[7])
+                             damping_increase_factor = options[2],
+                             damping_decrease_factor = options[3],
+                             finite_diff_step_geodesic = options[4],
+                             α_geodesic = options[5],
+                             b_uphill = options[6],
+                             min_damping_D = options[7])
 
     probN = NonlinearProblem{false}(f, u0, p)
     sol = solve(probN, alg, abstol = 1e-10)
     @test all(abs.(f(u, p)) .< 1e-10)
-
 end

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -299,3 +299,173 @@ for options in list_of_options
     sol = solve(probN, alg, abstol = 1e-10)
     @test all(abs.(f(u, p)) .< 1e-10)
 end
+
+# --- LevenbergMarquardt tests ---
+
+function benchmark_immutable(f, u0)
+    probN = NonlinearProblem{false}(f, u0)
+    solver = init(probN, LevenbergMarquardt(), abstol = 1e-9)
+    sol = solve!(solver)
+end
+
+function benchmark_mutable(f, u0)
+    probN = NonlinearProblem{false}(f, u0)
+    solver = init(probN, LevenbergMarquardt(), abstol = 1e-9)
+    sol = solve!(solver)
+end
+
+function benchmark_scalar(f, u0)
+    probN = NonlinearProblem{false}(f, u0)
+    sol = (solve(probN, LevenbergMarquardt()))
+end
+
+function ff(u, p)
+    u .* u .- 2
+end
+
+function sf(u, p)
+    u * u - 2
+end
+u0 = [1.0, 1.0]
+
+sol = benchmark_immutable(ff, cu0)
+@test sol.retcode === ReturnCode.Success
+@test all(abs.(sol.u .* sol.u .- 2) .< 1e-9)
+sol = benchmark_mutable(ff, u0)
+@test sol.retcode === ReturnCode.Success
+@test all(abs.(sol.u .* sol.u .- 2) .< 1e-9)
+sol = benchmark_scalar(sf, csu0)
+@test sol.retcode === ReturnCode.Success
+@test abs(sol.u * sol.u - 2) < 1e-9
+
+# function benchmark_inplace(f, u0)
+#     probN = NonlinearProblem{true}(f, u0)
+#     solver = init(probN, LevenbergMarquardt(), abstol = 1e-9)
+#     sol = solve!(solver)
+# end
+
+# function ffiip(du, u, p)
+#     du .= u .* u .- 2
+# end
+# u0 = [1.0, 1.0]
+
+# sol = benchmark_inplace(ffiip, u0)
+# @test sol.retcode === ReturnCode.Success
+# @test all(abs.(sol.u .* sol.u .- 2) .< 1e-9)
+
+# u0 = [1.0, 1.0]
+# probN = NonlinearProblem{true}(ffiip, u0)
+# solver = init(probN, LevenbergMarquardt(), abstol = 1e-9)
+# @test (@ballocated solve!(solver)) < 120
+
+# AD Tests
+using ForwardDiff
+
+# Immutable
+f, u0 = (u, p) -> u .* u .- p, @SVector[1.0, 1.0]
+
+g = function (p)
+    probN = NonlinearProblem{false}(f, csu0, p)
+    sol = solve(probN, LevenbergMarquardt(), abstol = 1e-9)
+    return sol.u[end]
+end
+
+for p in 1.1:0.1:100.0
+    @test g(p) ≈ sqrt(p)
+    @test ForwardDiff.derivative(g, p) ≈ 1 / (2 * sqrt(p))
+end
+
+# Scalar
+f, u0 = (u, p) -> u * u - p, 1.0
+
+g = function (p)
+    probN = NonlinearProblem{false}(f, oftype(p, u0), p)
+    sol = solve(probN, LevenbergMarquardt(), abstol = 1e-10)
+    return sol.u
+end
+
+@test ForwardDiff.derivative(g, 3.0) ≈ 1 / (2 * sqrt(3.0))
+
+for p in 1.1:0.1:100.0
+    @test g(p) ≈ sqrt(p)
+    @test ForwardDiff.derivative(g, p) ≈ 1 / (2 * sqrt(p))
+end
+
+f = (u, p) -> p[1] * u * u - p[2]
+t = (p) -> [sqrt(p[2] / p[1])]
+p = [0.9, 50.0]
+gnewton = function (p)
+    probN = NonlinearProblem{false}(f, 0.5, p)
+    sol = solve(probN, LevenbergMarquardt())
+    return [sol.u]
+end
+@test gnewton(p) ≈ [sqrt(p[2] / p[1])]
+@test ForwardDiff.jacobian(gnewton, p) ≈ ForwardDiff.jacobian(t, p)
+
+# Error Checks
+f, u0 = (u, p) -> u .* u .- 2.0, @SVector[1.0, 1.0]
+probN = NonlinearProblem(f, u0)
+
+@test solve(probN, LevenbergMarquardt()).u[end] ≈ sqrt(2.0)
+@test solve(probN, LevenbergMarquardt(; autodiff = false)).u[end] ≈ sqrt(2.0)
+
+for u0 in [1.0, [1, 1.0]]
+    local f, probN, sol
+    f = (u, p) -> u .* u .- 2.0
+    probN = NonlinearProblem(f, u0)
+    sol = sqrt(2) * u0
+
+    @test solve(probN, LevenbergMarquardt()).u ≈ sol
+    @test solve(probN, LevenbergMarquardt()).u ≈ sol
+    @test solve(probN, LevenbergMarquardt(; autodiff = false)).u ≈ sol
+end
+
+# Test that `LevenbergMarquardt` passes a test that `NewtonRaphson` fails on.
+u0 = [-10.0, -1.0, 1.0, 2.0, 3.0, 4.0, 10.0]
+global g, f
+f = (u, p) -> 0.010000000000000002 .+
+              10.000000000000002 ./ (1 .+
+               (0.21640425613334457 .+
+                216.40425613334457 ./ (1 .+
+                 (0.21640425613334457 .+
+                  216.40425613334457 ./
+                  (1 .+ 0.0006250000000000001(u .^ 2.0))) .^ 2.0)) .^ 2.0) .-
+              0.0011552453009332421u .- p
+g = function (p)
+    probN = NonlinearProblem{false}(f, u0, p)
+    sol = solve(probN, LevenbergMarquardt(), abstol = 1e-10)
+    return sol.u
+end
+p = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+u = g(p)
+f(u, p)
+@test all(abs.(f(u, p)) .< 1e-10)
+
+# # Test kwars in `LevenbergMarquardt`
+# max_trust_radius = [10.0, 100.0, 1000.0]
+# initial_trust_radius = [10.0, 1.0, 0.1]
+# step_threshold = [0.0, 0.01, 0.25]
+# shrink_threshold = [0.25, 0.3, 0.5]
+# expand_threshold = [0.5, 0.8, 0.9]
+# shrink_factor = [0.1, 0.3, 0.5]
+# expand_factor = [1.5, 2.0, 3.0]
+# max_shrink_times = [10, 20, 30]
+
+# list_of_options = zip(max_trust_radius, initial_trust_radius, step_threshold,
+#                       shrink_threshold, expand_threshold, shrink_factor,
+#                       expand_factor, max_shrink_times)
+# for options in list_of_options
+#     local probN, sol, alg
+#     alg = LevenbergMarquardt(max_trust_radius = options[1],
+#                       initial_trust_radius = options[2],
+#                       step_threshold = options[3],
+#                       shrink_threshold = options[4],
+#                       expand_threshold = options[5],
+#                       shrink_factor = options[6],
+#                       expand_factor = options[7],
+#                       max_shrink_times = options[8])
+
+#     probN = NonlinearProblem{false}(f, u0, p)
+#     sol = solve(probN, alg, abstol = 1e-10)
+#     @test all(abs.(f(u, p)) .< 1e-10)
+# end


### PR DESCRIPTION
Implementation of a Levenberg–Marquardt algorithm #119, according to the paper [Improvements to the Levenberg-Marquardt algorithm for nonlinear least-squares minimization](https://arxiv.org/abs/1201.5885).
The solver in `raphson.jl` was used as a template for this solver.