### PR TITLE
Add forward mode to line search

### DIFF
--- a/test/core/rootfind_tests.jl
+++ b/test/core/rootfind_tests.jl
@@ -55,7 +55,7 @@ end
 @testitem "NewtonRaphson" setup=[CoreRootfindTesting] tags=[:core] timeout=3600 begin
     @testset "LineSearch: $(_nameof(lsmethod)) LineSearch AD: $(_nameof(ad))" for lsmethod in (
             Static(), StrongWolfe(), BackTracking(), HagerZhang(), MoreThuente()),
-        ad in (AutoFiniteDiff(), AutoZygote())
+        ad in (AutoForwardDiff(), AutoZygote(), AutoFiniteDiff())
 
         linesearch = LineSearchesJL(; method = lsmethod, autodiff = ad)
         u0s = ([1.0, 1.0], @SVector[1.0, 1.0], 1.0)
@@ -466,7 +466,7 @@ end
     @testset "LineSearch: $(_nameof(lsmethod)) LineSearch AD: $(_nameof(ad)) Init Jacobian: $(init_jacobian) Update Rule: $(update_rule)" for lsmethod in (
             Static(), StrongWolfe(), BackTracking(),
             HagerZhang(), MoreThuente(), LiFukushimaLineSearch()),
-        ad in (AutoFiniteDiff(), AutoZygote()),
+        ad in (AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()),
         init_jacobian in (Val(:identity), Val(:true_jacobian)),
         update_rule in (Val(:good_broyden), Val(:bad_broyden), Val(:diagonal))
 
@@ -515,7 +515,7 @@ end
 @testitem "Klement" setup=[CoreRootfindTesting] tags=[:core] skip=:(Sys.isapple()) timeout=3600 begin
     @testset "LineSearch: $(_nameof(lsmethod)) LineSearch AD: $(_nameof(ad)) Init Jacobian: $(init_jacobian)" for lsmethod in (
             Static(), StrongWolfe(), BackTracking(), HagerZhang(), MoreThuente()),
-        ad in (AutoFiniteDiff(), AutoZygote()),
+        ad in (AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()),
         init_jacobian in (Val(:identity), Val(:true_jacobian), Val(:true_jacobian_diagonal))
 
         linesearch = LineSearchesJL(; method = lsmethod, autodiff = ad)
@@ -565,7 +565,7 @@ end
     @testset "LineSearch: $(_nameof(lsmethod)) LineSearch AD: $(_nameof(ad))" for lsmethod in (
             Static(), StrongWolfe(), BackTracking(),
             HagerZhang(), MoreThuente(), LiFukushimaLineSearch()),
-        ad in (AutoFiniteDiff(), AutoZygote())
+        ad in (AutoForwardDiff(), AutoZygote(), AutoFiniteDiff())
 
         linesearch = LineSearchesJL(; method = lsmethod, autodiff = ad)
         u0s = ([1.0, 1.0], @SVector[1.0, 1.0], 1.0)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Added forward mode support to line searches. We prefer forward AD for better performance, however, reverse AD is also supported if user explicitly requests it.

1. If jvp is available, we use forward AD;
2. If reverse type is requested, we use reverse AD;
3. Otherwise, we use forward AD.