### PR TITLE
CI: Temporarily disable downgrade tests for NonlinearSolve

### DIFF
--- a/.github/workflows/CI_NonlinearSolve.yml
+++ b/.github/workflows/CI_NonlinearSolve.yml
@@ -62,19 +62,25 @@ jobs:
       local_dependencies: "lib/BracketingNonlinearSolve,lib/NonlinearSolveBase,lib/NonlinearSolveFirstOrder,lib/NonlinearSolveQuasiNewton,lib/NonlinearSolveSpectralMethods,lib/SimpleNonlinearSolve"
       test_args: "GROUP=${{ matrix.group }}"
 
-  downgrade:
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - core
-          - downstream
-          - wrappers
-          - misc
-          - nopre
-    uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
-    with:
-      project: "."
-      julia_version: "1.11"
-      downgrade_testing: true
-      test_args: "GROUP=${{ matrix.group }}"
+  # NOTE: Downgrade tests are temporarily disabled because Resolver.jl
+  # (used by julia-downgrade-compat) doesn't support [sources] packages.
+  # NonlinearSolve uses [sources] to define local packages like SimpleNonlinearSolve,
+  # which causes Resolver.jl to fail with:
+  #   KeyError: key UUID("727e6d20-b764-4bd8-a329-72de5adea6c7") not found
+  # TODO: Re-enable once Resolver.jl supports [sources] packages
+  # downgrade:
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       group:
+  #         - core
+  #         - downstream
+  #         - wrappers
+  #         - misc
+  #         - nopre
+  #   uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
+  #   with:
+  #     project: "."
+  #     julia_version: "1.11"
+  #     downgrade_testing: true
+  #     test_args: "GROUP=${{ matrix.group }}"


### PR DESCRIPTION
## Summary

- Temporarily disables downgrade tests for the main NonlinearSolve package

## Problem

Resolver.jl (used by `julia-downgrade-compat`) doesn't support packages defined via `[sources]` in Project.toml. When Resolver.jl builds its package info dictionary for the SAT solver, it only includes packages from the Julia General Registry. Local packages defined via `[sources]` are not added to this dictionary.

NonlinearSolve uses `[sources]` to define local packages:

```toml
[sources]
SimpleNonlinearSolve = {path = "lib/SimpleNonlinearSolve"}
BracketingNonlinearSolve = {path = "lib/BracketingNonlinearSolve"}
# ... etc
```

When Resolver.jl encounters dependencies on these packages, it fails with:
```
ERROR: LoadError: KeyError: key UUID("727e6d20-b764-4bd8-a329-72de5adea6c7") not found
```

The UUID `727e6d20-b764-4bd8-a329-72de5adea6c7` is `SimpleNonlinearSolve`.

## Solution

This PR comments out the downgrade tests for the main NonlinearSolve package until Resolver.jl adds support for `[sources]` packages.

Sub-package CIs (like BracketingNonlinearSolve, SimpleNonlinearSolve) continue to work because they have simpler dependency graphs that Resolver.jl can handle.

## Test plan
- [x] Verify that CI passes without the downgrade job
- [ ] Track Resolver.jl for `[sources]` support and re-enable when fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)