### PR TITLE
fix type stability of SimpleNonlinearSolve

### DIFF
--- a/lib/SimpleNonlinearSolve/test/core/rootfind_tests.jl
+++ b/lib/SimpleNonlinearSolve/test/core/rootfind_tests.jl
@@ -28,10 +28,10 @@
     ]
 
     function run_nlsolve_oop(f::F, u0, p = 2.0; solver) where {F}
-        return solve(NonlinearProblem{false}(f, u0, p), solver; abstol = 1e-9)
+        return @inferred solve(NonlinearProblem{false}(f, u0, p), solver; abstol = 1e-9)
     end
     function run_nlsolve_iip(f!::F, u0, p = 2.0; solver) where {F}
-        return solve(NonlinearProblem{true}(f!, u0, p), solver; abstol = 1e-9)
+        return @inferred solve(NonlinearProblem{true}(f!, u0, p), solver; abstol = 1e-9)
     end
 end
 


### PR DESCRIPTION
This fixes an issue where we were returning a solution with a different `alg.autodiff` or `prob` if we had an `InitialFailure` vs a successful solve. This removes the allocations we were seeing in https://docs.sciml.ai/NonlinearSolve/stable/tutorials/code_optimization/#Further-Optimizations-for-Small-Nonlinear-Solves-with-Static-Arrays-and-SimpleNonlinearSolve.

Also fixes https://github.com/SciML/NonlinearSolve.jl/pull/536