### PR TITLE
Remove recompile_invalidations

### DIFF
--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -10,8 +10,8 @@ using PrecompileTools: @compile_workload, @setup_workload
 using ADTypes: ADTypes, AutoFiniteDiff, AutoForwardDiff, AutoPolyesterForwardDiff,
                AutoZygote, AutoEnzyme, AutoSparse
 # FIXME: deprecated, remove in future
-using ADTypes: AutoSparseFiniteDiff, AutoSparseForwardDiff,
-               AutoSparsePolyesterForwardDiff, AutoSparseZygote
+using ADTypes: AutoSparseFiniteDiff, AutoSparseForwardDiff, AutoSparsePolyesterForwardDiff,
+               AutoSparseZygote
 
 using ArrayInterface: ArrayInterface, can_setindex, restructure, fast_scalar_indexing,
                       ismutable

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -49,8 +49,8 @@ using SparseDiffTools: SparseDiffTools, AbstractSparsityDetection,
                        sparse_jacobian, sparse_jacobian!, sparse_jacobian_cache
 using StaticArraysCore: StaticArray, SVector, SArray, MArray, Size, SMatrix
 using SymbolicIndexingInterface: SymbolicIndexingInterface, ParameterIndexingProxy,
-                                 symbolic_container, parameter_values, state_values,
-                                 getu, setu
+                                 symbolic_container, parameter_values, state_values, getu,
+                                 setu
 
 @reexport using SciMLBase, SimpleNonlinearSolve
 

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -44,10 +44,9 @@ using SparseArrays: AbstractSparseMatrix, SparseMatrixCSC
 using SparseDiffTools: SparseDiffTools, AbstractSparsityDetection,
                        ApproximateJacobianSparsity, JacPrototypeSparsityDetection,
                        NoSparsityDetection, PrecomputedJacobianColorvec,
-                       SymbolicsSparsityDetection, auto_jacvec, auto_jacvec!,
-                       auto_vecjac, init_jacobian, num_jacvec, num_jacvec!, num_vecjac,
-                       num_vecjac!, sparse_jacobian, sparse_jacobian!,
-                       sparse_jacobian_cache
+                       SymbolicsSparsityDetection, auto_jacvec, auto_jacvec!, auto_vecjac,
+                       init_jacobian, num_jacvec, num_jacvec!, num_vecjac, num_vecjac!,
+                       sparse_jacobian, sparse_jacobian!, sparse_jacobian_cache
 using StaticArraysCore: StaticArray, SVector, SArray, MArray, Size, SMatrix
 using SymbolicIndexingInterface: SymbolicIndexingInterface, ParameterIndexingProxy,
                                  symbolic_container, parameter_values, state_values,

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -28,8 +28,8 @@ using FiniteDiff: FiniteDiff
 using ForwardDiff: ForwardDiff, Dual
 using LazyArrays: LazyArrays, ApplyArray, cache
 using LinearAlgebra: LinearAlgebra, ColumnNorm, Diagonal, I, LowerTriangular, Symmetric,
-                     UpperTriangular, axpy!, cond, diag, diagind, dot, issuccess,
-                     istril, istriu, lu, mul!, norm, pinv, tril!, triu!
+                     UpperTriangular, axpy!, cond, diag, diagind, dot, issuccess, istril,
+                     istriu, lu, mul!, norm, pinv, tril!, triu!
 using LineSearches: LineSearches
 using LinearSolve: LinearSolve, LUFactorization, QRFactorization, ComposePreconditioner,
                    InvPreconditioner, needs_concrete_A, AbstractFactorization,

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -5,56 +5,54 @@ if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@max_m
 end
 
 using Reexport: @reexport
-using PrecompileTools: @recompile_invalidations, @compile_workload, @setup_workload
+using PrecompileTools: @compile_workload, @setup_workload
 
