### PR TITLE
typo in makedocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,7 @@ makedocs(; sitename = "NonlinearSolve.jl",
         DiffEqBase, SciMLBase],
     clean = true, doctest = false, linkcheck = true,
     linkcheck_ignore = ["https://twitter.com/ChrisRackauckas/status/1544743542094020615"],
-    checkdocs = :export,
+    checkdocs = :exports,
     format = Documenter.HTML(assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/NonlinearSolve/stable/"),
     pages)


### PR DESCRIPTION
https://github.com/SciML/NonlinearSolve.jl/issues/221 should likely not have been closed.
It likely throws no errors about missing docs because of the typo.