### PR TITLE
Remove debugging macros in `reinit!` due to overhead

### DIFF
--- a/lib/NonlinearSolveBase/src/abstract_types.jl
+++ b/lib/NonlinearSolveBase/src/abstract_types.jl
@@ -10,11 +10,11 @@ function reinit! end
 function reinit_self! end
 
 function reinit!(x::Any; kwargs...)
-    @debug "`InternalAPI.reinit!` is not implemented for $(typeof(x))."
+    #@debug "`InternalAPI.reinit!` is not implemented for $(typeof(x))."
     return
 end
 function reinit_self!(x::Any; kwargs...)
-    @debug "`InternalAPI.reinit_self!` is not implemented for $(typeof(x))."
+    #@debug "`InternalAPI.reinit_self!` is not implemented for $(typeof(x))."
     return
 end
 


### PR DESCRIPTION
This ends up having a lot of overhead found in https://github.com/SciML/OrdinaryDiffEq.jl/issues/2757. They are triggered because the `reinit!` code recursively `reinit!`s the internals of the cache, and `LinearCache` doesn't have a `reinit!`, so it's a no-op. This is correct, but it turns out the debugging macro is just really expensive so it makes it slow even though it's not doing anything 😅 . I commented it out so we know where to put SciMLVerbosity.jl instructions for the near future @jClugstor