### PR TITLE
Copying SciMLJacobianOperators should not copy the size 

### DIFF
--- a/lib/SciMLJacobianOperators/src/SciMLJacobianOperators.jl
+++ b/lib/SciMLJacobianOperators/src/SciMLJacobianOperators.jl
@@ -409,7 +409,7 @@ function Base.copy(J::JacobianOperator)
         J.mode,
         J.jvp_op,
         J.vjp_op,
-        copy(J.size),
+        J.size,
         J.input_cache === nothing ? nothing : copy(J.input_cache),
         J.output_cache === nothing ? nohting : copy(J.output_cache)
     )


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This ends up trying to copy a Tuple of ints, which does not work. 
