### PR TITLE
Hardcode `get_tolerance` for `Float64` for trimming

### DIFF
--- a/lib/NonlinearSolveBase/src/common_defaults.jl
+++ b/lib/NonlinearSolveBase/src/common_defaults.jl
@@ -39,6 +39,11 @@ function get_tolerance(::Nothing, ::Type{T}) where {T}
     η = real(oneunit(T)) * (eps(real(one(T)))^(4 // 5))
     return get_tolerance(η, T)
 end
+function get_tolerance(::Nothing, ::Type{Float64})
+    # trimming hangs up on the literal_pow to rational numbers here
+    η = real(oneunit(Float64)) * 3e-13
+    return get_tolerance(η, Float64)
+end
 
 get_tolerance(_, η, ::Type{T}) where {T} = get_tolerance(η, T)
 function get_tolerance(::Union{StaticArray, Number}, ::Nothing, ::Type{T}) where {T}


### PR DESCRIPTION
This is definitely a bug somewhere, but without this `@report_opt` or `@report_trim` reports errors here.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
