### PR TITLE
Fix: reinit! error when using AbsTerminationMode

### DIFF
--- a/lib/NonlinearSolveBase/src/termination_conditions.jl
+++ b/lib/NonlinearSolveBase/src/termination_conditions.jl
@@ -98,10 +98,12 @@ function SciMLBase.reinit!(
     length(saved_value_prototype) != 0 && (cache.saved_values = saved_value_prototype)
 
     mode = cache.mode
-    if u isa Number || !ArrayInterface.can_setindex(u)
-        cache.u = u
-    else
-        cache.u .= u
+    if cache.u !== nothing
+        if u isa Number || !ArrayInterface.can_setindex(u)
+            cache.u = u
+        else
+            cache.u .= u
+        end
     end
     cache.retcode = ReturnCode.Default
 

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -33,4 +33,20 @@ using InteractiveUtils, Test
 
         @test NonlinearSolveBase.Utils.faster_vcat(b, d) == vcat(sparse(b), d)
     end
+
+    @testset "Termination Conditions" begin
+        using NonlinearSolveBase, SciMLBase
+        @testset "reinit! with AbsTerminationMode" begin
+            mode = NonlinearSolveBase.AbsTerminationMode()
+            u_unaliased = nothing
+            T = Float64
+            cache = NonlinearSolveBase.NonlinearTerminationModeCache(
+                u_unaliased, SciMLBase.ReturnCode.Default, 1e-8, 1e-8, Inf, mode,
+                nothing, nothing, 0, nothing, nothing, nothing, nothing, nothing, false
+            )
+            du = [1.0, 1.0]
+            u = [1.1, 1.1]
+            @test_nowarn SciMLBase.reinit!(cache, du, u)
+        end
+    end
 end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added  
- [x] Any code changes were done in a way that does not break public API  
- [ ] All documentation related to code changes were updated  
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC)  
- [ ] Any new documentation only uses public API  

## Additional context

Fixed an issue where calling `reinit!` with `AbsTerminationMode` would throw:

```julia
MethodError: no method matching ndims(::Type{Nothing})
undefined
```

### Root Cause
The `NonlinearTerminationModeCache` for `AbsTerminationMode` initializes `u` as `nothing`, but `reinit!` attempted to broadcast into it. The fix ensures we only update `cache.u` when it's not `nothing`.

### Solution
Added guard clause to skip updating `cache.u` when it's `nothing`:

```julia
if cache.u !== nothing
    #...existing logic...
end
```

### Verification
Added regression test that creates a termination cache with `u_unaliased = nothing` and verifies `reinit!` no longer throws:

```julia
@testset "reinit! with AbsTerminationMode" begin
    mode = AbsTerminationMode()
    cache = NonlinearTerminationModeCache(
        nothing, ReturnCode.Default, 1e-8, 1e-8, Inf, mode,
        nothing, nothing, 0, nothing, nothing, nothing, nothing, nothing, false
    )
    @test_nowarn SciMLBase.reinit!(cache, [1.0, 1.0], [1.1, 1.1])
end
```

Resolves #687.  
