### PR TITLE
Add ChainRulesCore support for SCCNonlinearProblem

### DIFF
--- a/lib/SCCNonlinearSolve/Project.toml
+++ b/lib/SCCNonlinearSolve/Project.toml
@@ -10,9 +10,16 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 
+[weakdeps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+
+[extensions]
+SCCNonlinearSolveChainRulesCoreExt = "ChainRulesCore"
+
 [compat]
 Aqua = "0.8"
 BenchmarkTools = "1.5.0"
+ChainRulesCore = "1"
 CommonSolve = "0.2.4"
 ExplicitImports = "1.5"
 Hwloc = "3"

--- a/lib/SCCNonlinearSolve/ext/SCCNonlinearSolveChainRulesCoreExt.jl
+++ b/lib/SCCNonlinearSolve/ext/SCCNonlinearSolveChainRulesCoreExt.jl
@@ -1,0 +1,17 @@
+module SCCNonlinearSolveChainRulesCoreExt
+
+using SCCNonlinearSolve
+using SCCNonlinearSolve: SCCAlg, scc_solve_up
+using SciMLBase: SCCNonlinearProblem, AbstractSensitivityAlgorithm, ChainRulesOriginator,
+    _concrete_solve_adjoint
+
+import ChainRulesCore
+
+function ChainRulesCore.rrule(
+        ::typeof(scc_solve_up), prob::SCCNonlinearProblem,
+        sensealg::Union{Nothing, AbstractSensitivityAlgorithm},
+        u0, p, alg::SCCAlg; kwargs...)
+    _concrete_solve_adjoint(prob, alg, sensealg, u0, p, ChainRulesOriginator(); kwargs...)
+end
+
+end


### PR DESCRIPTION
## Summary
- Add ChainRulesCore extension for SCCNonlinearProblem to enable automatic differentiation
- Route `solve` through internal `scc_solve_up` function that can be hooked by ChainRulesCore
- Extension defines `rrule` for `scc_solve_up` that calls `_concrete_solve_adjoint`

## Motivation
MTK v10 uses `SCCNonlinearProblem` for initialization of fully determined systems. Currently, differentiating through ODE solves with MTK v10 initialization returns zero gradients because `SCCNonlinearProblem`'s solve bypasses the ChainRulesCore hooks that exist for regular `NonlinearProblem`.

This PR adds the necessary hooks so that AD systems (Zygote, etc.) can differentiate through `SCCNonlinearProblem` solves by calling into SciMLSensitivity's `_concrete_solve_adjoint` machinery.

## Changes
1. **lib/SCCNonlinearSolve/src/SCCNonlinearSolve.jl**:
   - Add `scc_solve_up` internal function (hookable by ChainRulesCore)
   - Route public `solve` → `scc_solve_up` → `_scc_solve`
   - Export `scc_solve_up`

2. **lib/SCCNonlinearSolve/ext/SCCNonlinearSolveChainRulesCoreExt.jl** (new):
   - Define `rrule` for `scc_solve_up` that calls `_concrete_solve_adjoint`

3. **lib/SCCNonlinearSolve/Project.toml**:
   - Add ChainRulesCore as weak dependency
   - Register extension

## Related
This requires a corresponding PR to SciMLSensitivity.jl that adds `_concrete_solve_adjoint` implementations for `SCCNonlinearProblem`.

## Test plan
- [ ] Existing tests pass
- [ ] MTK v10 initialization differentiation tests pass (in SciMLSensitivity.jl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)