### PR TITLE
Add `trim` tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -143,6 +143,7 @@ PolyesterForwardDiff = "98d1487c-24ca-40b6-b7ab-df2af84e126b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
 SIAMFANLEquations = "084e46ad-d928-497d-ad5e-07fa361a48c4"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SpeedMapping = "f1835b91-879b-4a3f-a438-e4baacf14412"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -170,5 +171,4 @@ path = "lib/NonlinearSolveSpectralMethods"
 path = "lib/SimpleNonlinearSolve"
 
 [targets]
-test = ["Aqua", "BandedMatrices", "BenchmarkTools", "CUDA", "Enzyme", "ExplicitImports", "FastLevenbergMarquardt", "FixedPointAcceleration", "Hwloc", "InteractiveUtils", "LeastSquaresOptim", "LineSearches", "MINPACK", "NLSolvers", "NLsolve", "NaNMath", "NonlinearProblemLibrary", "OrdinaryDiffEqTsit5", "PETSc", "Pkg", "PolyesterForwardDiff", "Random", "ReTestItems", "SIAMFANLEquations", "SparseConnectivityTracer", "SpeedMapping", "StableRNGs", "StaticArrays", "Sundials", "Test", "Zygote"]
-
+test = ["Aqua", "BandedMatrices", "BenchmarkTools", "CUDA", "Enzyme", "ExplicitImports", "FastLevenbergMarquardt", "FixedPointAcceleration", "Hwloc", "InteractiveUtils", "LeastSquaresOptim", "LineSearches", "MINPACK", "NLSolvers", "NLsolve", "NaNMath", "NonlinearProblemLibrary", "OrdinaryDiffEqTsit5", "PETSc", "Pkg", "PolyesterForwardDiff", "Random", "ReTestItems", "SafeTestsets", "SIAMFANLEquations", "SparseConnectivityTracer", "SpeedMapping", "StableRNGs", "StaticArrays", "Sundials", "Test", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -143,7 +143,6 @@ PolyesterForwardDiff = "98d1487c-24ca-40b6-b7ab-df2af84e126b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
 SIAMFANLEquations = "084e46ad-d928-497d-ad5e-07fa361a48c4"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SpeedMapping = "f1835b91-879b-4a3f-a438-e4baacf14412"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -171,4 +170,4 @@ path = "lib/NonlinearSolveSpectralMethods"
 path = "lib/SimpleNonlinearSolve"
 
 [targets]
-test = ["Aqua", "BandedMatrices", "BenchmarkTools", "CUDA", "Enzyme", "ExplicitImports", "FastLevenbergMarquardt", "FixedPointAcceleration", "Hwloc", "InteractiveUtils", "LeastSquaresOptim", "LineSearches", "MINPACK", "NLSolvers", "NLsolve", "NaNMath", "NonlinearProblemLibrary", "OrdinaryDiffEqTsit5", "PETSc", "Pkg", "PolyesterForwardDiff", "Random", "ReTestItems", "SafeTestsets", "SIAMFANLEquations", "SparseConnectivityTracer", "SpeedMapping", "StableRNGs", "StaticArrays", "Sundials", "Test", "Zygote"]
+test = ["Aqua", "BandedMatrices", "BenchmarkTools", "CUDA", "Enzyme", "ExplicitImports", "FastLevenbergMarquardt", "FixedPointAcceleration", "Hwloc", "InteractiveUtils", "LeastSquaresOptim", "LineSearches", "MINPACK", "NLSolvers", "NLsolve", "NaNMath", "NonlinearProblemLibrary", "OrdinaryDiffEqTsit5", "PETSc", "Pkg", "PolyesterForwardDiff", "Random", "ReTestItems", "SIAMFANLEquations", "SparseConnectivityTracer", "SpeedMapping", "StableRNGs", "StaticArrays", "Sundials", "Test", "Zygote"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,14 +41,5 @@ if GROUP != "trim"
     )
 elseif GROUP == "trim" && VERSION >= v"1.12.0-rc1"  # trimming has been introduced in julia 1.12
     activate_trim_env!()
-    @safetestset "Clean implementation (non-trimmable)" begin
-        using SciMLBase: successful_retcode
-        include("trim/clean_optimization.jl")
-        @test successful_retcode(minimize(1.0).retcode)
-    end
-    @safetestset "Trimmable implementation" begin
-        using SciMLBase: successful_retcode
-        include("trim/trimmable_optimization.jl")
-        @test successful_retcode(minimize(1.0).retcode)
-    end
+    include("trim/runtests.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,17 @@
-using ReTestItems, NonlinearSolve, Hwloc, InteractiveUtils, Pkg
+using NonlinearSolve, Hwloc, InteractiveUtils, Pkg
+using SafeTestsets
+using ReTestItems
 
 @info sprint(InteractiveUtils.versioninfo)
 
 const GROUP = lowercase(get(ENV, "GROUP", "All"))
+
+function activate_trim_env!()
+    Pkg.activate(abspath(joinpath(dirname(@__FILE__), "trim")))
+    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+    Pkg.instantiate()
+    return nothing
+end
 
 const EXTRA_PKGS = Pkg.PackageSpec[]
 if GROUP == "all" || GROUP == "downstream"
@@ -12,11 +21,13 @@ end
 length(EXTRA_PKGS) ≥ 1 && Pkg.add(EXTRA_PKGS)
 
 const RETESTITEMS_NWORKERS = parse(
-    Int, get(ENV, "RETESTITEMS_NWORKERS",
+    Int, get(
+        ENV, "RETESTITEMS_NWORKERS",
         string(min(ifelse(Sys.iswindows(), 0, Hwloc.num_physical_cores()), 4))
     )
 )
-const RETESTITEMS_NWORKER_THREADS = parse(Int,
+const RETESTITEMS_NWORKER_THREADS = parse(
+    Int,
     get(
         ENV, "RETESTITEMS_NWORKER_THREADS",
         string(max(Hwloc.num_virtual_cores() ÷ max(RETESTITEMS_NWORKERS, 1), 1))
@@ -25,8 +36,22 @@ const RETESTITEMS_NWORKER_THREADS = parse(Int,
 
 @info "Running tests for group: $(GROUP) with $(RETESTITEMS_NWORKERS) workers"
 
-ReTestItems.runtests(
-    NonlinearSolve; tags = (GROUP == "all" ? nothing : [Symbol(GROUP)]),
-    nworkers = RETESTITEMS_NWORKERS, nworker_threads = RETESTITEMS_NWORKER_THREADS,
-    testitem_timeout = 3600
-)
+if GROUP != "trim"
+    ReTestItems.runtests(
+        NonlinearSolve; tags = (GROUP == "all" ? nothing : [Symbol(GROUP)]),
+        nworkers = RETESTITEMS_NWORKERS, nworker_threads = RETESTITEMS_NWORKER_THREADS,
+        testitem_timeout = 3600
+    )
+elseif GROUP == "trim" && VERSION >= v"1.12.0-rc1"  # trimming has been introduced in julia 1.12
+    activate_trim_env!()
+    @safetestset "Clean implementation (non-trimmable)" begin
+        using SciMLBase: successful_retcode
+        include("trim/clean_optimization.jl")
+        @test successful_retcode(minimize(1.0).retcode)
+    end
+    @safetestset "Trimmable implementation" begin
+        using SciMLBase: successful_retcode
+        include("trim/trimmable_optimization.jl")
+        @test successful_retcode(minimize(1.0).retcode)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,4 @@
-using NonlinearSolve, Hwloc, InteractiveUtils, Pkg
-using SafeTestsets
-using ReTestItems
+using ReTestItems, NonlinearSolve, Hwloc, InteractiveUtils, Pkg
 
 @info sprint(InteractiveUtils.versioninfo)
 
@@ -8,7 +6,6 @@ const GROUP = lowercase(get(ENV, "GROUP", "All"))
 
 function activate_trim_env!()
     Pkg.activate(abspath(joinpath(dirname(@__FILE__), "trim")))
-    Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
     Pkg.instantiate()
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,45 +1,42 @@
-using ReTestItems, NonlinearSolve, Hwloc, InteractiveUtils, Pkg
+using ReTestItems, Hwloc, InteractiveUtils, Pkg
 
 @info sprint(InteractiveUtils.versioninfo)
 
 const GROUP = lowercase(get(ENV, "GROUP", "All"))
 
-function activate_trim_env!()
-    Pkg.activate(abspath(joinpath(dirname(@__FILE__), "trim")))
-    Pkg.instantiate()
-    return nothing
-end
-
-const EXTRA_PKGS = Pkg.PackageSpec[]
-if GROUP == "all" || GROUP == "downstream"
-    push!(EXTRA_PKGS, Pkg.PackageSpec("ModelingToolkit"))
-    push!(EXTRA_PKGS, Pkg.PackageSpec("SymbolicIndexingInterface"))
-end
-length(EXTRA_PKGS) ≥ 1 && Pkg.add(EXTRA_PKGS)
-
-const RETESTITEMS_NWORKERS = parse(
-    Int, get(
-        ENV, "RETESTITEMS_NWORKERS",
-        string(min(ifelse(Sys.iswindows(), 0, Hwloc.num_physical_cores()), 4))
-    )
-)
-const RETESTITEMS_NWORKER_THREADS = parse(
-    Int,
-    get(
-        ENV, "RETESTITEMS_NWORKER_THREADS",
-        string(max(Hwloc.num_virtual_cores() ÷ max(RETESTITEMS_NWORKERS, 1), 1))
-    )
-)
-
-@info "Running tests for group: $(GROUP) with $(RETESTITEMS_NWORKERS) workers"
-
 if GROUP != "trim"
+    using NonlinearSolve  # trimming uses a NonlinearSolve from a custom environment
+
+    const EXTRA_PKGS = Pkg.PackageSpec[]
+    if GROUP == "all" || GROUP == "downstream"
+        push!(EXTRA_PKGS, Pkg.PackageSpec("ModelingToolkit"))
+        push!(EXTRA_PKGS, Pkg.PackageSpec("SymbolicIndexingInterface"))
+    end
+    length(EXTRA_PKGS) ≥ 1 && Pkg.add(EXTRA_PKGS)
+
+    const RETESTITEMS_NWORKERS = parse(
+        Int, get(
+            ENV, "RETESTITEMS_NWORKERS",
+            string(min(ifelse(Sys.iswindows(), 0, Hwloc.num_physical_cores()), 4))
+        )
+    )
+    const RETESTITEMS_NWORKER_THREADS = parse(
+        Int,
+        get(
+            ENV, "RETESTITEMS_NWORKER_THREADS",
+            string(max(Hwloc.num_virtual_cores() ÷ max(RETESTITEMS_NWORKERS, 1), 1))
+        )
+    )
+
+    @info "Running tests for group: $(GROUP) with $(RETESTITEMS_NWORKERS) workers"
+
     ReTestItems.runtests(
         NonlinearSolve; tags = (GROUP == "all" ? nothing : [Symbol(GROUP)]),
         nworkers = RETESTITEMS_NWORKERS, nworker_threads = RETESTITEMS_NWORKER_THREADS,
         testitem_timeout = 3600
     )
 elseif GROUP == "trim" && VERSION >= v"1.12.0-rc1"  # trimming has been introduced in julia 1.12
-    activate_trim_env!()
+    Pkg.activate(joinpath(dirname(@__FILE__), "trim"))
+    Pkg.instantiate()
     include("trim/runtests.jl")
 end

--- a/test/trim/Project.toml
+++ b/test/trim/Project.toml
@@ -30,6 +30,9 @@ SciMLBase = {url = "https://github.com/AayushSabharwal/SciMLBase.jl", rev="as/fi
 [compat]
 ADTypes = "1.15.0"
 DiffEqBase = "6.179.0"
+ForwardDiff = "1.0.1"
 LinearAlgebra = "1.12.0"
 NonlinearSolveFirstOrder = "1.6.0"
+Polyester = "0.7.18"
+PolyesterWeave = "0.2.2"
 StaticArrays = "1.9.0"

--- a/test/trim/Project.toml
+++ b/test/trim/Project.toml
@@ -13,12 +13,19 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [sources]
-ForwardDiff = {rev = "rv/remove-quote-assert-string-interpolation", url = "https://github.com/RomeoV/ForwardDiff.jl"}
-LinearSolve = {rev = "rv/remove-linsolve-forwarddiff-special-path", url = "https://github.com/RomeoV/LinearSolve.jl"}
+# Remove assert that triggers false positive for JET. Tracked at https://github.com/aviatesk/JET.jl/issues/736.
+ForwardDiff = {url = "https://github.com/RomeoV/ForwardDiff.jl", rev="rv/remove-quote-assert-string-interpolation"}
+# Remove special path code path for ForwarDiff of LinearSolve, which uses untrimmable `deepcopy`.
+# Use of `deepcopy` is tracked at https://github.com/SciML/LinearSolve.jl/issues/648.
+LinearSolve = {url = "https://github.com/RomeoV/LinearSolve.jl", rev="rv/remove-linsolve-forwarddiff-special-path"}
 NonlinearSolveFirstOrder = {path = "../../lib/NonlinearSolveFirstOrder"}
-Polyester = {rev = "master", url = "https://github.com/RomeoV/Polyester.jl"}
-PolyesterWeave = {rev = "main", url = "https://github.com/RomeoV/PolyesterWeave.jl"}
-SciMLBase = {rev = "as/fix-jet-opt", url = "https://github.com/AayushSabharwal/SciMLBase.jl"}
+# Remove use of CPUSummary which segfaults trimmed binary. Tracked at https://github.com/JuliaSIMD/Polyester.jl/pull/163.
+Polyester = {url = "https://github.com/RomeoV/Polyester.jl", rev="master"}
+# Remove use of CPUSummary which segfaults trimmed binary. Tracked at https://github.com/JuliaSIMD/PolyesterWeave.jl/pull/28
+PolyesterWeave = {url = "https://github.com/RomeoV/PolyesterWeave.jl", rev="main"}
+# Fix a type instability. Tracked at https://github.com/SciML/SciMLBase.jl/pull/1074.
+SciMLBase = {url = "https://github.com/AayushSabharwal/SciMLBase.jl", rev="as/fix-jet-opt"}
+
 
 [compat]
 ADTypes = "1.15.0"

--- a/test/trim/Project.toml
+++ b/test/trim/Project.toml
@@ -1,3 +1,6 @@
+name = "TrimTest"
+uuid = "7e54ada7-ece5-4046-aa01-512d530850d8"
+
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/test/trim/Project.toml
+++ b/test/trim/Project.toml
@@ -1,0 +1,27 @@
+[deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+NonlinearSolveFirstOrder = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
+PolyesterWeave = "1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[sources]
+ForwardDiff = {rev = "rv/remove-quote-assert-string-interpolation", url = "https://github.com/RomeoV/ForwardDiff.jl"}
+LinearSolve = {rev = "rv/remove-linsolve-forwarddiff-special-path", url = "https://github.com/RomeoV/LinearSolve.jl"}
+NonlinearSolveFirstOrder = {path = "../../lib/NonlinearSolveFirstOrder"}
+Polyester = {rev = "master", url = "https://github.com/RomeoV/Polyester.jl"}
+PolyesterWeave = {rev = "main", url = "https://github.com/RomeoV/PolyesterWeave.jl"}
+SciMLBase = {rev = "as/fix-jet-opt", url = "https://github.com/AayushSabharwal/SciMLBase.jl"}
+
+[compat]
+ADTypes = "1.15.0"
+DiffEqBase = "6.179.0"
+LinearAlgebra = "1.12.0"
+NonlinearSolveFirstOrder = "1.6.0"
+StaticArrays = "1.9.0"

--- a/test/trim/Project.toml
+++ b/test/trim/Project.toml
@@ -2,6 +2,7 @@
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 NonlinearSolveFirstOrder = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"

--- a/test/trim/clean_optimization.jl
+++ b/test/trim/clean_optimization.jl
@@ -34,4 +34,4 @@ function minimize(x)
 end
 
 @test successful_retcode(minimize(1.0).retcode)
-@test_opt minimize(1.0) broken=true
+@test_opt minimize(1.0)

--- a/test/trim/clean_optimization.jl
+++ b/test/trim/clean_optimization.jl
@@ -1,0 +1,32 @@
+using NonlinearSolveFirstOrder
+using ADTypes: AutoForwardDiff
+using ForwardDiff
+using LinearAlgebra
+using StaticArrays
+using LinearSolve
+const LS = LinearSolve
+
+function f(u, p)
+    L, U = cholesky(p.Σ)
+    rhs = (u .* u .- p.λ)
+    # there are some issues currently with LinearSolve and triangular matrices,
+    # so we just make `L` dense here.
+    linprob = LinearProblem(Matrix(L), rhs)
+    alg = LS.GenericLUFactorization()
+    sol = LinearSolve.solve(linprob, alg)
+    return sol.u
+end
+
+struct MyParams{T, M}
+    λ::T
+    Σ::M
+end
+
+function minimize(x)
+    autodiff = AutoForwardDiff(; chunksize=1)
+    alg = TrustRegion(; autodiff, linsolve=LS.CholeskyFactorization())
+    ps = MyParams(rand(), hermitianpart(rand(2,2)+2I))
+    prob = NonlinearLeastSquaresProblem{false}(f, rand(2), ps)
+    sol = solve(prob, alg)
+    return sol
+end

--- a/test/trim/clean_optimization.jl
+++ b/test/trim/clean_optimization.jl
@@ -5,8 +5,6 @@ using LinearAlgebra
 using StaticArrays
 using LinearSolve
 const LS = LinearSolve
-using SciMLBase: successful_retcode
-using JET
 
 function f(u, p)
     L, U = cholesky(p.Σ)
@@ -32,6 +30,3 @@ function minimize(x)
     sol = solve(prob, alg)
     return sol
 end
-
-@test successful_retcode(minimize(1.0).retcode)
-@test_opt minimize(1.0)

--- a/test/trim/clean_optimization.jl
+++ b/test/trim/clean_optimization.jl
@@ -5,6 +5,8 @@ using LinearAlgebra
 using StaticArrays
 using LinearSolve
 const LS = LinearSolve
+using SciMLBase: successful_retcode
+using JET
 
 function f(u, p)
     L, U = cholesky(p.Σ)
@@ -30,3 +32,6 @@ function minimize(x)
     sol = solve(prob, alg)
     return sol
 end
+
+@test successful_retcode(minimize(1.0).retcode)
+@test_opt minimize(1.0) broken=true

--- a/test/trim/main.jl
+++ b/test/trim/main.jl
@@ -1,11 +1,7 @@
 using TrimTest
 
 function (@main)(argv::Vector{String})::Cint
-    λ = try
-        parse(Float64, argv[2])
-    catch
-        parse(Float64, argv[1])
-    end
+    λ = parse(Float64, argv[2])
     sol = TrimTest.minimize(λ)
     println(Core.stdout, sum(sol.u))
     return 0

--- a/test/trim/main.jl
+++ b/test/trim/main.jl
@@ -1,0 +1,12 @@
+using TrimTest
+
+function (@main)(argv::Vector{String})::Cint
+    λ = try
+        parse(Float64, argv[2])
+    catch
+        parse(Float64, argv[1])
+    end
+    sol = TrimTest.minimize(λ)
+    println(Core.stdout, sum(sol.u))
+    return 0
+end

--- a/test/trim/runtests.jl
+++ b/test/trim/runtests.jl
@@ -1,0 +1,65 @@
+using SafeTestsets
+
+@safetestset "Clean implementation (non-trimmable)" begin
+    using JET
+    using SciMLBase: successful_retcode
+    include("clean_optimization.jl")
+    @test successful_retcode(minimize(1.0).retcode)
+    # can't use `@test_opt` macro here because it would eval before `using JET`
+    # is processed
+    test_opt(minimize, (typeof(1.0),))
+end
+
+@safetestset "Trimmable implementation" begin
+    using JET
+    using SciMLBase: successful_retcode
+    include("trimmable_optimization.jl")
+    @test successful_retcode(minimize(1.0).retcode)
+    # can't use `@test_opt` macro here because it would eval before `using JET`
+    # is processed
+    test_opt(minimize, (typeof(1.0),))
+end
+
+@safetestset "Run trim" begin
+    # https://discourse.julialang.org/t/capture-stdout-and-stderr-in-case-a-command-fails/101772/3?u=romeov
+    "Run a Cmd object, returning the stdout & stderr contents plus the exit code"
+    function _execute(cmd::Cmd)
+        out = Pipe()
+        err = Pipe()
+        process = run(pipeline(ignorestatus(cmd); stdout = out, stderr = err))
+        close(out.in)
+        close(err.in)
+        out = (
+            stdout = String(read(out)), stderr = String(read(err)),
+            exitcode = process.exitcode,
+        )
+        return out
+    end
+
+    JULIAC = normpath(
+        joinpath(
+            Sys.BINDIR, Base.DATAROOTDIR, "julia", "juliac",
+            "juliac.jl"
+        )
+    )
+    @test isfile(JULIAC)
+    binpath = tempname()
+    cmd = `$(Base.julia_cmd()) --project=. --depwarn=error $(JULIAC) --experimental --trim=unsafe-warn --output-exe $(binpath) main.jl`
+
+    # since we are calling Julia from Julia, we first need to clean some
+    # environment variables
+    clean_env = copy(ENV)
+    delete!(clean_env, "JULIA_PROJECT")
+    delete!(clean_env, "JULIA_LOAD_PATH")
+    # We could just check for success, but then failures are hard to debug.
+    # Instead we use `_execute` to also capture `stdout` and `stderr`.
+    # @test success(setenv(cmd, clean_env))
+    trimcall = _execute(setenv(cmd, clean_env; dir = @__DIR__))
+    if trimcall.exitcode != 0
+        @show trimcall.stdout
+        @show trimcall.stderr
+    end
+    @test trimcall.exitcode == 0
+    @test isfile(binpath)
+    @test success(`$(binpath) 1.0`)
+end

--- a/test/trim/src/TrimTest.jl
+++ b/test/trim/src/TrimTest.jl
@@ -1,3 +1,26 @@
 module TrimTest
+#=
+Currently, trimming only works if the target code is in a package. I.e., trying to trim
+```julia
+include("trimmable_optimization.jl")
+function (@main)(argv::Vector{String})::Cint
+    minimize(1.0)
+    return 0
+end
+```
+or even
+```julia
+mod MyMod
+    include("trimmable_optimization.jl")
+end
+function (@main)(argv::Vector{String})::Cint
+    MyMod.minimize(1.0)
+    return 0
+end
+```
+segfaults `juliac`. Looking at the segfault stacktrace it seems the culprit is
+`const cache = init(...)`. Either way, we circumvent the segfault by putting
+this below code into a package definition.
+=#
 include("../trimmable_optimization.jl")
 end

--- a/test/trim/src/TrimTest.jl
+++ b/test/trim/src/TrimTest.jl
@@ -1,0 +1,3 @@
+module TrimTest
+include("../trimmable_optimization.jl")
+end

--- a/test/trim/trimmable_optimization.jl
+++ b/test/trim/trimmable_optimization.jl
@@ -5,6 +5,8 @@ using LinearAlgebra
 using StaticArrays
 using LinearSolve
 const LS = LinearSolve
+using SciMLBase: successful_retcode
+using JET
 
 function f(u, p)
     L, U = cholesky(p.Σ)
@@ -33,3 +35,6 @@ function minimize(x)
     solve!(cache)
     return cache
 end
+
+@test successful_retcode(minimize(1.0).retcode)
+@test_opt minimize(1.0) broken=true

--- a/test/trim/trimmable_optimization.jl
+++ b/test/trim/trimmable_optimization.jl
@@ -1,13 +1,12 @@
 using NonlinearSolveFirstOrder
-using ADTypes: AutoForwardDiff
 using DiffEqBase
+using ADTypes: AutoForwardDiff
 using ForwardDiff
 using LinearAlgebra
 using StaticArrays
 using LinearSolve
+import SciMLBase
 const LS = LinearSolve
-using SciMLBase: successful_retcode
-using JET
 
 function f(u, p)
     L, U = cholesky(p.Σ)
@@ -24,7 +23,6 @@ struct MyParams{T, M}
     λ::T
     Σ::M
 end
-DiffEqBase.anyeltypedual(::MyParams) = Any
 
 const autodiff = AutoForwardDiff(; chunksize = 1)
 const alg = TrustRegion(; autodiff, linsolve = LS.CholeskyFactorization())
@@ -37,6 +35,3 @@ function minimize(x)
     solve!(cache)
     return cache
 end
-
-@test successful_retcode(minimize(1.0).retcode)
-@test_opt minimize(1.0)

--- a/test/trim/trimmable_optimization.jl
+++ b/test/trim/trimmable_optimization.jl
@@ -1,5 +1,6 @@
 using NonlinearSolveFirstOrder
 using ADTypes: AutoForwardDiff
+using DiffEqBase
 using ForwardDiff
 using LinearAlgebra
 using StaticArrays
@@ -23,6 +24,7 @@ struct MyParams{T, M}
     λ::T
     Σ::M
 end
+DiffEqBase.anyeltypedual(::MyParams) = Any
 
 const autodiff = AutoForwardDiff(; chunksize = 1)
 const alg = TrustRegion(; autodiff, linsolve = LS.CholeskyFactorization())

--- a/test/trim/trimmable_optimization.jl
+++ b/test/trim/trimmable_optimization.jl
@@ -37,4 +37,4 @@ function minimize(x)
 end
 
 @test successful_retcode(minimize(1.0).retcode)
-@test_opt minimize(1.0) broken=true
+@test_opt minimize(1.0)

--- a/test/trim/trimmable_optimization.jl
+++ b/test/trim/trimmable_optimization.jl
@@ -1,0 +1,35 @@
+using NonlinearSolveFirstOrder
+using ADTypes: AutoForwardDiff
+using ForwardDiff
+using LinearAlgebra
+using StaticArrays
+using LinearSolve
+const LS = LinearSolve
+
+function f(u, p)
+    L, U = cholesky(p.Σ)
+    rhs = (u .* u .- p.λ)
+    # there are some issues currently with LinearSolve and triangular matrices,
+    # so we just make `L` dense here.
+    linprob = LinearProblem(Matrix(L), rhs)
+    alg = LS.GenericLUFactorization()
+    sol = LinearSolve.solve(linprob, alg)
+    return sol.u
+end
+
+struct MyParams{T, M}
+    λ::T
+    Σ::M
+end
+
+const autodiff = AutoForwardDiff(; chunksize = 1)
+const alg = TrustRegion(; autodiff, linsolve = LS.CholeskyFactorization())
+const prob = NonlinearLeastSquaresProblem{false}(f, rand(2), MyParams(rand(), hermitianpart(rand(2, 2) + 2I)))
+const cache = init(prob, alg)
+
+function minimize(x)
+    ps = MyParams(x, hermitianpart(rand(2, 2) + 2I))
+    reinit!(cache, rand(2); p = ps)
+    solve!(cache)
+    return cache
+end


### PR DESCRIPTION
Add a `trim` directory with basic tests for trimming.
I tried to imitate the code/package loading structure of SciMLBase.

There are a few quirks here, most of which hopefully will resolve themselves soon:
1. We need to dev seven packages to appease JET and juliac. Each package's reason is documented in the new `test/trim/Project.toml` file. Also, when the upstream branches are merged and deleted, this will fail. But that's good so we can bump the compat accordingly.
2. The testing code includes `clean_optimization.jl` and `trimmable_optimization.jl`. One day hopefully both will be trimmable. At the moment both versions pass JET (impressive!) but only the heavily preallocating version passes `juliac`.
3. In order to run `juliac` we have to put the code to trim into a package. It seems a module will not do. This is documented in the `src/TrimTest.jl` file.
4. This is all Julia 1.12.0-rc1 only. But the `runtests.jl` should take care of that.