-@recompile_invalidations begin
-    using ADTypes: ADTypes, AutoFiniteDiff, AutoForwardDiff, AutoPolyesterForwardDiff,
-                   AutoZygote, AutoEnzyme, AutoSparse
-    # FIXME: deprecated, remove in future
-    using ADTypes: AutoSparseFiniteDiff, AutoSparseForwardDiff,
-                   AutoSparsePolyesterForwardDiff, AutoSparseZygote
+using ADTypes: ADTypes, AutoFiniteDiff, AutoForwardDiff, AutoPolyesterForwardDiff,
+               AutoZygote, AutoEnzyme, AutoSparse
+# FIXME: deprecated, remove in future
+using ADTypes: AutoSparseFiniteDiff, AutoSparseForwardDiff,
+               AutoSparsePolyesterForwardDiff, AutoSparseZygote
 
-    using ArrayInterface: ArrayInterface, can_setindex, restructure, fast_scalar_indexing,
-                          ismutable
-    using ConcreteStructs: @concrete
-    using DiffEqBase: DiffEqBase, AbstractNonlinearTerminationMode,
-                      AbstractSafeBestNonlinearTerminationMode, AbsNormTerminationMode,
-                      AbsSafeBestTerminationMode, AbsSafeTerminationMode,
-                      AbsTerminationMode, NormTerminationMode, RelNormTerminationMode,
-                      RelSafeBestTerminationMode, RelSafeTerminationMode,
-                      RelTerminationMode, SimpleNonlinearSolveTerminationMode,
-                      SteadyStateDiffEqTerminationMode
-    using FastBroadcast: @..
-    using FastClosures: @closure
-    using FiniteDiff: FiniteDiff
-    using ForwardDiff: ForwardDiff, Dual
-    using LazyArrays: LazyArrays, ApplyArray, cache
-    using LinearAlgebra: LinearAlgebra, ColumnNorm, Diagonal, I, LowerTriangular, Symmetric,
-                         UpperTriangular, axpy!, cond, diag, diagind, dot, issuccess,
-                         istril, istriu, lu, mul!, norm, pinv, tril!, triu!
-    using LineSearches: LineSearches
-    using LinearSolve: LinearSolve, LUFactorization, QRFactorization, ComposePreconditioner,
-                       InvPreconditioner, needs_concrete_A, AbstractFactorization,
-                       DefaultAlgorithmChoice, DefaultLinearSolver
-    using MaybeInplace: @bb
-    using Printf: @printf
-    using Preferences: Preferences, @load_preference, @set_preferences!
-    using RecursiveArrayTools: recursivecopy!, recursivefill!
-    using SciMLBase: AbstractNonlinearAlgorithm, JacobianWrapper, AbstractNonlinearProblem,
-                     AbstractSciMLOperator, _unwrap_val, has_jac, isinplace, NLStats
-    using SparseArrays: AbstractSparseMatrix, SparseMatrixCSC
-    using SparseDiffTools: SparseDiffTools, AbstractSparsityDetection,
-                           ApproximateJacobianSparsity, JacPrototypeSparsityDetection,
-                           NoSparsityDetection, PrecomputedJacobianColorvec,
-                           SymbolicsSparsityDetection, auto_jacvec, auto_jacvec!,
-                           auto_vecjac, init_jacobian, num_jacvec, num_jacvec!, num_vecjac,
-                           num_vecjac!, sparse_jacobian, sparse_jacobian!,
-                           sparse_jacobian_cache
-    using StaticArraysCore: StaticArray, SVector, SArray, MArray, Size, SMatrix
-    using SymbolicIndexingInterface: SymbolicIndexingInterface, ParameterIndexingProxy,
-                                     symbolic_container, parameter_values, state_values,
-                                     getu, setu
-end
+using ArrayInterface: ArrayInterface, can_setindex, restructure, fast_scalar_indexing,
+                      ismutable
+using ConcreteStructs: @concrete
+using DiffEqBase: DiffEqBase, AbstractNonlinearTerminationMode,
+                  AbstractSafeBestNonlinearTerminationMode, AbsNormTerminationMode,
+                  AbsSafeBestTerminationMode, AbsSafeTerminationMode,
+                  AbsTerminationMode, NormTerminationMode, RelNormTerminationMode,
+                  RelSafeBestTerminationMode, RelSafeTerminationMode,
+                  RelTerminationMode, SimpleNonlinearSolveTerminationMode,
+                  SteadyStateDiffEqTerminationMode
+using FastBroadcast: @..
+using FastClosures: @closure
+using FiniteDiff: FiniteDiff
+using ForwardDiff: ForwardDiff, Dual
+using LazyArrays: LazyArrays, ApplyArray, cache
+using LinearAlgebra: LinearAlgebra, ColumnNorm, Diagonal, I, LowerTriangular, Symmetric,
+                     UpperTriangular, axpy!, cond, diag, diagind, dot, issuccess,
+                     istril, istriu, lu, mul!, norm, pinv, tril!, triu!
+using LineSearches: LineSearches
+using LinearSolve: LinearSolve, LUFactorization, QRFactorization, ComposePreconditioner,
+                   InvPreconditioner, needs_concrete_A, AbstractFactorization,
+                   DefaultAlgorithmChoice, DefaultLinearSolver
+using MaybeInplace: @bb
+using Printf: @printf
+using Preferences: Preferences, @load_preference, @set_preferences!
+using RecursiveArrayTools: recursivecopy!, recursivefill!
+using SciMLBase: AbstractNonlinearAlgorithm, JacobianWrapper, AbstractNonlinearProblem,
+                 AbstractSciMLOperator, _unwrap_val, has_jac, isinplace, NLStats
+using SparseArrays: AbstractSparseMatrix, SparseMatrixCSC
+using SparseDiffTools: SparseDiffTools, AbstractSparsityDetection,
+                       ApproximateJacobianSparsity, JacPrototypeSparsityDetection,
+                       NoSparsityDetection, PrecomputedJacobianColorvec,
+                       SymbolicsSparsityDetection, auto_jacvec, auto_jacvec!,
+                       auto_vecjac, init_jacobian, num_jacvec, num_jacvec!, num_vecjac,
+                       num_vecjac!, sparse_jacobian, sparse_jacobian!,
+                       sparse_jacobian_cache
+using StaticArraysCore: StaticArray, SVector, SArray, MArray, Size, SMatrix
+using SymbolicIndexingInterface: SymbolicIndexingInterface, ParameterIndexingProxy,
+                                 symbolic_container, parameter_values, state_values,
+                                 getu, setu
 
 @reexport using SciMLBase, SimpleNonlinearSolve
 

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -18,11 +18,10 @@ using ArrayInterface: ArrayInterface, can_setindex, restructure, fast_scalar_ind
 using ConcreteStructs: @concrete
 using DiffEqBase: DiffEqBase, AbstractNonlinearTerminationMode,
                   AbstractSafeBestNonlinearTerminationMode, AbsNormTerminationMode,
