### PR TITLE
Fix unexpected pass for Broyden Wood function test on Julia 1.12+

### DIFF
--- a/test/23_test_problems_tests.jl
+++ b/test/23_test_problems_tests.jl
@@ -148,7 +148,10 @@ end
     if Sys.isapple()
         broken_tests[alg_ops[1]]=[1, 5, 11]
         broken_tests[alg_ops[3]]=[1, 5, 6, 9, 11]
-        if VERSION≥v"1.11-"
+        if VERSION≥v"1.12"
+            # Test #4 (Wood function) passes on v1.12+
+            broken_tests[alg_ops[5]]=[1, 5, 11]
+        elseif VERSION≥v"1.11-"
             broken_tests[alg_ops[5]]=[1, 4, 5, 11]
         else
             broken_tests[alg_ops[5]]=[1, 5, 11]


### PR DESCRIPTION
## Summary
Fixes an "Unexpected Pass" test error on Julia 1.12+ by updating the broken tests list for the Broyden solver.

## Issue
Test #4 (Wood function) for SimpleBroyden() was marked as `@test_broken` on Julia 1.11+ on macOS, but it now passes on Julia 1.12+. This caused the CI to fail with an "Unexpected Pass" error.

## Changes
Updated the `broken_tests` logic in `test/23_test_problems_tests.jl` to:
- Remove test #4 from broken tests on Julia 1.12+ (since it now passes)
- Keep test #4 as broken on Julia 1.11.x (where it still fails)
- Keep the original behavior for Julia < 1.11

## Root Cause
The test is now passing on v1.12+ likely due to improvements in Julia 1.12 that fixed the underlying numerical issue.

## Test plan
- CI should pass on all Julia versions without "Unexpected Pass" errors
- The Wood function test should pass on Julia 1.12+ on macOS
- The Wood function test remains marked as broken on Julia 1.11.x on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)