### PR TITLE
Use silent linear verbosity by default to avoid BLAS errors

### DIFF
--- a/lib/NonlinearSolveBase/src/verbosity.jl
+++ b/lib/NonlinearSolveBase/src/verbosity.jl
@@ -132,8 +132,10 @@ function NonlinearVerbosity(;
     end
 
     # Build arguments using NamedTuple for type stability
+    # Use None() for linear_verbosity by default since BLAS errors are not fatal
+    # in the nonlinear solver context (the solver handles singular matrices gracefully)
     default_args = (
-        linear_verbosity = linear_verbosity === nothing ? Minimal() : linear_verbosity,
+        linear_verbosity = linear_verbosity === nothing ? None() : linear_verbosity,
         non_enclosing_interval = WarnLevel(),
         alias_u0_immutable = WarnLevel(),
         linsolve_failed_noncurrent = WarnLevel(),
@@ -167,8 +169,10 @@ end
 function NonlinearVerbosity(verbose::AbstractVerbosityPreset)
     if verbose isa Minimal
         # Minimal: Only fatal errors and critical warnings
+        # Use None() for linear_verbosity since BLAS errors are not fatal
+        # in the nonlinear solver context (the solver handles singular matrices gracefully)
         NonlinearVerbosity(
-            linear_verbosity = Minimal(),
+            linear_verbosity = None(),
             non_enclosing_interval = WarnLevel(),
             alias_u0_immutable = Silent(),
             linsolve_failed_noncurrent = WarnLevel(),


### PR DESCRIPTION
## Summary
- Change the default `linear_verbosity` from `Minimal()` to `None()` in `NonlinearVerbosity`
- This prevents BLAS errors from being emitted when the linear solver encounters singular matrices
- These errors are not fatal in the nonlinear solver context since the solver handles singular matrices gracefully by falling back to QR factorization

## Motivation
Fixes #739 - BLAS errors should be silent by default because they are not fatal in the NonlinearSolve context. The solver gracefully handles singular matrices by switching from LU to QR factorization.

Before this change:
- `verbose=false` → silent switching ✓
- `verbose=true` → BLAS errors were thrown ✗
- `verbose=Detailed()` → BLAS errors were thrown ✗

After this change:
- `verbose=false` → silent switching ✓
- `verbose=true` → silent switching ✓
- `verbose=Detailed()` → warnings about switching (expected, user requested detailed output) ✓

## Test plan
- [x] Tested with the exact examples from the issue
- [x] Ran NonlinearSolveBase tests locally (all pass)
- [x] Verified that existing verbosity tests still pass
- [x] Tested all verbosity presets (None, Minimal, Standard, Detailed, All)

🤖 Generated with [Claude Code](https://claude.com/claude-code)