-                  AbsSafeBestTerminationMode, AbsSafeTerminationMode,
-                  AbsTerminationMode, NormTerminationMode, RelNormTerminationMode,
-                  RelSafeBestTerminationMode, RelSafeTerminationMode,
-                  RelTerminationMode, SimpleNonlinearSolveTerminationMode,
-                  SteadyStateDiffEqTerminationMode
+                  AbsSafeBestTerminationMode, AbsSafeTerminationMode, AbsTerminationMode,
+                  NormTerminationMode, RelNormTerminationMode, RelSafeBestTerminationMode,
+                  RelSafeTerminationMode, RelTerminationMode,
+                  SimpleNonlinearSolveTerminationMode, SteadyStateDiffEqTerminationMode
 using FastBroadcast: @..
 using FastClosures: @closure
 using FiniteDiff: FiniteDiff


### PR DESCRIPTION
`@recompile_invalidations` should only be used in very specific scenarios, and this is not one of those scenarios. Also, there are big changes being done with https://github.com/SciML/CommonWorldInvalidations.jl. With that, we only need to `@recompile_invalidations` on a few entry points. In particular, Static.jl, Symbolics.jl, and preferably ForwardDiff.jl and StaticArrays.jl would adopt it too. But this means that in order to handle all of this effectively, in SciML we only need to apply it on Static.jl, Symbolics.jl, and SciMLBase.jl and the whole ecosystem should be fine.

In any case, this library doesn't need it. It shouldn't make a tangible difference in compile times, while it increases precompile times by a lot.
