### PR TITLE
Specialize functions on f parameter for trim compatibility

### DIFF
--- a/lib/NonlinearSolveHomotopyContinuation/src/jacobian_handling.jl
+++ b/lib/NonlinearSolveHomotopyContinuation/src/jacobian_handling.jl
@@ -111,7 +111,7 @@ and `p` the parameter object.
 
 The returned function must have the signature required by `HomotopySystemWrapper`.
 """
-function construct_jacobian(f, autodiff, variant, u0, p)
+function construct_jacobian(f::F, autodiff, variant, u0, p) where F
     if variant == Scalar
         tmp = reinterpret(Float64, Vector{ComplexF64}(undef, 1))
     else
@@ -182,7 +182,7 @@ end
 
 Construct an `EnzymeJacobian` function.
 """
-function construct_jacobian(f, autodiff::AutoEnzyme, variant, u0, p)
+function construct_jacobian(f::F, autodiff::AutoEnzyme, variant, u0, p) where F
     if variant == Scalar
         prep = DI.prepare_derivative(f, autodiff, u0, DI.Constant(p), strict = Val(false))
     else

--- a/lib/NonlinearSolveSciPy/src/NonlinearSolveSciPy.jl
+++ b/lib/NonlinearSolveSciPy/src/NonlinearSolveSciPy.jl
@@ -94,7 +94,7 @@ end
 """
 Internal: wrap a Julia residual function into a Python callable
 """
-function _make_py_residual(f, p)
+function _make_py_residual(f::F, p) where F
     return pyfunc(x_py -> begin
         x = Vector{Float64}(x_py)
         r = f(x, p)
@@ -105,7 +105,7 @@ end
 """
 Internal: wrap a Julia scalar function into a Python callable
 """
-function _make_py_scalar(f, p)
+function _make_py_scalar(f::F, p) where F
     return pyfunc(x_py -> begin
         x = Float64(x_py)
         return f(x, p)

--- a/lib/SimpleNonlinearSolve/src/trust_region.jl
+++ b/lib/SimpleNonlinearSolve/src/trust_region.jl
@@ -193,7 +193,7 @@ function SciMLBase.__solve(
     return SciMLBase.build_solution(prob, alg, x, fx; retcode = ReturnCode.MaxIters)
 end
 
-function dogleg_method!!(cache, J, f, g, Δ)
+function dogleg_method!!(cache, J, f::F, g, Δ) where F
     (; δsd, δN_δsd, δN) = cache
 
     # Compute the Newton step


### PR DESCRIPTION
## Summary

Similar to #684 and SciML/OrdinaryDiffEq.jl#2854, this PR adds type specialization for the `f` parameter in several functions across NonlinearSolve.jl to improve compatibility with `--trim` and reduce dynamic dispatch.

## Functions specialized

- `_make_py_residual` in `lib/NonlinearSolveSciPy/src/NonlinearSolveSciPy.jl:97`
- `_make_py_scalar` in `lib/NonlinearSolveSciPy/src/NonlinearSolveSciPy.jl:108`  
- `dogleg_method!!` in `lib/SimpleNonlinearSolve/src/trust_region.jl:196`
- `construct_jacobian` in `lib/NonlinearSolveHomotopyContinuation/src/jacobian_handling.jl:114` (general version)
- `construct_jacobian` in `lib/NonlinearSolveHomotopyContinuation/src/jacobian_handling.jl:185` (AutoEnzyme version)

## Rationale

These functions either:
- Call `f` directly as a function
- Pass `f` to other functions (like ComplexJacobianWrapper)
- Work with `f` in ways that benefit from type specialization

Adding `where F` type parameters enables better compiler optimizations and reduces dynamic dispatch, following the same pattern established in PR #684.

## Testing

The package compiles and loads successfully with these changes.