### PR TITLE
Fix test error for non-CUDA machines

### DIFF
--- a/test/cuda_tests.jl
+++ b/test/cuda_tests.jl
@@ -46,28 +46,31 @@ end
 
 @testitem "Termination Conditions: Allocations" tags=[:cuda] begin
     using CUDA, NonlinearSolveBase, Test, LinearAlgebra
-    CUDA.allowscalar(false)
-    du = cu(rand(4))
-    u = cu(rand(4))
-    uprev = cu(rand(4))
-    TERMINATION_CONDITIONS = [
-        RelTerminationMode, AbsTerminationMode
-    ]
-    NORM_TERMINATION_CONDITIONS = [
-        AbsNormTerminationMode, RelNormTerminationMode, RelNormSafeTerminationMode,
-        AbsNormSafeTerminationMode, RelNormSafeBestTerminationMode, AbsNormSafeBestTerminationMode
-    ]
 
-    @testset begin
-        @testset "Mode: $(tcond)" for tcond in TERMINATION_CONDITIONS
-            @test_nowarn NonlinearSolveBase.check_convergence(
-                tcond(), du, u, uprev, 1e-3, 1e-3)
-        end
+    if CUDA.functional()
+        CUDA.allowscalar(false)
+        du = cu(rand(4))
+        u = cu(rand(4))
+        uprev = cu(rand(4))
+        TERMINATION_CONDITIONS = [
+            RelTerminationMode, AbsTerminationMode
+        ]
+        NORM_TERMINATION_CONDITIONS = [
+            AbsNormTerminationMode, RelNormTerminationMode, RelNormSafeTerminationMode,
+            AbsNormSafeTerminationMode, RelNormSafeBestTerminationMode, AbsNormSafeBestTerminationMode
+        ]
 
-        @testset "Mode: $(tcond)" for tcond in NORM_TERMINATION_CONDITIONS
-            for nfn in (Base.Fix1(maximum, abs), Base.Fix2(norm, 2), Base.Fix2(norm, Inf))
+        @testset begin
+            @testset "Mode: $(tcond)" for tcond in TERMINATION_CONDITIONS
                 @test_nowarn NonlinearSolveBase.check_convergence(
-                    tcond(nfn), du, u, uprev, 1e-3, 1e-3)
+                    tcond(), du, u, uprev, 1e-3, 1e-3)
+            end
+
+            @testset "Mode: $(tcond)" for tcond in NORM_TERMINATION_CONDITIONS
+                for nfn in (Base.Fix1(maximum, abs), Base.Fix2(norm, 2), Base.Fix2(norm, Inf))
+                    @test_nowarn NonlinearSolveBase.check_convergence(
+                        tcond(nfn), du, u, uprev, 1e-3, 1e-3)
+                end
             end
         end
     end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This is a small fix. I've added a (second) `CUDA.functional()` if statement to the CUDA tests, so the test passes on machines that don't have an NVIDIA GPU installed or CUDA drivers.
