### PR TITLE
Fix NonlinearSolveFirstOrder type definition order

### DIFF
--- a/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl
+++ b/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl
@@ -31,16 +31,13 @@ using SciMLJacobianOperators: VecJacOperator, JacVecOperator, StatefulJacobianOp
 using FiniteDiff: FiniteDiff    # Default Finite Difference Method
 using ForwardDiff: ForwardDiff, Dual  # Default Forward Mode AD
 
+include("solve.jl")
 include("raphson.jl")
 include("gauss_newton.jl")
 include("levenberg_marquardt.jl")
 include("trust_region.jl")
 include("pseudo_transient.jl")
-
 include("poly_algs.jl")
-
-include("solve.jl")
-
 include("forward_diff.jl")
 
 @setup_workload begin


### PR DESCRIPTION
Fixes https://github.com/SciML/NonlinearSolve.jl/issues/576 due to ensuring the type being constructed by the specific first order cases is defined before the usage.

