### PR TITLE
Add Alefeld method to documentation page

### DIFF
--- a/docs/src/native/bracketingnonlinearsolve.md
+++ b/docs/src/native/bracketingnonlinearsolve.md
@@ -12,11 +12,11 @@ These methods are suited for interval (scalar) root-finding problems,
 i.e. [`IntervalNonlinearProblem`](@ref).
 
 ```@docs
-ITP
 Alefeld
 Bisection
-Falsi
-Ridder
 Brent
+Falsi
+ITP
 Muller
+Ridder
 ```

--- a/docs/src/solvers/bracketing_solvers.md
+++ b/docs/src/solvers/bracketing_solvers.md
@@ -31,9 +31,10 @@ This gives a robust and fast method, which therefore enjoys considerable popular
 These methods are automatically included as part of NonlinearSolve.jl. Though, one can use
 BracketingNonlinearSolve.jl directly to decrease the dependencies and improve load time.
 
-  - [`ITP`](@ref): A non-allocating ITP (Interpolate, Truncate & Project) method
-  - [`Falsi`](@ref): A non-allocating regula falsi method
+  - [`Alefeld`](@ref): A non-allocating Alefeld method
   - [`Bisection`](@ref): A common bisection method
-  - [`Ridder`](@ref): A non-allocating Ridder method
   - [`Brent`](@ref): A non-allocating Brent method
+  - [`Falsi`](@ref): A non-allocating regula falsi method
+  - [`ITP`](@ref): A non-allocating ITP (Interpolate, Truncate & Project) method
   - [`Muller`](@ref): A non-allocating Muller's method
+  - [`Ridder`](@ref): A non-allocating Ridder method


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

I noticed that the `Alefeld` method is currently missing on this [page](https://docs.sciml.ai/NonlinearSolve/stable/solvers/bracketing_solvers/) of the documentation. I also took the opportunity to alphabetise the lists.
