### PR TITLE
Fix string escaping in lazy string error messages

### DIFF
--- a/lib/NonlinearSolveSciPy/src/NonlinearSolveSciPy.jl
+++ b/lib/NonlinearSolveSciPy/src/NonlinearSolveSciPy.jl
@@ -44,11 +44,11 @@ function SciPyLeastSquares(; method::String = "trf", loss::String = "linear")
     valid_losses = ("linear", "soft_l1", "huber", "cauchy", "arctan")
     method in valid_methods ||
         throw(ArgumentError(
-            lazy"Invalid method: $method. Valid methods are: $(join(valid_methods, ", "))"))
+            lazy"Invalid method: $method. Valid methods are: $(join(valid_methods, \", \"))"))
     loss in valid_losses ||
         throw(ArgumentError(
-            lazy"Invalid loss: $loss. Valid loss functions are: $(join(valid_losses, ",
-            "))"))
+            lazy"Invalid loss: $loss. Valid loss functions are: $(join(valid_losses, \",
+            \"))"))
     return SciPyLeastSquares(method, loss, :SciPyLeastSquares)
 end
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

https://github.com/SciML/NonlinearSolve.jl/commit/bd4fba903f394e73263baafaad73f9bfcc6ede61 broke NonlinearSolveSciPy
