### PR TITLE
Add downgrade CI for all sublibraries

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -19,7 +19,6 @@ jobs:
         downgrade_mode: ['alldeps']
         julia-version: ['1.10']
         project:
-          - '.'
           - 'lib/BracketingNonlinearSolve'
           - 'lib/NonlinearSolveBase'
           - 'lib/NonlinearSolveFirstOrder'

--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -1,0 +1,48 @@
+name: Downgrade Sublibraries
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        downgrade_mode: ['alldeps']
+        julia-version: ['1.10']
+        project:
+          - '.'
+          - 'lib/BracketingNonlinearSolve'
+          - 'lib/NonlinearSolveBase'
+          - 'lib/NonlinearSolveFirstOrder'
+          - 'lib/NonlinearSolveHomotopyContinuation'
+          - 'lib/NonlinearSolveQuasiNewton'
+          - 'lib/NonlinearSolveSciPy'
+          - 'lib/NonlinearSolveSpectralMethods'
+          - 'lib/SCCNonlinearSolve'
+          - 'lib/SciMLJacobianOperators'
+          - 'lib/SimpleNonlinearSolve'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.julia-version }}
+      - uses: julia-actions/julia-downgrade-compat@v2
+        with:
+          project: ${{ matrix.project }}
+          skip: Pkg,TOML
+      - uses: julia-actions/julia-buildpkg@v1
+        with:
+          project: ${{ matrix.project }}
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          project: ${{ matrix.project }}
+          ALLOW_RERESOLVE: false


### PR DESCRIPTION
## Summary
- Adds comprehensive downgrade CI testing for all sublibraries
- Tests the main package (.) and all 10 sublibraries in 
- Each sublibrary is tested individually with downgraded dependencies
- Uses julia-downgrade-compat@v2 with ALLOW_RERESOLVE: false

## Sublibraries Covered
Main package: 

**10 Sublibraries:**
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 

## Benefits
- Ensures compatibility across the entire package ecosystem
- Catches dependency issues early for each sublibrary
- Provides comprehensive downgrade testing coverage
- Maintains lean testing with focused sublibrary-specific tests

## Test plan
- [ ] Verify workflow triggers correctly on PRs and pushes
- [ ] Confirm each sublibrary builds and tests successfully
- [ ] Check that downgrade testing works for all projects
- [ ] Validate matrix strategy runs all combinations

🤖 Generated with [Claude Code](https://claude.ai/code)