### PR TITLE
Only apply AD overloads to out-of-place

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 authors = ["SciML"]
-version = "2.1.0"
+version = "2.1.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -26,15 +26,15 @@ function scalar_nlsolve_ad(prob, alg, args...; kwargs...)
 end
 
 function SciMLBase.solve(prob::NonlinearProblem{<:Union{Number, SVector, <:AbstractArray},
-        iip, <:Dual{T, V, P}}, alg::AbstractNewtonAlgorithm, args...;
-    kwargs...) where {iip, T, V, P}
+        false, <:Dual{T, V, P}}, alg::AbstractNewtonAlgorithm, args...;
+    kwargs...) where {T, V, P}
     sol, partials = scalar_nlsolve_ad(prob, alg, args...; kwargs...)
     dual_soln = scalar_nlsolve_dual_soln(sol.u, partials, prob.p)
     return SciMLBase.build_solution(prob, alg, dual_soln, sol.resid; sol.retcode)
 end
 
 function SciMLBase.solve(prob::NonlinearProblem{<:Union{Number, SVector, <:AbstractArray},
-        iip, <:AbstractArray{<:Dual{T, V, P}}}, alg::AbstractNewtonAlgorithm, args...;
+        false, <:AbstractArray{<:Dual{T, V, P}}}, alg::AbstractNewtonAlgorithm, args...;
     kwargs...) where {iip, T, V, P}
     sol, partials = scalar_nlsolve_ad(prob, alg, args...; kwargs...)
     dual_soln = scalar_nlsolve_dual_soln(sol.u, partials, prob.p)


### PR DESCRIPTION
These methods are only tested for out-of-place functions right now, and the tests in OrdinaryDiffEq are seeing that they fail on in-place functions. So this changes the dispatches so they only apply when they are known to work. The in-place versions should be added in the future.
