### PR TITLE
Set strict=false for DI in HomotopyContinuation

### DIFF
--- a/lib/NonlinearSolveHomotopyContinuation/src/jacobian_handling.jl
+++ b/lib/NonlinearSolveHomotopyContinuation/src/jacobian_handling.jl
@@ -118,9 +118,9 @@ function construct_jacobian(f, autodiff, variant, u0, p)
     end
     f = ComplexJacobianWrapper{variant}(f)
     if variant == OutOfPlace
-        prep = DI.prepare_jacobian(f, autodiff, tmp, DI.Constant(p))
+        prep = DI.prepare_jacobian(f, autodiff, tmp, DI.Constant(p), strict = Val(false))
     else
-        prep = DI.prepare_jacobian(f, tmp, autodiff, copy(tmp), DI.Constant(p))
+        prep = DI.prepare_jacobian(f, tmp, autodiff, copy(tmp), DI.Constant(p), strict = Val(false))
     end
 
     if variant == Scalar
@@ -182,13 +182,13 @@ Construct an `EnzymeJacobian` function.
 """
 function construct_jacobian(f, autodiff::AutoEnzyme, variant, u0, p)
     if variant == Scalar
-        prep = DI.prepare_derivative(f, autodiff, u0, DI.Constant(p))
+        prep = DI.prepare_derivative(f, autodiff, u0, DI.Constant(p), strict = Val(false))
     else
         tmp = Vector{ComplexF64}(undef, length(u0))
         if variant == Inplace
-            prep = DI.prepare_jacobian(f, tmp, autodiff, copy(tmp), DI.Constant(p))
+            prep = DI.prepare_jacobian(f, tmp, autodiff, copy(tmp), DI.Constant(p), strict = Val(false))
         else
-            prep = DI.prepare_jacobian(f, autodiff, tmp, DI.Constant(p))
+            prep = DI.prepare_jacobian(f, autodiff, tmp, DI.Constant(p), strict = Val(false))
         end
     end
     return EnzymeJacobian{variant}(f, prep, autodiff)


### PR DESCRIPTION
```julia
/home/runner/work/NonlinearSolve.jl/NonlinearSolve.jl/lib/NonlinearSolveHomotopyContinuation/test/single_root.jl:151
  Got exception outside of a @test
  PreparationMismatchError (inconsistent types between preparation and execution):
    - f!: ✅
    - y: ✅
    - backend: ✅
    - x: ❌
      - prep: Vector{Float64}
      - exec: Base.ReinterpretArray{Float64, 1, ComplexF64, Vector{ComplexF64}, false}
    - contexts: ✅
  If you are confident that this check is superfluous, you can disable it by running preparation with the keyword argument `strict=Val(false)` inside DifferentiationInterface.
  
```

Reinterpret seems to bug it so it's easiest to just remove it.