### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/CI_BracketingNonlinearSolve.yml
+++ b/.github/workflows/CI_BracketingNonlinearSolve.yml
@@ -31,7 +31,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI_NonlinearSolve.yml
+++ b/.github/workflows/CI_NonlinearSolve.yml
@@ -44,7 +44,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI_NonlinearSolveBase.yml
+++ b/.github/workflows/CI_NonlinearSolveBase.yml
@@ -30,7 +30,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI_NonlinearSolveFirstOrder.yml
+++ b/.github/workflows/CI_NonlinearSolveFirstOrder.yml
@@ -31,7 +31,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI_NonlinearSolveHomotopyContinuation.yml
+++ b/.github/workflows/CI_NonlinearSolveHomotopyContinuation.yml
@@ -30,7 +30,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI_NonlinearSolveQuasiNewton.yml
+++ b/.github/workflows/CI_NonlinearSolveQuasiNewton.yml
@@ -31,7 +31,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI_NonlinearSolveSpectralMethods.yml
+++ b/.github/workflows/CI_NonlinearSolveSpectralMethods.yml
@@ -31,7 +31,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI_SCCNonlinearSolve.yml
+++ b/.github/workflows/CI_SCCNonlinearSolve.yml
@@ -31,7 +31,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI_SciMLJacobianOperators.yml
+++ b/.github/workflows/CI_SciMLJacobianOperators.yml
@@ -29,7 +29,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI_SimpleNonlinearSolve.yml
+++ b/.github/workflows/CI_SimpleNonlinearSolve.yml
@@ -32,7 +32,6 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
         group:
           - core
           - adjoint


### PR DESCRIPTION
RetestItems.jl is broken for Windows, the fix is stalled https://github.com/JuliaTesting/ReTestItems.jl/pull/203, so we're just removing it. This package isn't doing low level things where it should matter anyways.