### PR TITLE
Add explicit error for Simple algorithms iterator interface

### DIFF
--- a/lib/SimpleNonlinearSolve/src/SimpleNonlinearSolve.jl
+++ b/lib/SimpleNonlinearSolve/src/SimpleNonlinearSolve.jl
@@ -124,6 +124,29 @@ function simplenonlinearsolve_solve_up(
     return SciMLBase.__solve(prob, alg, args...; kwargs...)
 end
 
+# Iterator Interface Error Handling
+# Simple algorithms do not support the iterator interface (init/step!)
+function SciMLBase.init(
+        prob::Union{NonlinearProblem, NonlinearLeastSquaresProblem},
+        alg::AbstractSimpleNonlinearSolveAlgorithm, args...; kwargs...
+)
+    error("""
+    The Simple algorithms from SimpleNonlinearSolve.jl do not support the iterator interface (init/step!).
+
+    The iterator interface is only available for the full-featured algorithms from NonlinearSolve.jl.
+
+    If you need the iterator interface, please use one of the following algorithms instead:
+    - NewtonRaphson()
+    - TrustRegion()
+    - LevenbergMarquardt()
+    - And other algorithms from NonlinearSolve.jl
+
+    If you want to solve the problem directly, use `solve(prob, alg)` instead of `init(prob, alg)`.
+
+    Algorithm attempted: $(typeof(alg))
+    """)
+end
+
 @setup_workload begin
     for T in (Float64,)
         prob_scalar = NonlinearProblem{false}((u, p) -> u .* u .- p, T(0.1), T(2))

--- a/lib/SimpleNonlinearSolve/test/core/iterator_interface_tests.jl
+++ b/lib/SimpleNonlinearSolve/test/core/iterator_interface_tests.jl
@@ -1,0 +1,33 @@
+@testitem "Iterator Interface Error" tags=[:core] begin
+    using SimpleNonlinearSolve
+
+    # Test that Simple algorithms properly error when used with the iterator interface
+    f(u, p) = u .* u .- 2.0
+    u0 = 1.5
+    prob = NonlinearProblem(f, u0)
+
+    # Test with various Simple algorithms
+    for alg in [SimpleNewtonRaphson(), SimpleBroyden(), SimpleTrustRegion(),
+        SimpleDFSane(), SimpleKlement(), SimpleLimitedMemoryBroyden()]
+        @test_throws ErrorException init(prob, alg)
+
+        # Verify the error message contains helpful information
+        try
+            init(prob, alg)
+            @test false  # Should not reach here
+        catch e
+            msg = sprint(showerror, e)
+            @test occursin("iterator interface", msg)
+            @test occursin("Simple algorithms", msg)
+            @test occursin("NewtonRaphson()", msg)
+            @test occursin("solve(prob, alg)", msg)
+        end
+    end
+
+    # Verify that solve() still works correctly
+    for alg in [SimpleNewtonRaphson(), SimpleBroyden(), SimpleTrustRegion()]
+        sol = solve(prob, alg)
+        @test sol.retcode == ReturnCode.Success
+        @test abs(sol.u^2 - 2.0) < 1e-6
+    end
+end


### PR DESCRIPTION
## Summary

Fixes #712 

This PR adds a clear error message when users attempt to use the iterator interface (`init`/`step!`) with Simple algorithms from SimpleNonlinearSolve.jl.

## Problem

Previously, when users tried to use Simple algorithms with the iterator interface, they received a confusing error about a missing `force_stop` field. This made it unclear what the actual problem was.

## Solution

Added an override of `SciMLBase.init()` for `AbstractSimpleNonlinearSolveAlgorithm` that throws a descriptive error message explaining:
- Simple algorithms don't support the iterator interface
- The iterator interface is only available for full-featured algorithms from NonlinearSolve.jl
- Users should either use algorithms like `NewtonRaphson()`, `TrustRegion()`, etc., or use `solve(prob, alg)` directly

## Changes

- `lib/SimpleNonlinearSolve/src/SimpleNonlinearSolve.jl`: Added `SciMLBase.init()` override with clear error message
- `lib/SimpleNonlinearSolve/test/core/iterator_interface_tests.jl`: Added tests to verify error behavior

## Testing

All Simple algorithms tested:
- ✅ SimpleNewtonRaphson
- ✅ SimpleBroyden
- ✅ SimpleTrustRegion
- ✅ SimpleDFSane
- ✅ SimpleKlement
- ✅ SimpleLimitedMemoryBroyden

Tests verify:
- Error is thrown when calling `init(prob, alg)`
- Error message contains helpful guidance
- `solve(prob, alg)` still works correctly

## Example Error Message

```julia
julia> init(prob, SimpleNewtonRaphson())
ERROR: The Simple algorithms from SimpleNonlinearSolve.jl do not support the iterator interface (init/step!).

The iterator interface is only available for the full-featured algorithms from NonlinearSolve.jl.

If you need the iterator interface, please use one of the following algorithms instead:
- NewtonRaphson()
- TrustRegion()
- LevenbergMarquardt()
- And other algorithms from NonlinearSolve.jl

If you want to solve the problem directly, use `solve(prob, alg)` instead of `init(prob, alg)`.

Algorithm attempted: SimpleNewtonRaphson{Nothing}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)