### PR TITLE
Add precommit for formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+ci:
+  skip:
+    - julia-formatter
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/domluna/JuliaFormatter.jl
+    rev: v1.0.45
+    hooks:
+      - id: julia-formatter
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    # We only want to format yaml, md files
+    hooks:
+      - id: prettier
+        types_or:
+          - yaml
+          - markdown


### PR DESCRIPTION
With 1.10 the overhead is very small to run it per-commit.