### PR TITLE
remove true_jacobian Broyden from default alg

### DIFF
--- a/src/poly_algs.jl
+++ b/src/poly_algs.jl
@@ -72,7 +72,6 @@ function FastShortcutNonlinearPolyalg(
             if T <: Complex
                 algs = (
                     Broyden(; autodiff),
-                    Broyden(; init_jacobian = Val(:true_jacobian), autodiff),
                     Klement(; linsolve, autodiff),
                     NewtonRaphson(; common_kwargs...)
                 )
@@ -81,7 +80,6 @@ function FastShortcutNonlinearPolyalg(
                 start_index = u0_len !== nothing ? (u0_len ≤ 25 ? 4 : 1) : 1
                 algs = (
                     Broyden(; autodiff),
-                    Broyden(; init_jacobian = Val(:true_jacobian), autodiff),
                     Klement(; linsolve, autodiff),
                     NewtonRaphson(; common_kwargs...),
                     NewtonRaphson(; common_kwargs..., linesearch = BackTracking()),


### PR DESCRIPTION
This method is unlikely to be much better than normal Broyden or Klement and requires a pseudoinverse which is really bad for sparse jacobians. As such, this PR removes it when we aren't preferring the Simple algs
