### PR TITLE
Update CI to test on Julia 1, lts, and pre versions

### DIFF
--- a/.github/workflows/CI_NonlinearSolve.yml
+++ b/.github/workflows/CI_NonlinearSolve.yml
@@ -37,8 +37,8 @@ jobs:
           - wrappers
           - misc
         version:
-          - "1.10"
           - "1"
+          - "lts"
           - "pre"
         os:
           - ubuntu-latest


### PR DESCRIPTION
## Summary
- Replace specific Julia version '1.10' with standard 'lts' in CI matrix
- Aligns with SciML ecosystem standards for testing on Julia 1, lts, and pre versions

## Test plan
- [x] Validate YAML syntax
- [ ] Verify CI passes on all Julia versions after merge

🤖 Generated with [Claude Code](https://claude.ai/code)