### PR TITLE
Improve GPU array support: auto-fallback from ForwardDiff to FiniteDiff

### DIFF
--- a/lib/NonlinearSolveBase/src/autodiff.jl
+++ b/lib/NonlinearSolveBase/src/autodiff.jl
@@ -107,9 +107,18 @@ function incompatible_backend_and_problem(
 end
 
 additional_incompatible_backend_check(::AbstractNonlinearProblem, ::AbstractADType) = false
+
+# ForwardDiff and PolyesterForwardDiff require scalar indexing for seeding dual numbers,
+# which is not supported by GPU arrays (arrays where fast_scalar_indexing returns false)
+function additional_incompatible_backend_check(
+        prob::AbstractNonlinearProblem, ::ADTypes.AutoForwardDiff)
+    !ArrayInterface.fast_scalar_indexing(prob.u0) && return true
+    return false
+end
 function additional_incompatible_backend_check(
         prob::AbstractNonlinearProblem, ::ADTypes.AutoPolyesterForwardDiff)
     prob.u0 isa SArray && return true # promotes to a mutable array
+    !ArrayInterface.fast_scalar_indexing(prob.u0) && return true
     return false
 end
 


### PR DESCRIPTION
## Summary

This PR improves GPU array support by adding automatic detection of GPU-like arrays (those where `ArrayInterface.fast_scalar_indexing` returns `false`) and falling back from `AutoForwardDiff` to `AutoFiniteDiff` during autodiff selection.

### Problem

ForwardDiff and PolyesterForwardDiff require scalar indexing for seeding dual numbers, which is not supported by GPU arrays. Previously, solving `NonlinearProblem`s with GPU arrays (like JLArrays or CUDA arrays) would fail with a scalar indexing error when using the default autodiff selection:

```
Scalar indexing is disallowed.
Invocation of getindex resulted in scalar indexing of a GPU array.
```

### Solution

Added checks in `additional_incompatible_backend_check` for:
- `AutoForwardDiff`: Returns `true` (incompatible) when `!ArrayInterface.fast_scalar_indexing(prob.u0)`
- `AutoPolyesterForwardDiff`: Added the same check (in addition to the existing SArray check)

This allows the autodiff selection system to correctly identify that ForwardDiff is incompatible with GPU arrays and fall back to FiniteDiff automatically.

### Testing

Tested with JLArrays (GPU-like array that catches interface violations):
- `solve(prob)` with default algorithm now works with JLArrays
- `solve(prob, NewtonRaphson())` now correctly selects `AutoFiniteDiff` for JLArrays
- CPU arrays continue to use `AutoForwardDiff` as before
- BigFloat support remains unchanged

## Test plan

- [x] Tested with JLArrays (GPU simulation)
- [x] Verified CPU array behavior unchanged
- [x] Verified BigFloat behavior unchanged
- [x] Basic functionality tests pass

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)