### PR TITLE
Rm `kwargs`

### DIFF
--- a/lib/NonlinearSolveFirstOrder/src/solve.jl
+++ b/lib/NonlinearSolveFirstOrder/src/solve.jl
@@ -266,7 +266,7 @@ function InternalAPI.step!(
             end
             # In the 2nd call the `new_jacobian` is guaranteed to be `true`.
             cache.make_new_jacobian = true
-            InternalAPI.step!(cache; recompute_jacobian = true, kwargs...)
+            InternalAPI.step!(cache; recompute_jacobian = true)
             return
         end
     end


### PR DESCRIPTION
This is nevery defined anywhere and thus invalid code and trips up JET.

Fixes #679 

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
