### PR TITLE
Add documentation for Muller's method

### DIFF
--- a/docs/src/native/bracketingnonlinearsolve.md
+++ b/docs/src/native/bracketingnonlinearsolve.md
@@ -18,4 +18,5 @@ Bisection
 Falsi
 Ridder
 Brent
+Muller
 ```

--- a/docs/src/solvers/bracketing_solvers.md
+++ b/docs/src/solvers/bracketing_solvers.md
@@ -26,13 +26,14 @@ This gives a robust and fast method, which therefore enjoys considerable popular
 
 ## Full List of Methods
 
-### SimpleNonlinearSolve.jl
+### BracketingNonlinearSolve.jl
 
 These methods are automatically included as part of NonlinearSolve.jl. Though, one can use
-SimpleNonlinearSolve.jl directly to decrease the dependencies and improve load time.
+BracketingNonlinearSolve.jl directly to decrease the dependencies and improve load time.
 
   - [`ITP`](@ref): A non-allocating ITP (Interpolate, Truncate & Project) method
   - [`Falsi`](@ref): A non-allocating regula falsi method
   - [`Bisection`](@ref): A common bisection method
   - [`Ridder`](@ref): A non-allocating Ridder method
   - [`Brent`](@ref): A non-allocating Brent method
+  - [`Muller`](@ref): A non-allocating Muller's method

--- a/lib/BracketingNonlinearSolve/src/muller.jl
+++ b/lib/BracketingNonlinearSolve/src/muller.jl
@@ -1,10 +1,20 @@
 """
     Muller(; middle = nothing)
 
-Muller's method for determining a root of a univariate, scalar function. The
-algorithm, described in Sec. 9.5.2 of
-[Press et al. (2007)](https://numerical.recipes/book.html), requires three
-initial guesses `(left, middle, right)` for the root.
+Muller's method for determining a root of a univariate, scalar function.
+
+The algorithm, described in Sec. 9.5.2 of
+[Press et al. (2007)](https://numerical.recipes/book.html), is a generalization
+of the secant method, using quadratic interpolation of three points to find the
+next estimate for the root. Due to the quadratic interpolation, the method is
+well suited for obtaining complex roots.
+
+This method requires three initial guesses `(left, middle, right)` for the
+solution. The guesses `(left, right) = tspan` are provided by the
+`IntervalNonlinearProblem`, while the `middle` guess may be specified as an
+optional keyword argument. In notable contrast to the other
+`BracketingNonlinearSolve.jl` solvers, the `Muller` algorithm does not need
+`(left, right)` to bracket the root.
 
 ### Keyword Arguments
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

I implemented Muller's method into `BracketingNonlinearSolve.jl`, which was merged in #568. This pull request adds some more information to the docstring of `Muller` and updates the relevant documentation ([this](https://docs.sciml.ai/NonlinearSolve/stable/solvers/bracketing_solvers/) and [this page)](https://docs.sciml.ai/NonlinearSolve/stable/native/bracketingnonlinearsolve/).

In the process, I noticed that the former page had some out-of-date information; mentioning `SimpleNonlinearSolve.jl` when the listed methods are all now in `BracketingNonlinearSolve.jl`. I corrected this.
