### PR TITLE
remove iip function parameter

### DIFF
--- a/src/ad.jl
+++ b/src/ad.jl
@@ -35,7 +35,7 @@ end
 
 function SciMLBase.solve(prob::NonlinearProblem{<:Union{Number, SVector, <:AbstractArray},
         false, <:AbstractArray{<:Dual{T, V, P}}}, alg::AbstractNewtonAlgorithm, args...;
-    kwargs...) where {iip, T, V, P}
+    kwargs...) where {T, V, P}
     sol, partials = scalar_nlsolve_ad(prob, alg, args...; kwargs...)
     dual_soln = scalar_nlsolve_dual_soln(sol.u, partials, prob.p)
     return SciMLBase.build_solution(prob, alg, dual_soln, sol.resid; sol.retcode)


### PR DESCRIPTION
Fixes warning
```
┌ NonlinearSolve [8913a72c-1f9b-4ce2-8d82-65094dcecaec]
│  WARNING: method definition for #solve#52 at /central/scratch/esm/slurm-buildkite/climacore-ci/2648/depot/default/packages/NonlinearSolve/lOnjn/src/ad.jl:36 declares type variable iip but does not use it.
└  
```