### PR TITLE
Use approximate sparsity detection by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 authors = ["SciML"]
-version = "3.0.1"
+version = "3.0.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -35,6 +35,7 @@ FastLevenbergMarquardt = "7a0df574-e128-4d35-8cbd-3d84502bf7ce"
 LeastSquaresOptim = "0fc2ff8b-aaa3-5acd-a817-1944a5e08891"
 MINPACK = "4854310b-de5a-5eb6-a2a5-c1dee2bd17f9"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [extensions]
@@ -43,6 +44,7 @@ NonlinearSolveFastLevenbergMarquardtExt = "FastLevenbergMarquardt"
 NonlinearSolveLeastSquaresOptimExt = "LeastSquaresOptim"
 NonlinearSolveMINPACKExt = "MINPACK"
 NonlinearSolveNLsolveExt = "NLsolve"
+NonlinearSolveSymbolicsExt = "Symbolics"
 NonlinearSolveZygoteExt = "Zygote"
 
 [compat]

--- a/ext/NonlinearSolveSymbolicsExt.jl
+++ b/ext/NonlinearSolveSymbolicsExt.jl
@@ -1,0 +1,7 @@
+module NonlinearSolveSymbolicsExt
+
+import NonlinearSolve, Symbolics
+
+NonlinearSolve.is_extension_loaded(::Val{:Symbolics}) = true
+
+end

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -12,7 +12,15 @@ sparsity_detection_alg(_, _) = NoSparsityDetection()
 function sparsity_detection_alg(f, ad::AbstractSparseADType)
     if f.sparsity === nothing
         if f.jac_prototype === nothing
-            return SymbolicsSparsityDetection()
+            if is_extension_loaded(Val(:Symbolics))
+                return SymbolicsSparsityDetection()
+            else
+                @warn "Symbolics.jl is not loaded and sparse AD mode $(ad) is being used. \
+                       Using approximate sparsity detection using ForwardDiff. This can \
+                       potentially fail or generate incorrect sparsity pattern for \
+                       complicated problems. Use with caution." maxlog=1
+                return ApproximateJacobianSparsity()
+            end
         else
             jac_prototype = f.jac_prototype
         end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [ScioML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

If Symbolics.jl is not loaded, it uses ForwardDiff for approximate sparsity detection. I am displaying a warning because this can lead to failures due to incorrect sparsity pattern. But overall this is very promising at least for the brusselator example. Approximate Detection + Solving takes the similar time as Symbolics Solving (symbolic detection being extremely slow)
