### PR TITLE
Use DI preparation result when initializing Jacobian

### DIFF
--- a/src/internal/jacobian.jl
+++ b/src/internal/jacobian.jl
@@ -89,7 +89,7 @@ function JacobianCache(prob, alg, f::F, fu_, u, p; stats, autodiff = nothing,
                 if iip
                     DI.jacobian(f, fu, di_extras, autodiff, u, Constant(p))
                 else
-                    DI.jacobian(f, autodiff, u, Constant(p))
+                    DI.jacobian(f, di_extras, autodiff, u, Constant(p))
                 end
             end
         else


### PR DESCRIPTION
This should fix #469 for the example you gave.