### PR TITLE
Fix CI deprecation warnings in GitHub Actions workflows

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
 

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1.10'
       - name: Install dependencies

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: julia-actions/julia-downgrade-compat@v2
         with:
           skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-buildpkg@v1.7.0
+      - uses: julia-actions/julia-runtest@v1.11.2
         with:
           ALLOW_RERESOLVE: false
         env:

--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -38,10 +38,10 @@ jobs:
         with:
           project: ${{ matrix.project }}
           skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-buildpkg@v1.7.0
         with:
           project: ${{ matrix.project }}
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-runtest@v1.11.2
         with:
           project: ${{ matrix.project }}
           ALLOW_RERESOLVE: false


### PR DESCRIPTION
## Summary
- Fixed deprecated `@latest` tag usage in julia-actions
- Updated julia-actions to their latest stable versions
- Ensures consistent and predictable CI behavior

## Changes Made
- Replace `julia-actions/setup-julia@latest` with `@v2` in CompatHelper.yml and Documentation.yml
- Update `julia-actions/julia-buildpkg` from `@v1` to `@v1.7.0` (latest as of Nov 2024)
- Update `julia-actions/julia-runtest` from `@v1` to `@v1.11.2` (latest as of Jan 2025)

## Test Plan
- [x] All changes are in CI configuration files only
- [x] No functional code changes
- [x] Actions versions verified against official repositories
- [ ] CI workflows should run successfully with updated actions

🤖 Generated with [Claude Code](https://claude.ai/code)