### PR TITLE
run precompile workload in parallel

### DIFF
--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -135,11 +135,19 @@ include("default.jl")
         TrustRegion(; linsolve = LUFactorization()), nothing)
 
     @compile_workload begin
+        @sync begin
+        for T in (Float32, Float64), (fn, u0) in nlfuncs
+            Threads.@spawn NonlinearProblem(fn, T.(u0), T(2))
+        end
+        for (fn, u0) in nlfuncs
+            Threads.@spawn NonlinearLeastSquaresProblem(fn, u0, 2.0)
+        end
         for prob in probs_nls, alg in nls_algs
-            solve(prob, alg; abstol = 1e-2, verbose = false)
+            Threads.@spawn solve(prob, alg; abstol = 1e-2, verbose = false)
         end
         for prob in probs_nlls, alg in nlls_algs
-            solve(prob, alg; abstol = 1e-2, verbose = false)
+            Threads.@spawn solve(prob, alg; abstol = 1e-2, verbose = false)
+        end
         end
     end
 end


### PR DESCRIPTION
I'm not 100% sure this is working as intended (because these precompiles are over-specialized), but it does bring the precompile time down from ~150 seconds to 50 seconds on 4 cores.