### PR TITLE
Bump package versions following NonlinearSolveBase v1.15.0 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 authors = ["SciML"]
-version = "4.10.1"
+version = "4.11.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/BracketingNonlinearSolve/Project.toml
+++ b/lib/BracketingNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "BracketingNonlinearSolve"
 uuid = "70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.3.1"
+version = "1.4.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/NonlinearSolveFirstOrder/Project.toml
+++ b/lib/NonlinearSolveFirstOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveFirstOrder"
 uuid = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.8.1"
+version = "1.9.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/NonlinearSolveHomotopyContinuation/Project.toml
+++ b/lib/NonlinearSolveHomotopyContinuation/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveHomotopyContinuation"
 uuid = "2ac3b008-d579-4536-8c91-a1a5998c2f8b"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com> and contributors"]
-version = "0.1.6"
+version = "0.2.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/NonlinearSolveQuasiNewton/Project.toml
+++ b/lib/NonlinearSolveQuasiNewton/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveQuasiNewton"
 uuid = "9a2c21bd-3a47-402d-9113-8faf9a0ee114"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.8.1"
+version = "1.9.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/NonlinearSolveSciPy/Project.toml
+++ b/lib/NonlinearSolveSciPy/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveSciPy"
 uuid = "4827a3aa-8a82-4c61-8bd0-3c7d3e464ee5"
 authors = ["SciML"]
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"

--- a/lib/NonlinearSolveSpectralMethods/Project.toml
+++ b/lib/NonlinearSolveSpectralMethods/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveSpectralMethods"
 uuid = "26075421-4e9a-44e1-8bd1-420ed7ad02b2"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.3.1"
+version = "1.4.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/SCCNonlinearSolve/Project.toml
+++ b/lib/SCCNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "SCCNonlinearSolve"
 uuid = "9dfe8606-65a1-4bb3-9748-cb89d1561431"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.4.1"
+version = "1.5.0"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/SimpleNonlinearSolve/Project.toml
+++ b/lib/SimpleNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleNonlinearSolve"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 authors = ["SciML"]
-version = "2.7.1"
+version = "2.8.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
## Summary

Following the merge of PR #669 which migrated `solve` dispatches from DiffEqBase to NonlinearSolveBase and updated NonlinearSolveBase to v1.15.0, this PR bumps the minor versions of all dependent packages that had their compat requirements updated to require NonlinearSolveBase v1.15.

### Version Updates

- **NonlinearSolve**: 4.10.1 → 4.11.0  
- **BracketingNonlinearSolve**: 1.3.1 → 1.4.0
- **SimpleNonlinearSolve**: 2.7.1 → 2.8.0
- **NonlinearSolveFirstOrder**: 1.8.1 → 1.9.0
- **NonlinearSolveQuasiNewton**: 1.8.1 → 1.9.0
- **NonlinearSolveSpectralMethods**: 1.3.1 → 1.4.0
- **NonlinearSolveHomotopyContinuation**: 0.1.6 → 0.2.0
- **NonlinearSolveSciPy**: 1.0.1 → 1.1.0
- **SCCNonlinearSolve**: 1.4.1 → 1.5.0

## Rationale

These packages all had their compat requirements updated to `NonlinearSolveBase = "1.15"` in PR #669, which represents a breaking change in their dependency requirements. According to semantic versioning, this requires a minor version bump for all affected packages.

## Test plan

- [x] Verified package loading works correctly
- [x] All version bumps follow semantic versioning (minor bumps for new dependency requirements)
- [x] No breaking API changes in the packages themselves

🤖 Generated with [Claude Code](https://claude.ai/code)