### PR TITLE
Remove irrelevant mention of StaticArrays macros

### DIFF
--- a/docs/src/tutorials/code_optimization.md
+++ b/docs/src/tutorials/code_optimization.md
@@ -106,8 +106,7 @@ up) is determined at runtime. But there are structures in Julia which are stack-
 `struct`s for example are stack-allocated “value-type”s. `Tuple`s are a stack-allocated
 collection. The most useful data structure for NonlinearSolve though is the `StaticArray`
 from the package [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl). These
-arrays have their length determined at compile-time. They are created using macros attached
-to normal array expressions, for example:
+arrays have their length determined at compile-time. For example:
 
 ```@example small_opt
 import StaticArrays


### PR DESCRIPTION
I think the example was updated to not use macros without updating the text

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
