### PR TITLE
Allow linsolve to be \

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 authors = ["SciML"]
-version = "3.5.0"
+version = "3.5.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/src/internal/helpers.jl
+++ b/src/internal/helpers.jl
@@ -123,7 +123,8 @@ use this functionality unless it can't be avoided (like in [`LevenbergMarquardt`
 
 # Extension Algorithm Helpers
 function __test_termination_condition(termination_condition, alg)
-    termination_condition !== AbsNormTerminationMode && termination_condition !== nothing &&
+    !(termination_condition isa AbsNormTerminationMode) &&
+        termination_condition !== nothing &&
         error("`$(alg)` does not support termination conditions!")
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -18,6 +18,7 @@ end
 end
 
 @inline __needs_concrete_A(::Nothing) = false
+@inline __needs_concrete_A(::typeof(\)) = true
 @inline __needs_concrete_A(linsolve) = needs_concrete_A(linsolve)
 
 @inline __maybe_mutable(x, ::AutoSparseEnzyme) = __mutable(x)

--- a/test/core/rootfind.jl
+++ b/test/core/rootfind.jl
@@ -72,7 +72,7 @@ const TERMINATION_CONDITIONS = [
         ]
 
         @testset "[IIP] u0: $(typeof(u0)) precs: $(_nameof(prec)) linsolve: $(_nameof(linsolve))" for u0 in ([
-                1.0, 1.0],), prec in precs, linsolve in (nothing, KrylovJL_GMRES())
+                1.0, 1.0],), prec in precs, linsolve in (nothing, KrylovJL_GMRES(), \)
             ad isa AutoZygote && continue
             if prec === :Random
                 prec = (args...) -> (Diagonal(randn!(similar(u0))), nothing)
@@ -139,7 +139,7 @@ end
         RadiusUpdateSchemes.NLsolve, RadiusUpdateSchemes.Hei, RadiusUpdateSchemes.Yuan,
         RadiusUpdateSchemes.Fan, RadiusUpdateSchemes.Bastin]
     u0s = ([1.0, 1.0], @SVector[1.0, 1.0], 1.0)
-    linear_solvers = [nothing, LUFactorization(), KrylovJL_GMRES()]
+    linear_solvers = [nothing, LUFactorization(), KrylovJL_GMRES(), \]
 
     @testset "[OOP] u0: $(typeof(u0)) radius_update_scheme: $(radius_update_scheme) linear_solver: $(linsolve)" for u0 in u0s,
         radius_update_scheme in radius_update_schemes, linsolve in linear_solvers
@@ -471,7 +471,7 @@ end
         precs = [NonlinearSolve.DEFAULT_PRECS, :Random]
 
         @testset "[IIP] u0: $(typeof(u0)) precs: $(_nameof(prec)) linsolve: $(_nameof(linsolve))" for u0 in ([
-                1.0, 1.0],), prec in precs, linsolve in (nothing, KrylovJL_GMRES())
+                1.0, 1.0],), prec in precs, linsolve in (nothing, KrylovJL_GMRES(), \)
             ad isa AutoZygote && continue
             if prec === :Random
                 prec = (args...) -> (Diagonal(randn!(similar(u0))), nothing)


### PR DESCRIPTION
For very simple problems with a diagonal Jacobian this is much faster.

Testing on the quadratic problem

```julia
julia> @benchmark solve(prob, NLsolveJL())
BenchmarkTools.Trial: 10000 samples with 5 evaluations.
 Range (min … max):  6.047 μs …  2.675 ms  ┊ GC (min … max):  0.00% … 98.90%
 Time  (median):     7.052 μs              ┊ GC (median):     0.00%
 Time  (mean ± σ):   9.251 μs ± 50.774 μs  ┊ GC (mean ± σ):  10.88% ±  1.98%

    ▁█▂                                                       
  ▁▂███▆▃▂▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▂▂▂▃▃▃▄▄▄▃▄▃▃▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁ ▂
  6.05 μs        Histogram: frequency by time        12.6 μs <

 Memory estimate: 8.20 KiB, allocs estimate: 107.

julia> @benchmark solve(prob, NewtonRaphson(; linsolve = \, autodiff = AutoForwardDiff(; chunksize = 2)))
BenchmarkTools.Trial: 10000 samples with 9 evaluations.
 Range (min … max):  2.446 μs …  1.465 ms  ┊ GC (min … max):  0.00% … 98.65%
 Time  (median):     2.976 μs              ┊ GC (median):     0.00%
 Time  (mean ± σ):   4.062 μs ± 27.179 μs  ┊ GC (mean ± σ):  13.24% ±  1.98%

     ▄█▇▅▁                                                    
  ▁▂▅██████▆▃▃▃▂▂▂▂▃▂▃▃▃▃▂▂▂▂▂▁▂▂▂▂▃▃▃▃▃▃▃▄▄▃▃▂▂▂▂▂▂▂▂▂▁▁▁▁▁ ▂
  2.45 μs        Histogram: frequency by time        5.89 μs <

 Memory estimate: 5.09 KiB, allocs estimate: 54.

julia> @benchmark solve(prob, NewtonRaphson(; linsolve = LUFactorization(), autodiff = AutoForwardDiff(; chunksize = 2)))
BenchmarkTools.Trial: 10000 samples with 8 evaluations.
 Range (min … max):  3.409 μs …  1.503 ms  ┊ GC (min … max): 0.00% … 98.89%
 Time  (median):     3.759 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.631 μs ± 25.575 μs  ┊ GC (mean ± σ):  9.47% ±  1.71%

   ▄▆██▇▇▇▆▅▄▃▃▂▁ ▁             ▁▁▁▁▂▁▂▂▂▂▃▂▃▃▂▃▂▁▂▁▁▁       ▂
  █████████████████▇▅▆▆▆▅▆▆▇▇▇███████████████████████████▇▇▇ █
  3.41 μs      Histogram: log(frequency) by time     6.77 μs <

 Memory estimate: 5.22 KiB, allocs estimate: 55.

julia> @benchmark solve(prob, NewtonRaphson(; autodiff = AutoForwardDiff(; chunksize = 2)))
BenchmarkTools.Trial: 10000 samples with 7 evaluations.
 Range (min … max):  4.846 μs …  1.846 ms  ┊ GC (min … max):  0.00% … 98.97%
 Time  (median):     5.304 μs              ┊ GC (median):     0.00%
 Time  (mean ± σ):   6.414 μs ± 40.806 μs  ┊ GC (mean ± σ):  14.11% ±  2.21%

   ▃▅▇███▇▆▅▄▃▂▂▂                                            ▂
  █████████████████▇▆▇▇▆▆▆▇▆▇▆▅▆▄▅▆▅▄▄▅▅▄▆▅▇▆▆▇▇▇▆███▇█▇▇▇▇▇ █
  4.85 μs      Histogram: log(frequency) by time     9.25 μs <

 Memory estimate: 8.25 KiB, allocs estimate: 100.
```