### PR TITLE
Improvements for Broyden and Klement

### DIFF
--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -81,7 +81,7 @@ function SciMLBase.reinit!(cache::AbstractNonlinearSolveCache{iip}, u0 = get_u(c
             get_u(cache), p, get_fu(cache), Val(iip))
     end
 
-    hasfield(typeof(cache), :uf) && (cache.uf.p = p)
+    hasfield(typeof(cache), :uf) && cache.uf !== nothing && (cache.uf.p = p)
 
     cache.abstol = abstol
     cache.reltol = reltol

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -117,6 +117,7 @@ function Base.show(io::IO, alg::AbstractNonlinearSolveAlgorithm)
             push!(modifiers, "linesearch = $(nameof(typeof(alg.linesearch)))()")
         end
     end
+    append!(modifiers, __alg_print_modifiers(alg))
     if __getproperty(alg, Val(:radius_update_scheme)) !== nothing
         push!(modifiers, "radius_update_scheme = $(alg.radius_update_scheme)")
     end
@@ -124,6 +125,8 @@ function Base.show(io::IO, alg::AbstractNonlinearSolveAlgorithm)
     print(io, "$(str))")
     return nothing
 end
+
+__alg_print_modifiers(_) = String[]
 
 function SciMLBase.__solve(prob::Union{NonlinearProblem, NonlinearLeastSquaresProblem},
         alg::AbstractNonlinearSolveAlgorithm, args...; kwargs...)

--- a/src/broyden.jl
+++ b/src/broyden.jl
@@ -164,7 +164,7 @@ function perform_step!(cache::GeneralBroydenCache{iip, IJ, UR}) where {iip, IJ, 
     T = eltype(cache.u)
 
     if IJ === :true_jacobian && cache.stats.nsteps == 0
-        if __isdiag(cache.J⁻¹) && cache.J⁻¹_cache !== nothing
+        if UR === :diagonal
             cache.J⁻¹_cache = __safe_inv(jacobian!!(cache.J⁻¹_cache, cache))
             cache.J⁻¹ = __get_diagonal!!(cache.J⁻¹, cache.J⁻¹_cache)
         else
@@ -172,7 +172,7 @@ function perform_step!(cache::GeneralBroydenCache{iip, IJ, UR}) where {iip, IJ, 
         end
     end
 
-    if __isdiag(cache.J⁻¹)
+    if UR === :diagonal
         @bb @. cache.du = cache.J⁻¹ * cache.fu
     else
         @bb cache.du = cache.J⁻¹ × vec(cache.fu)
@@ -197,7 +197,7 @@ function perform_step!(cache::GeneralBroydenCache{iip, IJ, UR}) where {iip, IJ, 
             return nothing
         end
         if IJ === :true_jacobian
-            if __isdiag(cache.J⁻¹) && cache.J⁻¹_cache !== nothing
+            if UR === :diagonal
                 cache.J⁻¹_cache = __safe_inv(jacobian!!(cache.J⁻¹_cache, cache))
                 cache.J⁻¹ = __get_diagonal!!(cache.J⁻¹, cache.J⁻¹_cache)
             else

--- a/src/broyden.jl
+++ b/src/broyden.jl
@@ -1,6 +1,7 @@
 # Sadly `Broyden` is taken up by SimpleNonlinearSolve.jl
 """
-    GeneralBroyden(; max_resets = 3, linesearch = nothing, reset_tolerance = nothing)
+    GeneralBroyden(; max_resets = 3, linesearch = nothing, reset_tolerance = nothing,
+        init_jacobian::Val = Val(:identity), autodiff = nothing)
 
 An implementation of `Broyden` with resetting and line search.
 
@@ -14,20 +15,36 @@ An implementation of `Broyden` with resetting and line search.
     used here directly, and they will be converted to the correct `LineSearch`. It is
     recommended to use [LiFukushimaLineSearch](@ref) -- a derivative free linesearch
     specifically designed for Broyden's method.
+  - `init_jacobian`: the method to use for initializing the jacobian. Defaults to using the
+    identity matrix (`Val(:identitiy)`). Alternatively, can be set to `Val(:true_jacobian)`
+    to use the true jacobian as initialization.
+  - `autodiff`: determines the backend used for the Jacobian. Note that this argument is
+    ignored if an analytical Jacobian is passed, as that will be used instead. Defaults to
+    `nothing` which means that a default is selected according to the problem specification!
+    Valid choices are types from ADTypes.jl. (Used if `init_jacobian = Val(:true_jacobian)`)
 """
-@concrete struct GeneralBroyden <: AbstractNewtonAlgorithm{false, Nothing}
+@concrete struct GeneralBroyden{IJ, CJ, AD} <: AbstractNewtonAlgorithm{CJ, AD}
+    ad::AD
     max_resets::Int
     reset_tolerance
     linesearch
 end
 
-function GeneralBroyden(; max_resets = 3, linesearch = nothing,
-        reset_tolerance = nothing)
-    linesearch = linesearch isa LineSearch ? linesearch : LineSearch(; method = linesearch)
-    return GeneralBroyden(max_resets, reset_tolerance, linesearch)
+function set_ad(alg::GeneralBroyden{IJ, CJ}, ad) where {IJ, CJ}
+    return GeneralBroyden{IJ, CJ}(ad, alg.max_resets, alg.reset_tolerance, alg.linesearch)
 end
 
-@concrete mutable struct GeneralBroydenCache{iip} <: AbstractNonlinearSolveCache{iip}
+function GeneralBroyden(; max_resets = 3, linesearch = nothing,
+        reset_tolerance = nothing, init_jacobian::Val = Val(:identity),
+        autodiff = nothing)
+    IJ = _unwrap_val(init_jacobian)
+    @assert IJ ∈ (:identity, :true_jacobian)
+    linesearch = linesearch isa LineSearch ? linesearch : LineSearch(; method = linesearch)
+    CJ = IJ === :true_jacobian
+    return GeneralBroyden{IJ, CJ}(autodiff, max_resets, reset_tolerance, linesearch)
+end
+
+@concrete mutable struct GeneralBroydenCache{iip, IJ} <: AbstractNonlinearSolveCache{iip}
     f
     alg
     u
@@ -37,6 +54,7 @@ end
     fu_cache
     dfu
     p
+    uf
     J⁻¹
     J⁻¹dfu
     force_stop::Bool
@@ -49,6 +67,7 @@ end
     reltol
     reset_tolerance
     reset_check
+    jac_cache
     prob
     stats::NLStats
     ls_cache
@@ -56,22 +75,33 @@ end
     trace
 end
 
-function SciMLBase.__init(prob::NonlinearProblem{uType, iip}, alg::GeneralBroyden, args...;
-        alias_u0 = false, maxiters = 1000, abstol = nothing, reltol = nothing,
+function SciMLBase.__init(prob::NonlinearProblem{uType, iip}, alg_::GeneralBroyden{IJ},
+        args...; alias_u0 = false, maxiters = 1000, abstol = nothing, reltol = nothing,
         termination_condition = nothing, internalnorm::F = DEFAULT_NORM,
-        kwargs...) where {uType, iip, F}
+        kwargs...) where {uType, iip, F, IJ}
     @unpack f, u0, p = prob
     u = __maybe_unaliased(u0, alias_u0)
     fu = evaluate_f(prob, u)
     @bb du = copy(u)
-    J⁻¹ = __init_identity_jacobian(u, fu)
+
+    if IJ === :true_jacobian
+        alg = get_concrete_algorithm(alg_, prob)
+        uf, _, J, fu_cache, jac_cache, du = jacobian_caches(alg, f, u, p, Val(iip);
+            lininit = Val(false))
+        J⁻¹ = J
+    else
+        alg = alg_
+        @bb du = similar(u)
+        uf, fu_cache, jac_cache = nothing, nothing, nothing
+        J⁻¹ = __init_identity_jacobian(u, fu)
+    end
+
     reset_tolerance = alg.reset_tolerance === nothing ? sqrt(eps(real(eltype(u)))) :
                       alg.reset_tolerance
     reset_check = x -> abs(x) ≤ reset_tolerance
 
     @bb u_cache = copy(u)
-    @bb fu_cache = copy(fu)
-    @bb dfu = similar(fu)
+    @bb dfu = copy(fu)
     @bb J⁻¹dfu = similar(u)
 
     abstol, reltol, tc_cache = init_termination_cache(abstol, reltol, fu, u,
@@ -79,14 +109,19 @@ function SciMLBase.__init(prob::NonlinearProblem{uType, iip}, alg::GeneralBroyde
     trace = init_nonlinearsolve_trace(alg, u, fu, J⁻¹, du; uses_jac_inverse = Val(true),
         kwargs...)
 
-    return GeneralBroydenCache{iip}(f, alg, u, u_cache, du, fu, fu_cache, dfu, p,
+    return GeneralBroydenCache{iip, IJ}(f, alg, u, u_cache, du, fu, fu_cache, dfu, p, uf,
         J⁻¹, J⁻¹dfu, false, 0, alg.max_resets, maxiters, internalnorm, ReturnCode.Default,
-        abstol, reltol, reset_tolerance, reset_check, prob, NLStats(1, 0, 0, 0, 0),
+        abstol, reltol, reset_tolerance, reset_check, jac_cache, prob,
+        NLStats(1, 0, 0, 0, 0),
         init_linesearch_cache(alg.linesearch, f, u, p, fu, Val(iip)), tc_cache, trace)
 end
 
-function perform_step!(cache::GeneralBroydenCache{iip}) where {iip}
+function perform_step!(cache::GeneralBroydenCache{iip, IJ}) where {iip, IJ}
     T = eltype(cache.u)
+
+    if IJ === :true_jacobian && cache.stats.nsteps == 0
+        cache.J⁻¹ = inv(jacobian!!(cache.J⁻¹, cache)) # This allocates
+    end
 
     @bb cache.du = cache.J⁻¹ × vec(cache.fu)
     α = perform_linesearch!(cache.ls_cache, cache.u, cache.du)
@@ -100,7 +135,7 @@ function perform_step!(cache::GeneralBroydenCache{iip}) where {iip}
     cache.force_stop && return nothing
 
     # Update the inverse jacobian
-    @bb @. cache.dfu = cache.fu - cache.fu_cache
+    @bb @. cache.dfu = cache.fu - cache.dfu
 
     if all(cache.reset_check, cache.du) || all(cache.reset_check, cache.dfu)
         if cache.resets ≥ cache.max_resets
@@ -108,7 +143,11 @@ function perform_step!(cache::GeneralBroydenCache{iip}) where {iip}
             cache.force_stop = true
             return nothing
         end
-        cache.J⁻¹ = __reinit_identity_jacobian!!(cache.J⁻¹)
+        if IJ === :true_jacobian
+            cache.J⁻¹ = inv(jacobian!!(cache.J⁻¹, cache))
+        else
+            cache.J⁻¹ = __reinit_identity_jacobian!!(cache.J⁻¹)
+        end
         cache.resets += 1
     else
         @bb cache.du .*= -1
@@ -119,7 +158,7 @@ function perform_step!(cache::GeneralBroydenCache{iip}) where {iip}
         @bb cache.J⁻¹ += vec(cache.du) × transpose(_vec(cache.u_cache))
     end
 
-    @bb copyto!(cache.fu_cache, cache.fu)
+    @bb copyto!(cache.dfu, cache.fu)
     @bb copyto!(cache.u_cache, cache.u)
 
     return nothing

--- a/src/broyden.jl
+++ b/src/broyden.jl
@@ -50,8 +50,8 @@ end
 
 function __alg_print_modifiers(alg::GeneralBroyden{IJ, UR}) where {IJ, UR}
     modifiers = String[]
-    IJ !== :identity && push!(modifiers, "init_jacobian = :$(IJ)")
-    UR !== :good_broyden && push!(modifiers, "update_rule = :$(UR)")
+    IJ !== :identity && push!(modifiers, "init_jacobian = Val(:$(IJ))")
+    UR !== :good_broyden && push!(modifiers, "update_rule = Val(:$(UR))")
     alg.alpha !== nothing && push!(modifiers, "alpha = $(alg.alpha)")
     return modifiers
 end
@@ -141,8 +141,8 @@ function SciMLBase.__init(prob::NonlinearProblem{uType, iip}, alg_::GeneralBroyd
 
     abstol, reltol, tc_cache = init_termination_cache(abstol, reltol, fu, u,
         termination_condition)
-    trace = init_nonlinearsolve_trace(alg, u, fu, J⁻¹, du; uses_jac_inverse = Val(true),
-        kwargs...)
+    trace = init_nonlinearsolve_trace(alg, u, fu, ApplyArray(__zero, J⁻¹), du;
+        uses_jac_inverse = Val(true), kwargs...)
 
     return GeneralBroydenCache{iip, IJ, UR}(f, alg, u, u_cache, du, fu, fu_cache, dfu, p,
         uf, J⁻¹, J⁻¹dfu, inv_alpha, alg.alpha, false, 0, alg.max_resets, maxiters,

--- a/src/broyden.jl
+++ b/src/broyden.jl
@@ -155,7 +155,7 @@ function perform_step!(cache::GeneralBroydenCache{iip, IJ, UR}) where {iip, IJ, 
     T = eltype(cache.u)
 
     if IJ === :true_jacobian && cache.stats.nsteps == 0
-        cache.J⁻¹ = inv(jacobian!!(cache.J⁻¹, cache)) # This allocates
+        cache.J⁻¹ = __safe_inv(jacobian!!(cache.J⁻¹, cache)) # This allocates
     end
 
     @bb cache.du = cache.J⁻¹ × vec(cache.fu)
@@ -179,7 +179,7 @@ function perform_step!(cache::GeneralBroydenCache{iip, IJ, UR}) where {iip, IJ, 
             return nothing
         end
         if IJ === :true_jacobian
-            cache.J⁻¹ = inv(jacobian!!(cache.J⁻¹, cache))
+            cache.J⁻¹ = __safe_inv(jacobian!!(cache.J⁻¹, cache))
         else
             cache.inv_alpha = __initial_inv_alpha(cache.inv_alpha, cache.alpha_initial,
                 cache.u, cache.fu, cache.internalnorm)

--- a/src/broyden.jl
+++ b/src/broyden.jl
@@ -175,7 +175,7 @@ function perform_step!(cache::GeneralBroydenCache{iip, IJ, UR}) where {iip, IJ, 
                               ifelse(iszero(denom), T(1e-5), denom)
             @bb cache.J⁻¹ += vec(cache.du) × transpose(_vec(cache.u_cache))
         elseif UR === :bad_broyden
-            dfu_norm = norm(cache.dfu)^2
+            dfu_norm = cache.internalnorm(cache.dfu)^2
             @bb @. cache.du = (cache.du - cache.J⁻¹dfu) /
                               ifelse(iszero(dfu_norm), T(1e-5), dfu_norm)
             @bb cache.J⁻¹ += vec(cache.du) × transpose(_vec(cache.dfu))

--- a/src/default.jl
+++ b/src/default.jl
@@ -248,8 +248,9 @@ function FastShortcutNonlinearPolyalg(; concrete_jac = nothing, linsolve = nothi
             TrustRegion(; concrete_jac, linsolve, precs,
                 radius_update_scheme = RadiusUpdateSchemes.Bastin, adkwargs...))
     else
-        algs = (GeneralKlement(; linsolve, precs),
-            GeneralBroyden(),
+        algs = (GeneralBroyden(),
+            GeneralBroyden(; init_jacobian = Val(:true_jacobian)),
+            GeneralKlement(; linsolve, precs),
             NewtonRaphson(; concrete_jac, linsolve, precs, adkwargs...),
             NewtonRaphson(; concrete_jac, linsolve, precs, linesearch = BackTracking(),
                 adkwargs...),

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -58,6 +58,7 @@ function jacobian!!(::Number, cache)
     cache.stats.njacs += 1
     return last(value_derivative(cache.uf, cache.u))
 end
+
 # Build Jacobian Caches
 function jacobian_caches(alg::AbstractNonlinearSolveAlgorithm, f::F, u, p, ::Val{iip};
         linsolve_kwargs = (;), lininit::Val{linsolve_init} = Val(true),

--- a/src/klement.jl
+++ b/src/klement.jl
@@ -198,7 +198,7 @@ function perform_step!(cache::GeneralKlementCache{iip, IJ}) where {iip, IJ}
         cache.resets += 1
     end
 
-    if cache.J isa AbstractVector || cache.J isa Number
+    if __isdiag(cache.J)
         @bb @. cache.du = cache.fu / cache.J
     else
         # u = u - J \ fu
@@ -223,7 +223,7 @@ function perform_step!(cache::GeneralKlementCache{iip, IJ}) where {iip, IJ}
 
     # Update the Jacobian
     @bb cache.du .*= -1
-    if cache.J isa AbstractVector || cache.J isa Number
+    if __isdiag(cache.J)
         @bb @. cache.Jdu = (cache.J^2) * (cache.du^2)
         @bb @. cache.J += ((cache.fu - cache.fu_cache_2 - cache.J * cache.du) /
                            ifelse(iszero(cache.Jdu), T(1e-5), cache.Jdu)) * cache.du *

--- a/src/klement.jl
+++ b/src/klement.jl
@@ -198,7 +198,7 @@ function perform_step!(cache::GeneralKlementCache{iip, IJ}) where {iip, IJ}
         cache.resets += 1
     end
 
-    if __isdiag(cache.J)
+    if IJ === :true_jacobian_diagonal || IJ === :identity
         @bb @. cache.du = cache.fu / cache.J
     else
         # u = u - J \ fu
@@ -223,7 +223,7 @@ function perform_step!(cache::GeneralKlementCache{iip, IJ}) where {iip, IJ}
 
     # Update the Jacobian
     @bb cache.du .*= -1
-    if __isdiag(cache.J)
+    if IJ === :true_jacobian_diagonal || IJ === :identity
         @bb @. cache.Jdu = (cache.J^2) * (cache.du^2)
         @bb @. cache.J += ((cache.fu - cache.fu_cache_2 - cache.J * cache.du) /
                            ifelse(iszero(cache.Jdu), T(1e-5), cache.Jdu)) * cache.du *

--- a/src/klement.jl
+++ b/src/klement.jl
@@ -49,7 +49,7 @@ end
 
 function __alg_print_modifiers(alg::GeneralKlement{IJ}) where {IJ}
     modifiers = String[]
-    IJ !== :identity && push!(modifiers, "init_jacobian = :$(IJ)")
+    IJ !== :identity && push!(modifiers, "init_jacobian = Val(:$(IJ))")
     alg.alpha !== nothing && push!(modifiers, "alpha = $(alg.alpha)")
     return modifiers
 end
@@ -231,7 +231,7 @@ function perform_step!(cache::GeneralKlementCache{iip, IJ}) where {iip, IJ}
     else
         # Klement Updates to the Full Jacobian don't work for most problems, we should
         # probably be using the Broyden Update Rule here
-        @bb @. cache.J_cache = cache.J' ^ 2
+        @bb @. cache.J_cache = cache.J'^2
         @bb @. cache.Jdu = cache.du^2
         @bb cache.Jdu_cache = cache.J_cache × vec(cache.Jdu)
         @bb cache.Jdu = cache.J × vec(cache.du)

--- a/src/klement.jl
+++ b/src/klement.jl
@@ -19,33 +19,54 @@ solves.
   - `linesearch`: the line search algorithm to use. Defaults to [`LineSearch()`](@ref),
     which means that no line search is performed. Algorithms from `LineSearches.jl` can be
     used here directly, and they will be converted to the correct `LineSearch`.
+  - `init_jacobian`: the method to use for initializing the jacobian. Defaults to using the
+    identity matrix (`Val(:identitiy)`). Alternatively, can be set to `Val(:true_jacobian)`
+    to use the true jacobian as initialization. (Our tests suggest it is a good idea to
+    to initialize with an identity matrix)
+  - `autodiff`: determines the backend used for the Jacobian. Note that this argument is
+    ignored if an analytical Jacobian is passed, as that will be used instead. Defaults to
+    `nothing` which means that a default is selected according to the problem specification!
+    Valid choices are types from ADTypes.jl. (Used if `init_jacobian = Val(:true_jacobian)`)
 """
-@concrete struct GeneralKlement <: AbstractNewtonAlgorithm{false, Nothing}
+@concrete struct GeneralKlement{IJ, CJ, AD} <: AbstractNewtonAlgorithm{CJ, AD}
+    ad::AD
     max_resets::Int
     linsolve
     precs
     linesearch
 end
 
-function set_linsolve(alg::GeneralKlement, linsolve)
-    return GeneralKlement(alg.max_resets, linsolve, alg.precs, alg.linesearch)
+function set_linsolve(alg::GeneralKlement{IJ, CS}, linsolve) where {IJ, CS}
+    return GeneralKlement{IJ, CS}(alg.ad, alg.max_resets, linsolve, alg.precs,
+        alg.linesearch)
+end
+
+function set_ad(alg::GeneralKlement{IJ, CS}, ad) where {IJ, CS}
+    return GeneralKlement{IJ, CS}(ad, alg.max_resets, alg.linsolve, alg.precs,
+        alg.linesearch)
 end
 
 function GeneralKlement(; max_resets::Int = 5, linsolve = nothing,
-        linesearch = nothing, precs = DEFAULT_PRECS)
+        linesearch = nothing, precs = DEFAULT_PRECS, init_jacobian::Val = Val(:identity),
+        autodiff = nothing)
+    IJ = _unwrap_val(init_jacobian)
+    @assert IJ ∈ (:identity, :true_jacobian)
     linesearch = linesearch isa LineSearch ? linesearch : LineSearch(; method = linesearch)
-    return GeneralKlement(max_resets, linsolve, precs, linesearch)
+    CJ = IJ === :true_jacobian
+    return GeneralKlement{IJ, CJ}(autodiff, max_resets, linsolve, precs, linesearch)
 end
 
-@concrete mutable struct GeneralKlementCache{iip} <: AbstractNonlinearSolveCache{iip}
+@concrete mutable struct GeneralKlementCache{iip, IJ} <: AbstractNonlinearSolveCache{iip}
     f
     alg
     u
     u_cache
     fu
     fu_cache
+    fu_cache_2
     du
     p
+    uf
     linsolve
     J
     J_cache
@@ -60,31 +81,38 @@ end
     abstol
     reltol
     prob
+    jac_cache
     stats::NLStats
     ls_cache
     tc_cache
     trace
 end
 
-function SciMLBase.__init(prob::NonlinearProblem{uType, iip}, alg_::GeneralKlement, args...;
-        alias_u0 = false, maxiters = 1000, abstol = nothing, reltol = nothing,
+function SciMLBase.__init(prob::NonlinearProblem{uType, iip}, alg_::GeneralKlement{IJ},
+        args...; alias_u0 = false, maxiters = 1000, abstol = nothing, reltol = nothing,
         termination_condition = nothing, internalnorm::F = DEFAULT_NORM,
-        linsolve_kwargs = (;), kwargs...) where {uType, iip, F}
+        linsolve_kwargs = (;), kwargs...) where {uType, iip, F, IJ}
     @unpack f, u0, p = prob
     u = __maybe_unaliased(u0, alias_u0)
     fu = evaluate_f(prob, u)
-    J = __init_identity_jacobian(u, fu)
-    @bb du = similar(u)
 
-    if u isa Number
-        linsolve = FakeLinearSolveJLCache(J, fu)
+    if IJ === :true_jacobian
+        alg = get_concrete_algorithm(alg_, prob)
+        uf, _, J, fu_cache, jac_cache, du = jacobian_caches(alg, f, u, p, Val(iip);
+            lininit = Val(false))
+    elseif IJ === :identity
         alg = alg_
+        @bb du = similar(u)
+        uf, fu_cache, jac_cache = nothing, nothing, nothing
+        J = one.(u) # Identity Init Jacobian for Klement maintains a Diagonal Structure
     else
-        # For General Julia Arrays default to LU Factorization
-        linsolve_alg = (alg_.linsolve === nothing && (u isa Array || u isa StaticArray)) ?
-                       LUFactorization() : nothing
-        alg = set_linsolve(alg_, linsolve_alg)
-        linsolve = linsolve_caches(J, _vec(fu), _vec(du), p, alg; linsolve_kwargs)
+        error("Invalid `init_jacobian` value")
+    end
+
+    if IJ === :true_jacobian
+        linsolve = linsolve_caches(J, _vec(fu), _vec(du), p, alg_; linsolve_kwargs)
+    else
+        linsolve = nothing
     end
 
     abstol, reltol, tc_cache = init_termination_cache(abstol, reltol, fu, u,
@@ -92,41 +120,57 @@ function SciMLBase.__init(prob::NonlinearProblem{uType, iip}, alg_::GeneralKleme
     trace = init_nonlinearsolve_trace(alg, u, fu, J, du; kwargs...)
 
     @bb u_cache = copy(u)
-    @bb fu_cache = copy(fu)
-    @bb J_cache = similar(J)
-    @bb J_cache_2 = similar(J)
+    @bb fu_cache_2 = copy(fu)
     @bb Jdu = similar(fu)
-    @bb Jdu_cache = similar(fu)
+    if IJ === :true_jacobian
+        @bb J_cache = similar(J)
+        @bb J_cache_2 = similar(J)
+        @bb Jdu_cache = similar(fu)
+    else
+        J_cache, J_cache_2, Jdu_cache = nothing, nothing, nothing
+    end
 
-    return GeneralKlementCache{iip}(f, alg, u, u_cache, fu, fu_cache, du, p, linsolve,
-        J, J_cache, J_cache_2, Jdu, Jdu_cache, 0, false, maxiters, internalnorm,
-        ReturnCode.Default, abstol, reltol, prob, NLStats(1, 0, 0, 0, 0),
+    return GeneralKlementCache{iip, IJ}(f, alg, u, u_cache, fu, fu_cache, fu_cache_2, du, p,
+        uf, linsolve, J, J_cache, J_cache_2, Jdu, Jdu_cache, 0, false, maxiters,
+        internalnorm,
+        ReturnCode.Default, abstol, reltol, prob, jac_cache, NLStats(1, 0, 0, 0, 0),
         init_linesearch_cache(alg.linesearch, f, u, p, fu, Val(iip)), tc_cache, trace)
 end
 
-function perform_step!(cache::GeneralKlementCache{iip}) where {iip}
+function perform_step!(cache::GeneralKlementCache{iip, IJ}) where {iip, IJ}
     @unpack linsolve, alg = cache
     T = eltype(cache.J)
-    singular, fact_done = __try_factorize_and_check_singular!(linsolve, cache.J)
 
-    if singular
+    if IJ === :true_jacobian
+        cache.stats.nsteps == 0 && (cache.J = jacobian!!(cache.J, cache))
+        ill_conditioned = __is_ill_conditioned(cache.J)
+    elseif IJ === :identity
+        ill_conditioned = __is_ill_conditioned(cache.J)
+    end
+
+    if ill_conditioned
         if cache.resets == alg.max_resets
             cache.force_stop = true
             cache.retcode = ReturnCode.ConvergenceFailure
             return nothing
         end
-        fact_done = false
-        cache.J = __reinit_identity_jacobian!!(cache.J)
+        if IJ === :true_jacobian && cache.stats.nsteps != 0
+            cache.J = jacobian!!(cache.J, cache)
+        else
+            cache.J = __reinit_identity_jacobian!!(cache.J)
+        end
         cache.resets += 1
     end
 
-    A = ifelse(cache.J isa SMatrix || cache.J isa Number || !fact_done, cache.J, nothing)
-
-    # u = u - J \ fu
-    linres = dolinsolve(cache, alg.precs, cache.linsolve; A,
-        b = _vec(cache.fu), linu = _vec(cache.du), cache.p, reltol = cache.abstol)
-    cache.linsolve = linres.cache
-    cache.du = _restructure(cache.du, linres.u)
+    if IJ === :identity
+        @bb @. cache.du = cache.fu / cache.J
+    else
+        # u = u - J \ fu
+        linres = dolinsolve(cache, alg.precs, cache.linsolve; A = cache.J,
+            b = _vec(cache.fu), linu = _vec(cache.du), cache.p, reltol = cache.abstol)
+        cache.linsolve = linres.cache
+        cache.du = _restructure(cache.du, linres.u)
+    end
 
     # Line Search
     α = perform_linesearch!(cache.ls_cache, cache.u, cache.du)
@@ -143,18 +187,25 @@ function perform_step!(cache::GeneralKlementCache{iip}) where {iip}
 
     # Update the Jacobian
     @bb cache.du .*= -1
-    @bb cache.J_cache .= cache.J' .^ 2
-    @bb @. cache.Jdu = cache.du^2
-    @bb cache.Jdu_cache = cache.J_cache × vec(cache.Jdu)
-    @bb cache.Jdu = cache.J × vec(cache.du)
-    @bb @. cache.fu_cache = (cache.fu - cache.fu_cache - cache.Jdu) /
-                            ifelse(iszero(cache.Jdu_cache), T(1e-5), cache.Jdu_cache)
-    @bb cache.J_cache = vec(cache.fu_cache) × transpose(_vec(cache.du))
-    @bb @. cache.J_cache *= cache.J
-    @bb cache.J_cache_2 = cache.J_cache × cache.J
-    @bb cache.J .+= cache.J_cache_2
+    if IJ === :identity
+        @bb @. cache.Jdu = (cache.J^2) * (cache.du^2)
+        @bb @. cache.J += ((cache.fu - cache.fu_cache_2 - cache.J * cache.du) /
+                           ifelse(iszero(cache.Jdu), T(1e-5), cache.Jdu)) * cache.du *
+                          (cache.J^2)
+    else
+        @bb cache.J_cache .= cache.J' .^ 2
+        @bb @. cache.Jdu = cache.du^2
+        @bb cache.Jdu_cache = cache.J_cache × vec(cache.Jdu)
+        @bb cache.Jdu = cache.J × vec(cache.du)
+        @bb @. cache.fu_cache_2 = (cache.fu - cache.fu_cache_2 - cache.Jdu) /
+                                  ifelse(iszero(cache.Jdu_cache), T(1e-5), cache.Jdu_cache)
+        @bb cache.J_cache = vec(cache.fu_cache_2) × transpose(_vec(cache.du))
+        @bb @. cache.J_cache *= cache.J
+        @bb cache.J_cache_2 = cache.J_cache × cache.J
+        @bb cache.J .+= cache.J_cache_2
+    end
 
-    @bb copyto!(cache.fu_cache, cache.fu)
+    @bb copyto!(cache.fu_cache_2, cache.fu)
 
     return nothing
 end

--- a/src/klement.jl
+++ b/src/klement.jl
@@ -36,6 +36,12 @@ solves.
     linesearch
 end
 
+function __alg_print_modifiers(::GeneralKlement{IJ}) where {IJ}
+    modifiers = String[]
+    IJ !== :identity && push!(modifiers, "init_jacobian = :$(IJ)")
+    return modifiers
+end
+
 function set_linsolve(alg::GeneralKlement{IJ, CS}, linsolve) where {IJ, CS}
     return GeneralKlement{IJ, CS}(alg.ad, alg.max_resets, linsolve, alg.precs,
         alg.linesearch)

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -174,7 +174,7 @@ function init_nonlinearsolve_trace(alg, ::Val{show_trace},
         print("\nAlgorithm: ")
         Base.printstyled(alg, "\n\n"; color = :green, bold = true)
     end
-    J_ = uses_jac_inverse ? (trace_level isa TraceMinimal ? J : inv(J)) : J
+    J_ = uses_jac_inverse ? (trace_level isa TraceMinimal ? J : __safe_inv(J)) : J
     history = __init_trace_history(Val{show_trace}(), trace_level, Val{store_trace}(), u,
         fu, J_, δu)
     return NonlinearSolveTrace{show_trace, store_trace}(history, trace_level)
@@ -231,7 +231,7 @@ function update_trace!(cache::AbstractNonlinearSolveCache, α = true)
                 nothing, cache.du, α)
         else
             update_trace!(trace, cache.stats.nsteps + 1, get_u(cache), get_fu(cache),
-                ApplyArray(inv, J_inv), cache.du, α)
+                ApplyArray(__safe_inv, J_inv), cache.du, α)
         end
     else
         update_trace!(trace, cache.stats.nsteps + 1, get_u(cache), get_fu(cache), J,

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -134,7 +134,9 @@ function NonlinearSolveTraceEntry(iteration, fu, δu, J, u)
 end
 
 __cond(J::AbstractMatrix) = cond(J)
+__cond(J::SVector) = __cond(Diagonal(MVector(J)))
 __cond(J::AbstractVector) = __cond(Diagonal(J))
+__cond(J::ApplyArray) = __cond(J.f(J.args...))
 __cond(J) = -1  # Covers cases where `J` is a Operator, nothing, etc.
 
 __copy(x::AbstractArray) = copy(x)

--- a/src/trace.jl
+++ b/src/trace.jl
@@ -134,6 +134,7 @@ function NonlinearSolveTraceEntry(iteration, fu, δu, J, u)
 end
 
 __cond(J::AbstractMatrix) = cond(J)
+__cond(J::AbstractVector) = __cond(Diagonal(J))
 __cond(J) = -1  # Covers cases where `J` is a Operator, nothing, etc.
 
 __copy(x::AbstractArray) = copy(x)

--- a/src/trustRegion.jl
+++ b/src/trustRegion.jl
@@ -582,7 +582,6 @@ function __reinit_internal!(cache::TrustRegionCache; kwargs...)
     return nothing
 end
 
-# This only holds for 2-norm?
 __trust_region_loss(cache::TrustRegionCache, x) = __trust_region_loss(cache.internalnorm, x)
 __trust_region_loss(nf::F, x) where {F} = nf(x)^2 / 2
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -556,7 +556,3 @@ end
 @inline __diag(x::AbstractMatrix) = diag(x)
 @inline __diag(x::AbstractVector) = x
 @inline __diag(x::Number) = x
-
-@inline __isdiag(::AbstractVector) = true
-@inline __isdiag(::Number) = true
-@inline __isdiag(::AbstractMatrix) = false

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -528,6 +528,7 @@ end
 @inline __diag(x::Number) = x
 
 # Safe Inverse: Try to use `inv` but if lu fails use `pinv`
+__safe_inv(A::AbstractMatrix) = pinv(A)
 function __safe_inv(A::StridedMatrix{T}) where {T}
     LinearAlgebra.checksquare(A)
     if istriu(A)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -551,6 +551,9 @@ end
     end
     return J
 end
+@inline function __get_diagonal!!(J::AbstractArray, J_full::AbstractMatrix)
+    return _restructure(J, __get_diagonal!!(_vec(J), J_full))
+end
 @inline __get_diagonal!!(J::Number, J_full::Number) = J_full
 
 @inline __diag(x::AbstractMatrix) = diag(x)

--- a/test/23_test_problems.jl
+++ b/test/23_test_problems.jl
@@ -90,22 +90,25 @@ end
 end
 
 @testset "GeneralBroyden 23 Test Problems" begin
-    alg_ops = (GeneralBroyden(; max_resets = 10),)
+    alg_ops = (GeneralBroyden(; max_resets = 1000),
+        GeneralBroyden(; max_resets = 1000, init_jacobian = Val(:true_jacobian)))
 
     broken_tests = Dict(alg => Int[] for alg in alg_ops)
     broken_tests[alg_ops[1]] = [1, 4, 5, 6, 11, 12, 13, 14]
+    broken_tests[alg_ops[2]] = [1, 5, 6, 8, 11, 18]
 
     skip_tests = Dict(alg => Int[] for alg in alg_ops)
     skip_tests[alg_ops[1]] = [2, 22]
+    skip_tests[alg_ops[2]] = [2, 22]
 
     test_on_library(problems, dicts, alg_ops, broken_tests; skip_tests)
 end
 
 @testset "GeneralKlement 23 Test Problems" begin
-    alg_ops = (GeneralKlement(),)
+    alg_ops = (GeneralKlement(; max_resets = 1000),)
 
     broken_tests = Dict(alg => Int[] for alg in alg_ops)
-    broken_tests[alg_ops[1]] = [1, 2, 4, 5, 6, 7, 11, 13, 22]
+    broken_tests[alg_ops[1]] = [1, 2, 4, 5, 6, 11, 22]
 
     test_on_library(problems, dicts, alg_ops, broken_tests)
 end

--- a/test/23_test_problems.jl
+++ b/test/23_test_problems.jl
@@ -94,19 +94,25 @@ end
         GeneralBroyden(; init_jacobian = Val(:true_jacobian)),
         GeneralBroyden(; update_rule = Val(:bad_broyden)),
         GeneralBroyden(; init_jacobian = Val(:true_jacobian),
-            update_rule = Val(:bad_broyden)))
+            update_rule = Val(:bad_broyden)),
+        GeneralBroyden(; update_rule = Val(:diagonal)),
+        GeneralBroyden(; init_jacobian = Val(:true_jacobian), update_rule = Val(:diagonal)))
 
     broken_tests = Dict(alg => Int[] for alg in alg_ops)
     broken_tests[alg_ops[1]] = [1, 5, 6, 11]
     broken_tests[alg_ops[2]] = [1, 5, 6, 8, 11, 18]
     broken_tests[alg_ops[3]] = [1, 4, 5, 6, 9, 11]
     broken_tests[alg_ops[4]] = [1, 5, 6, 8, 11]
+    broken_tests[alg_ops[5]] = [1, 3, 4, 5, 6, 8, 9, 11, 12, 15, 21]
+    broken_tests[alg_ops[6]] = [3, 4, 5, 6, 8, 9, 11, 12, 21]
 
     skip_tests = Dict(alg => Int[] for alg in alg_ops)
     skip_tests[alg_ops[1]] = [2, 22]
     skip_tests[alg_ops[2]] = [2, 22]
     skip_tests[alg_ops[3]] = [2, 22]
     skip_tests[alg_ops[4]] = [2, 22]
+    skip_tests[alg_ops[5]] = [2, 22]
+    skip_tests[alg_ops[6]] = [2, 22]
 
     test_on_library(problems, dicts, alg_ops, broken_tests; skip_tests)
 end

--- a/test/23_test_problems.jl
+++ b/test/23_test_problems.jl
@@ -90,25 +90,36 @@ end
 end
 
 @testset "GeneralBroyden 23 Test Problems" begin
-    alg_ops = (GeneralBroyden(; max_resets = 1000),
-        GeneralBroyden(; max_resets = 1000, init_jacobian = Val(:true_jacobian)))
+    alg_ops = (GeneralBroyden(),
+        GeneralBroyden(; init_jacobian = Val(:true_jacobian)),
+        GeneralBroyden(; update_rule = Val(:bad_broyden)),
+        GeneralBroyden(; init_jacobian = Val(:true_jacobian),
+            update_rule = Val(:bad_broyden)))
 
     broken_tests = Dict(alg => Int[] for alg in alg_ops)
-    broken_tests[alg_ops[1]] = [1, 4, 5, 6, 11, 12, 13, 14]
+    broken_tests[alg_ops[1]] = [1, 5, 6, 11]
     broken_tests[alg_ops[2]] = [1, 5, 6, 8, 11, 18]
+    broken_tests[alg_ops[3]] = [1, 4, 5, 6, 9, 11]
+    broken_tests[alg_ops[4]] = [1, 5, 6, 8, 11]
 
     skip_tests = Dict(alg => Int[] for alg in alg_ops)
     skip_tests[alg_ops[1]] = [2, 22]
     skip_tests[alg_ops[2]] = [2, 22]
+    skip_tests[alg_ops[3]] = [2, 22]
+    skip_tests[alg_ops[4]] = [2, 22]
 
     test_on_library(problems, dicts, alg_ops, broken_tests; skip_tests)
 end
 
 @testset "GeneralKlement 23 Test Problems" begin
-    alg_ops = (GeneralKlement(; max_resets = 1000),)
+    alg_ops = (GeneralKlement(),
+        GeneralKlement(; init_jacobian = Val(:true_jacobian)),
+        GeneralKlement(; init_jacobian = Val(:true_jacobian_diagonal)))
 
     broken_tests = Dict(alg => Int[] for alg in alg_ops)
     broken_tests[alg_ops[1]] = [1, 2, 4, 5, 6, 11, 22]
+    broken_tests[alg_ops[2]] = [1, 2, 4, 5, 6, 8, 9, 10, 11, 13, 17, 21, 22, 23]
+    broken_tests[alg_ops[3]] = [2, 4, 5, 6, 7, 18, 22]
 
     test_on_library(problems, dicts, alg_ops, broken_tests)
 end

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -692,42 +692,50 @@ end
 # --- GeneralBroyden tests ---
 
 @testset "GeneralBroyden" begin
-    function benchmark_nlsolve_oop(f, u0, p = 2.0; linesearch = nothing)
+    function benchmark_nlsolve_oop(f, u0, p = 2.0; linesearch = nothing,
+            init_jacobian = Val(:identity), update_rule = Val(:good_broyden))
         prob = NonlinearProblem{false}(f, u0, p)
-        return solve(prob, GeneralBroyden(; linesearch), abstol = 1e-9)
+        return solve(prob, GeneralBroyden(; linesearch, init_jacobian, update_rule);
+            abstol = 1e-9)
     end
 
-    function benchmark_nlsolve_iip(f, u0, p = 2.0; linesearch = nothing)
+    function benchmark_nlsolve_iip(f, u0, p = 2.0; linesearch = nothing,
+            init_jacobian = Val(:identity), update_rule = Val(:good_broyden))
         prob = NonlinearProblem{true}(f, u0, p)
-        return solve(prob, GeneralBroyden(; linesearch), abstol = 1e-9)
+        return solve(prob, GeneralBroyden(; linesearch, init_jacobian, update_rule);
+            abstol = 1e-9)
     end
 
-    @testset "LineSearch: $(_nameof(lsmethod)) LineSearch AD: $(_nameof(ad))" for lsmethod in (Static(),
+    @testset "LineSearch: $(_nameof(lsmethod)) LineSearch AD: $(_nameof(ad)) Init Jacobian: $(init_jacobian) Update Rule: $(update_rule)" for lsmethod in (Static(),
             StrongWolfe(), BackTracking(), HagerZhang(), MoreThuente(),
             LiFukushimaLineSearch()),
-        ad in (AutoFiniteDiff(), AutoZygote())
+        ad in (AutoFiniteDiff(), AutoZygote()),
+        init_jacobian in (Val(:identity), Val(:true_jacobian)),
+        update_rule in (Val(:good_broyden), Val(:bad_broyden), Val(:diagonal))
 
         linesearch = LineSearch(; method = lsmethod, autodiff = ad)
         u0s = ([1.0, 1.0], @SVector[1.0, 1.0], 1.0)
 
         @testset "[OOP] u0: $(typeof(u0))" for u0 in u0s
-            sol = benchmark_nlsolve_oop(quadratic_f, u0; linesearch)
+            sol = benchmark_nlsolve_oop(quadratic_f, u0; linesearch, update_rule,
+                init_jacobian)
             @test SciMLBase.successful_retcode(sol)
             @test all(abs.(sol.u .* sol.u .- 2) .< 1e-9)
 
             cache = init(NonlinearProblem{false}(quadratic_f, u0, 2.0),
-                GeneralBroyden(; linesearch), abstol = 1e-9)
+                GeneralBroyden(; linesearch, update_rule, init_jacobian), abstol = 1e-9)
             @test (@ballocated solve!($cache)) < 200
         end
 
         @testset "[IIP] u0: $(typeof(u0))" for u0 in ([1.0, 1.0],)
             ad isa AutoZygote && continue
-            sol = benchmark_nlsolve_iip(quadratic_f!, u0; linesearch)
+            sol = benchmark_nlsolve_iip(quadratic_f!, u0; linesearch, update_rule,
+                init_jacobian)
             @test SciMLBase.successful_retcode(sol)
             @test all(abs.(sol.u .* sol.u .- 2) .< 1e-9)
 
             cache = init(NonlinearProblem{true}(quadratic_f!, u0, 2.0),
-                GeneralBroyden(; linesearch), abstol = 1e-9)
+                GeneralBroyden(; linesearch, update_rule, init_jacobian), abstol = 1e-9)
             @test (@ballocated solve!($cache)) ≤ 64
         end
     end

--- a/test/basictests.jl
+++ b/test/basictests.jl
@@ -789,25 +789,28 @@ end
 # --- GeneralKlement tests ---
 
 @testset "GeneralKlement" begin
-    function benchmark_nlsolve_oop(f, u0, p = 2.0; linesearch = nothing)
+    function benchmark_nlsolve_oop(f, u0, p = 2.0; linesearch = nothing,
+            init_jacobian = Val(:identity))
         prob = NonlinearProblem{false}(f, u0, p)
-        return solve(prob, GeneralKlement(; linesearch), abstol = 1e-9)
+        return solve(prob, GeneralKlement(; linesearch, init_jacobian), abstol = 1e-9)
     end
 
-    function benchmark_nlsolve_iip(f, u0, p = 2.0; linesearch = nothing)
+    function benchmark_nlsolve_iip(f, u0, p = 2.0; linesearch = nothing,
+            init_jacobian = Val(:identity))
         prob = NonlinearProblem{true}(f, u0, p)
-        return solve(prob, GeneralKlement(; linesearch), abstol = 1e-9)
+        return solve(prob, GeneralKlement(; linesearch, init_jacobian), abstol = 1e-9)
     end
 
-    @testset "LineSearch: $(_nameof(lsmethod)) LineSearch AD: $(_nameof(ad))" for lsmethod in (Static(),
+    @testset "LineSearch: $(_nameof(lsmethod)) LineSearch AD: $(_nameof(ad)) Init Jacobian: $(init_jacobian)" for lsmethod in (Static(),
             StrongWolfe(), BackTracking(), HagerZhang(), MoreThuente()),
-        ad in (AutoFiniteDiff(), AutoZygote())
+        ad in (AutoFiniteDiff(), AutoZygote()),
+        init_jacobian in (Val(:identity), Val(:true_jacobian), Val(:true_jacobian_diagonal))
 
         linesearch = LineSearch(; method = lsmethod, autodiff = ad)
         u0s = ([1.0, 1.0], @SVector[1.0, 1.0], 1.0)
 
         @testset "[OOP] u0: $(typeof(u0))" for u0 in u0s
-            sol = benchmark_nlsolve_oop(quadratic_f, u0; linesearch)
+            sol = benchmark_nlsolve_oop(quadratic_f, u0; linesearch, init_jacobian)
             # Some are failing by a margin
             # @test SciMLBase.successful_retcode(sol)
             @test all(abs.(sol.u .* sol.u .- 2) .< 3e-9)
@@ -819,7 +822,7 @@ end
 
         @testset "[IIP] u0: $(typeof(u0))" for u0 in ([1.0, 1.0],)
             ad isa AutoZygote && continue
-            sol = benchmark_nlsolve_iip(quadratic_f!, u0; linesearch)
+            sol = benchmark_nlsolve_iip(quadratic_f!, u0; linesearch, init_jacobian)
             @test SciMLBase.successful_retcode(sol)
             @test all(abs.(sol.u .* sol.u .- 2) .< 1e-9)
 

--- a/test/matrix_resizing.jl
+++ b/test/matrix_resizing.jl
@@ -1,7 +1,7 @@
-using NonlinearSolve, Test
+using NonlinearSolve, Test, StableRNGs
 
 ff(u, p) = u .* u .- p
-u0 = rand(2, 2)
+u0 = rand(StableRNG(0), 2, 2)
 p = 2.0
 vecprob = NonlinearProblem(ff, vec(u0), p)
 prob = NonlinearProblem(ff, u0, p)
@@ -13,7 +13,7 @@ for alg in (NewtonRaphson(), TrustRegion(), LevenbergMarquardt(), PseudoTransien
 end
 
 fiip(du, u, p) = (du .= u .* u .- p)
-u0 = rand(2, 2)
+u0 = rand(StableRNG(0), 2, 2)
 p = 2.0
 vecprob = NonlinearProblem(fiip, vec(u0), p)
 prob = NonlinearProblem(fiip, u0, p)


### PR DESCRIPTION
See https://github.com/JuliaNLSolvers/NLsolve.jl/pull/287

Needs #297 to go in first

Fixes https://github.com/SciML/NonlinearSolve.jl/issues/260

## Summary

1. Broyden and Klement can (re-)start with the true (inv-)jacobian if asked for
2. For Broyden, it improves robustness but makes Klement even more unstable for ill-conditioned problems
3. Klement with identity initialization makes the Jacobian always diagonal; the updated solver exploits this and is significantly faster
4. Klement for non-diagonal jacobians resets the jacobian if the jacobian is "too" ill-conditioned; this improves the stability somewhat
5. Bad Broyden Update Rule
6. Klement with true jacobian diagonal initialization
7. Initial Scaling factor to improve stability

## TODOs

- [x] Diagonal Update Rule for Broyden
- [ ] ~Exciting Mixing Update Rule for Broyden~
- [x] Testing