### PR TITLE
Use correct constructors for JacobianOperators in `copy`

### DIFF
--- a/lib/SciMLJacobianOperators/src/SciMLJacobianOperators.jl
+++ b/lib/SciMLJacobianOperators/src/SciMLJacobianOperators.jl
@@ -404,8 +404,8 @@ function get_dense_ad(ad::AutoSparse)
     return dense_ad
 end
 
-function Base.copy(J::JacobianOperator)
-    return JacobianOperator(
+function Base.copy(J::JacobianOperator{iip, T}) where {iip, T}
+    return JacobianOperator{iip,T}(
         J.mode,
         J.jvp_op,
         J.vjp_op,
@@ -423,8 +423,8 @@ function Base.copy(J::StatefulJacobianOperator)
     )
 end
 
-function Base.copy(J::StatefulJacobianNormalFormOperator)
-    return StatefulJacobianNormalFormOperator(
+function Base.copy(J::StatefulJacobianNormalFormOperator{T}) where {T}
+    return StatefulJacobianNormalFormOperator{T}(
         J.vjp_operator === nothing ? nothing : copy(J.vjp_operator),
         J.jvp_operator === nothing ? nothing : copy(J.jvp_operator),
         J.cache === nothing ? nothing : copy(J.cache)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This should make sure that `copy` uses the correct constructors for the JacobianOperators. This passes tests locally.