### PR TITLE
README.md: Improve variable name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ using NonlinearSolve, StaticArrays
 f(u, p) = u .* u .- 2
 u0 = @SVector[1.0, 1.0]
 prob = NonlinearProblem(f, u0)
-solver = solve(prob)
+sol = solve(prob)
 
 ## Bracketing Methods
 


### PR DESCRIPTION
I believe `solve` returns a solution, not a solver, hence the variable should be called `sol` as in the second example.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
