### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,4 +1,0 @@
-style = "sciml"
-format_markdown = true
-annotate_untyped_fields_with_any = false
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,11 +1,19 @@
-name: Format suggestions
+name: format-check
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
 
 jobs:
-  code-style:
+  runic:
     runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/julia-format@v4
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
         with:
           version: '1'

--- a/common/common_rootfind_testing.jl
+++ b/common/common_rootfind_testing.jl
@@ -9,7 +9,7 @@ const TERMINATION_CONDITIONS = [
     AbsTerminationMode(),
     AbsNormTerminationMode(Base.Fix1(maximum, abs)),
     AbsNormSafeTerminationMode(Base.Fix1(maximum, abs)),
-    AbsNormSafeBestTerminationMode(Base.Fix1(maximum, abs))
+    AbsNormSafeBestTerminationMode(Base.Fix1(maximum, abs)),
 ]
 
 quadratic_f(u, p) = u .* u .- p
@@ -18,27 +18,35 @@ quadratic_f2(u, p) = @. p[1] * u * u - p[2]
 
 function newton_fails(u, p)
     return 0.010000000000000002 .+
-           10.000000000000002 ./ (1 .+
-            (0.21640425613334457 .+
-             216.40425613334457 ./ (1 .+
-              (0.21640425613334457 .+
-               216.40425613334457 ./ (1 .+ 0.0006250000000000001(u .^ 2.0))) .^ 2.0)) .^
-            2.0) .- 0.0011552453009332421u .- p
+        10.000000000000002 ./ (
+        1 .+
+            (
+            0.21640425613334457 .+
+                216.40425613334457 ./ (
+                1 .+
+                    (
+                    0.21640425613334457 .+
+                        216.40425613334457 ./ (1 .+ 0.0006250000000000001(u .^ 2.0))
+                ) .^ 2.0
+            )
+        ) .^
+            2.0
+    ) .- 0.0011552453009332421u .- p
 end
 
 function solve_oop(f, u0, p = 2.0; solver, kwargs...)
     prob = NonlinearProblem{false}(f, u0, p)
-    return solve(prob, solver; abstol = 1e-9, kwargs...)
+    return solve(prob, solver; abstol = 1.0e-9, kwargs...)
 end
 
 function solve_iip(f, u0, p = 2.0; solver, kwargs...)
     prob = NonlinearProblem{true}(f, u0, p)
-    return solve(prob, solver; abstol = 1e-9, kwargs...)
+    return solve(prob, solver; abstol = 1.0e-9, kwargs...)
 end
 
 function nlprob_iterator_interface(f, p_range, isinplace, solver)
     probN = NonlinearProblem{isinplace}(f, isinplace ? [0.5] : 0.5, p_range[begin])
-    cache = init(probN, solver; maxiters = 100, abstol = 1e-10)
+    cache = init(probN, solver; maxiters = 100, abstol = 1.0e-10)
     sols = zeros(length(p_range))
     for (i, p) in enumerate(p_range)
         reinit!(cache, isinplace ? [cache.u[1]] : cache.u; p = p)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,7 +38,7 @@ makedocs(;
         NonlinearSolveHomotopyContinuation,
         Sundials, LineSearch,
         SciMLJacobianOperators, NonlinearSolveSciPy,
-        NonlinearSolve, SteadyStateDiffEq
+        NonlinearSolve, SteadyStateDiffEq,
     ],
     clean = true,
     doctest = false,
@@ -50,7 +50,7 @@ makedocs(;
         "https://www.sciencedirect.com/science/article/abs/pii/S0045782523007156",
         "https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/hybrd.c",
         "https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/hybrj.c",
-        "https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/lmder.c"
+        "https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/lmder.c",
     ],
     checkdocs = :exports,
     warnonly = [:missing_docs],

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -11,7 +11,7 @@ pages = [
         "tutorials/iterator_interface.md",
         "tutorials/optimizing_parameterized_ode.md",
         "tutorials/nonlinear_solve_gpus.md",
-        "tutorials/snes_ex2.md"
+        "tutorials/snes_ex2.md",
     ],
     "Basics" => Any[
         "basics/nonlinear_problem.md",
@@ -23,14 +23,14 @@ pages = [
         "basics/diagnostics_api.md",
         "basics/sparsity_detection.md",
         "basics/faq.md",
-        "basics/verbosity.md"
+        "basics/verbosity.md",
     ],
     "Solver Summaries and Recommendations" => Any[
         "solvers/nonlinear_system_solvers.md",
         "solvers/bracketing_solvers.md",
         "solvers/steady_state_solvers.md",
         "solvers/nonlinear_least_squares_solvers.md",
-        "solvers/fixed_point_solvers.md"
+        "solvers/fixed_point_solvers.md",
     ],
     "Native Functionalities" => Any[
         "native/solvers.md",
@@ -39,7 +39,7 @@ pages = [
         "native/steadystatediffeq.md",
         "native/descent.md",
         "native/globalization.md",
-        "native/diagnostics.md"
+        "native/diagnostics.md",
     ],
     "Wrapped Solver APIs" => Any[
         "api/fastlevenbergmarquardt.md",
@@ -53,7 +53,7 @@ pages = [
         "api/siamfanlequations.md",
         "api/speedmapping.md",
         "api/sundials.md",
-        "api/homotopycontinuation.md"
+        "api/homotopycontinuation.md",
     ],
     "Sub-Packages" => Any[
         "api/SciMLJacobianOperators.md",
@@ -63,8 +63,8 @@ pages = [
         "devdocs/linear_solve.md",
         "devdocs/jacobian.md",
         "devdocs/operators.md",
-        "devdocs/algorithm_helpers.md"
+        "devdocs/algorithm_helpers.md",
     ],
     "Release Notes" => "release_notes.md",
-    "References" => "references.md"
+    "References" => "references.md",
 ]

--- a/ext/NonlinearSolveFastLevenbergMarquardtExt.jl
+++ b/ext/NonlinearSolveFastLevenbergMarquardtExt.jl
@@ -16,13 +16,13 @@ function SciMLBase.__solve(
         prob::AbstractNonlinearProblem, alg::FastLevenbergMarquardtJL, args...;
         alias_u0 = false, abstol = nothing, reltol = nothing, maxiters = 1000,
         termination_condition = nothing, kwargs...
-)
+    )
     NonlinearSolveBase.assert_extension_supported_termination_condition(
         termination_condition, alg
     )
 
     f_wrapped, u,
-    resid = NonlinearSolveBase.construct_extension_function_wrapper(
+        resid = NonlinearSolveBase.construct_extension_function_wrapper(
         prob; alias_u0, can_handle_oop = Val(prob.u0 isa SArray)
     )
     f = if prob.u0 isa SArray
@@ -46,12 +46,12 @@ function SciMLBase.__solve(
     solver_kwargs = (;
         xtol = reltol, ftol = reltol, gtol = abstol, maxit = maxiters,
         alg.factor, alg.factoraccept, alg.factorreject, alg.minscale,
-        alg.maxscale, alg.factorupdate, alg.minfactor, alg.maxfactor
+        alg.maxscale, alg.factorupdate, alg.minfactor, alg.maxfactor,
     )
 
     if prob.u0 isa SArray
         res, fx, info, iter, nfev,
-        njev = FastLM.lmsolve(
+            njev = FastLM.lmsolve(
             f, jac_fn, prob.u0; solver_kwargs...
         )
         LM, solver = nothing, nothing
@@ -71,7 +71,7 @@ function SciMLBase.__solve(
         LM = FastLM.LMWorkspace(u, resid, J)
 
         res, fx, info, iter, nfev, njev,
-        LM, solver = FastLM.lmsolve!(
+            LM, solver = FastLM.lmsolve!(
             f, jac_fn, LM; solver, solver_kwargs...
         )
     end

--- a/ext/NonlinearSolveFixedPointAccelerationExt.jl
+++ b/ext/NonlinearSolveFixedPointAccelerationExt.jl
@@ -10,7 +10,7 @@ function SciMLBase.__solve(
         prob::NonlinearProblem, alg::FixedPointAccelerationJL, args...;
         abstol = nothing, maxiters = 1000, alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = false),
         show_trace::Val = Val(false), termination_condition = nothing, kwargs...
-)
+    )
     if haskey(kwargs, :alias_u0)
         alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = kwargs[:alias_u0])
     end
@@ -20,7 +20,7 @@ function SciMLBase.__solve(
     )
 
     f, u0,
-    resid = NonlinearSolveBase.construct_extension_function_wrapper(
+        resid = NonlinearSolveBase.construct_extension_function_wrapper(
         prob; alias_u0, make_fixed_point = Val(true), force_oop = Val(true)
     )
 
@@ -41,7 +41,7 @@ function SciMLBase.__solve(
         converged = false
     else
         res = prob.u0 isa Number ? first(sol.FixedPoint_) :
-              reshape(sol.FixedPoint_, size(prob.u0))
+            reshape(sol.FixedPoint_, size(prob.u0))
         resid = NonlinearSolveBase.Utils.evaluate_f(prob, res)
         converged = maximum(abs, resid) ≤ tol
     end

--- a/ext/NonlinearSolveLeastSquaresOptimExt.jl
+++ b/ext/NonlinearSolveLeastSquaresOptimExt.jl
@@ -13,7 +13,7 @@ function SciMLBase.__solve(
         alias_u0 = false, abstol = nothing, reltol = nothing, maxiters = 1000,
         trace_level = TraceMinimal(), termination_condition = nothing,
         show_trace::Val = Val(false), store_trace::Val = Val(false), kwargs...
-)
+    )
     NonlinearSolveBase.assert_extension_supported_termination_condition(
         termination_condition, alg
     )
@@ -36,8 +36,10 @@ function SciMLBase.__solve(
     end
 
     linsolve = alg.linsolve === :qr ? LSO.QR() :
-               (alg.linsolve === :cholesky ? LSO.Cholesky() :
-                (alg.linsolve === :lsmr ? LSO.LSMR() : nothing))
+        (
+            alg.linsolve === :cholesky ? LSO.Cholesky() :
+            (alg.linsolve === :lsmr ? LSO.LSMR() : nothing)
+        )
 
     lso_solver = if alg.alg === :lm
         LSO.LevenbergMarquardt(linsolve)
@@ -56,8 +58,10 @@ function SciMLBase.__solve(
     )
 
     retcode = res.x_converged || res.f_converged || res.g_converged ? ReturnCode.Success :
-              (res.iterations ≥ maxiters ? ReturnCode.MaxIters :
-               ReturnCode.ConvergenceFailure)
+        (
+            res.iterations ≥ maxiters ? ReturnCode.MaxIters :
+            ReturnCode.ConvergenceFailure
+        )
     stats = SciMLBase.NLStats(res.f_calls, res.g_calls, -1, -1, res.iterations)
 
     f!(resid, res.minimizer)

--- a/ext/NonlinearSolveMINPACKExt.jl
+++ b/ext/NonlinearSolveMINPACKExt.jl
@@ -12,13 +12,13 @@ function SciMLBase.__solve(
         abstol = nothing, maxiters = 1000, alias_u0::Bool = false,
         show_trace::Val = Val(false), store_trace::Val = Val(false),
         termination_condition = nothing, kwargs...
-)
+    )
     NonlinearSolveBase.assert_extension_supported_termination_condition(
         termination_condition, alg
     )
 
     f_wrapped!, u0,
-    resid = NonlinearSolveBase.construct_extension_function_wrapper(
+        resid = NonlinearSolveBase.construct_extension_function_wrapper(
         prob; alias_u0
     )
     resid_size = size(resid)

--- a/ext/NonlinearSolveNLSolversExt.jl
+++ b/ext/NonlinearSolveNLSolversExt.jl
@@ -15,7 +15,7 @@ function SciMLBase.__solve(
         prob::NonlinearProblem, alg::NLSolversJL, args...;
         abstol = nothing, reltol = nothing, maxiters = 1000, alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = false),
         termination_condition = nothing, kwargs...
-)
+    )
     if haskey(kwargs, :alias_u0)
         alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = kwargs[:alias_u0])
     end
@@ -37,8 +37,10 @@ function SciMLBase.__solve(
             prob.f, autodiff, prob.u0, Constant(prob.p)
         )
 
-        fj_scalar = @closure (Jx,
-            x) -> begin
+        fj_scalar = @closure (
+            Jx,
+            x,
+        ) -> begin
             return DifferentiationInterface.value_and_derivative(
                 prob.f, prep, autodiff, x, Constant(prob.p)
             )

--- a/ext/NonlinearSolveNLsolveExt.jl
+++ b/ext/NonlinearSolveNLsolveExt.jl
@@ -12,7 +12,7 @@ function SciMLBase.__solve(
         abstol = nothing, maxiters = 1000, alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = false),
         termination_condition = nothing, trace_level = TraceMinimal(),
         store_trace::Val = Val(false), show_trace::Val = Val(false), kwargs...
-)
+    )
     if haskey(kwargs, :alias_u0)
         alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = kwargs[:alias_u0])
     end
@@ -56,7 +56,7 @@ function SciMLBase.__solve(
     resid = prob.u0 isa Number ? resid[1] : resid
 
     retcode = original.x_converged || original.f_converged ? ReturnCode.Success :
-              ReturnCode.Failure
+        ReturnCode.Failure
     stats = SciMLBase.NLStats(
         original.f_calls, original.g_calls, original.g_calls,
         original.g_calls, original.iterations

--- a/ext/NonlinearSolvePETScExt.jl
+++ b/ext/NonlinearSolvePETScExt.jl
@@ -16,7 +16,7 @@ function SciMLBase.__solve(
         abstol = nothing, reltol = nothing,
         maxiters = 1000, alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = false), termination_condition = nothing,
         show_trace::Val = Val(false), kwargs...
-)
+    )
     if haskey(kwargs, :alias_u0)
         alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = kwargs[:alias_u0])
     end
@@ -27,7 +27,7 @@ function SciMLBase.__solve(
     )
 
     f_wrapped!, u0,
-    resid = NonlinearSolveBase.construct_extension_function_wrapper(
+        resid = NonlinearSolveBase.construct_extension_function_wrapper(
         prob; alias_u0
     )
     T = eltype(u0)
@@ -53,9 +53,11 @@ function SciMLBase.__solve(
 
     nf = Ref{Int}(0)
 
-    f! = @closure (cfx,
+    f! = @closure (
+        cfx,
         cx,
-        user_ctx) -> begin
+        user_ctx,
+    ) -> begin
         nf[] += 1
         fx = cfx isa Ptr{Nothing} ? PETSc.unsafe_localarray(T, cfx; read = false) : cfx
         x = cx isa Ptr{Nothing} ? PETSc.unsafe_localarray(T, cx; write = false) : cx
@@ -84,7 +86,7 @@ function SciMLBase.__solve(
             J_init = zeros(T, 1, 1)
         else
             jac!,
-            J_init = NonlinearSolveBase.construct_extension_jac(
+                J_init = NonlinearSolveBase.construct_extension_jac(
                 prob, alg, u0, resid; autodiff, initial_jacobian = Val(true)
             )
         end
@@ -93,10 +95,12 @@ function SciMLBase.__solve(
 
         if J_init isa AbstractSparseMatrix
             PJ = PETSc.MatSeqAIJ(J_init)
-            jac_fn! = @closure (cx,
+            jac_fn! = @closure (
+                cx,
                 J,
                 _,
-                user_ctx) -> begin
+                user_ctx,
+            ) -> begin
                 njac[] += 1
                 x = cx isa Ptr{Nothing} ? PETSc.unsafe_localarray(T, cx; write = false) : cx
                 if J isa PETSc.AbstractMat
@@ -113,10 +117,12 @@ function SciMLBase.__solve(
             snes.user_ctx = (; jacobian = J_init)
         else
             PJ = PETSc.MatSeqDense(J_init)
-            jac_fn! = @closure (cx,
+            jac_fn! = @closure (
+                cx,
                 J,
                 _,
-                user_ctx) -> begin
+                user_ctx,
+            ) -> begin
                 njac[] += 1
                 x = cx isa Ptr{Nothing} ? PETSc.unsafe_localarray(T, cx; write = false) : cx
                 jac!(J, x)

--- a/ext/NonlinearSolveSIAMFANLEquationsExt.jl
+++ b/ext/NonlinearSolveSIAMFANLEquationsExt.jl
@@ -2,7 +2,7 @@ module NonlinearSolveSIAMFANLEquationsExt
 
 using FastClosures: @closure
 using SIAMFANLEquations: SIAMFANLEquations, aasol, nsol, nsoli, nsolsc, ptcsol, ptcsoli,
-                         ptcsolsc, secant
+    ptcsolsc, secant
 
 using NonlinearSolveBase: NonlinearSolveBase
 using NonlinearSolve: NonlinearSolve, SIAMFANLEquationsJL
@@ -41,7 +41,7 @@ function SciMLBase.__solve(
         prob::NonlinearProblem, alg::SIAMFANLEquationsJL, args...;
         abstol = nothing, reltol = nothing, alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = false), maxiters = 1000,
         termination_condition = nothing, show_trace = Val(false), kwargs...
-)
+    )
     if haskey(kwargs, :alias_u0)
         alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = kwargs[:alias_u0])
     end
@@ -69,7 +69,7 @@ function SciMLBase.__solve(
             sol = secant(f, prob.u0; maxit = maxiters, atol, rtol, printerr)
         elseif method == :anderson
             f_aa, u,
-            _ = NonlinearSolveBase.construct_extension_function_wrapper(
+                _ = NonlinearSolveBase.construct_extension_function_wrapper(
                 prob; alias_u0, make_fixed_point = Val(true)
             )
             sol = aasol(
@@ -79,7 +79,7 @@ function SciMLBase.__solve(
         end
     else
         f, u,
-        resid = NonlinearSolveBase.construct_extension_function_wrapper(
+            resid = NonlinearSolveBase.construct_extension_function_wrapper(
             prob; alias_u0, make_fixed_point = Val(method == :anderson)
         )
         N = length(u)
@@ -122,7 +122,7 @@ function SciMLBase.__solve(
             else
                 autodiff = alg.autodiff === missing ? nothing : alg.autodiff
                 FPS = prob.f.jac_prototype !== nothing ? zero(prob.f.jac_prototype) :
-                      zeros_like(u, N, N)
+                    zeros_like(u, N, N)
                 jac = NonlinearSolveBase.construct_extension_jac(
                     prob, alg, u, resid; autodiff
                 )

--- a/ext/NonlinearSolveSpeedMappingExt.jl
+++ b/ext/NonlinearSolveSpeedMappingExt.jl
@@ -11,7 +11,7 @@ function SciMLBase.__solve(
         abstol = nothing, maxiters = 1000, alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = false),
         maxtime = nothing, store_trace::Val = Val(false),
         termination_condition = nothing, kwargs...
-)
+    )
     if haskey(kwargs, :alias_u0)
         alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = kwargs[:alias_u0])
     end
@@ -21,7 +21,7 @@ function SciMLBase.__solve(
     )
 
     m!, u,
-    resid = NonlinearSolveBase.construct_extension_function_wrapper(
+        resid = NonlinearSolveBase.construct_extension_function_wrapper(
         prob; alias_u0, make_fixed_point = Val(true)
     )
     tol = NonlinearSolveBase.get_tolerance(abstol, eltype(u))

--- a/ext/NonlinearSolveSundialsExt.jl
+++ b/ext/NonlinearSolveSundialsExt.jl
@@ -4,7 +4,7 @@ using Sundials: KINSOL
 
 using CommonSolve: CommonSolve
 using NonlinearSolveBase: NonlinearSolveBase, nonlinearsolve_forwarddiff_solve,
-                          nonlinearsolve_dual_solution
+    nonlinearsolve_dual_solution
 using NonlinearSolve: NonlinearSolve, DualNonlinearProblem
 using SciMLBase: SciMLBase
 

--- a/lib/BracketingNonlinearSolve/ext/BracketingNonlinearSolveChainRulesCoreExt.jl
+++ b/lib/BracketingNonlinearSolve/ext/BracketingNonlinearSolveChainRulesCoreExt.jl
@@ -10,7 +10,7 @@ function ChainRulesCore.rrule(
         ::typeof(bracketingnonlinear_solve_up),
         prob::IntervalNonlinearProblem,
         sensealg, p, alg, args...; kwargs...
-)
+    )
     out = solve(prob, alg)
     u = out.u
     f = unwrapped_f(prob.f)
@@ -24,9 +24,11 @@ function ChainRulesCore.rrule(
         else
             dgdp = -λ * gradient(p -> f(u, p), p)
         end
-        return (NoTangent(), NoTangent(), NoTangent(),
+        return (
+            NoTangent(), NoTangent(), NoTangent(),
             dgdp, NoTangent(),
-            ntuple(_ -> NoTangent(), length(args))...)
+            ntuple(_ -> NoTangent(), length(args))...,
+        )
     end
     return out, ∇bracketingnonlinear_solve_up
 end

--- a/lib/BracketingNonlinearSolve/ext/BracketingNonlinearSolveForwardDiffExt.jl
+++ b/lib/BracketingNonlinearSolve/ext/BracketingNonlinearSolveForwardDiffExt.jl
@@ -7,17 +7,19 @@ using SciMLBase: SciMLBase, IntervalNonlinearProblem
 
 using BracketingNonlinearSolve: Bisection, Brent, Alefeld, Falsi, ITP, Ridder
 
-const DualIntervalNonlinearProblem{T,
+const DualIntervalNonlinearProblem{
+    T,
     V,
-    P} = IntervalNonlinearProblem{
-    uType, iip, <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}}
+    P,
+} = IntervalNonlinearProblem{
+    uType, iip, <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}},
 } where {uType, iip}
 
 for algT in (Bisection, Brent, Alefeld, Falsi, ITP, Ridder)
     @eval function CommonSolve.solve(
             prob::DualIntervalNonlinearProblem{T, V, P}, alg::$(algT), args...;
             kwargs...
-    ) where {T, V, P}
+        ) where {T, V, P}
         sol, partials = nonlinearsolve_forwarddiff_solve(prob, alg, args...; kwargs...)
         dual_soln = nonlinearsolve_dual_solution(sol.u, partials, prob.p)
         return SciMLBase.build_solution(

--- a/lib/BracketingNonlinearSolve/src/BracketingNonlinearSolve.jl
+++ b/lib/BracketingNonlinearSolve/src/BracketingNonlinearSolve.jl
@@ -30,14 +30,18 @@ function CommonSolve.solve(prob::IntervalNonlinearProblem, nothing, args...; kwa
     return CommonSolve.solve(prob, ITP(), args...; kwargs...)
 end
 
-function CommonSolve.solve(prob::IntervalNonlinearProblem,
-        alg::AbstractBracketingAlgorithm, args...; sensealg = nothing, kwargs...)
+function CommonSolve.solve(
+        prob::IntervalNonlinearProblem,
+        alg::AbstractBracketingAlgorithm, args...; sensealg = nothing, kwargs...
+    )
     return bracketingnonlinear_solve_up(
-        prob::IntervalNonlinearProblem, sensealg, prob.p, alg, args...; kwargs...)
+        prob::IntervalNonlinearProblem, sensealg, prob.p, alg, args...; kwargs...
+    )
 end
 
 function bracketingnonlinear_solve_up(
-        prob::IntervalNonlinearProblem, sensealg, p, alg, args...; kwargs...)
+        prob::IntervalNonlinearProblem, sensealg, p, alg, args...; kwargs...
+    )
     return SciMLBase.__solve(prob, alg, args...; kwargs...)
 end
 
@@ -50,7 +54,7 @@ end
 
         @compile_workload begin
             @sync for alg in algs
-                Threads.@spawn CommonSolve.solve(prob_brack, alg; abstol = 1e-6)
+                Threads.@spawn CommonSolve.solve(prob_brack, alg; abstol = 1.0e-6)
             end
         end
     end

--- a/lib/BracketingNonlinearSolve/src/alefeld.jl
+++ b/lib/BracketingNonlinearSolve/src/alefeld.jl
@@ -11,7 +11,7 @@ struct Alefeld <: AbstractBracketingAlgorithm end
 function SciMLBase.__solve(
         prob::IntervalNonlinearProblem, alg::Alefeld, args...;
         maxiters = 1000, abstol = nothing, kwargs...
-)
+    )
     f = Base.Fix2(prob.f, prob.p)
     a, b = prob.tspan
     c = a - (b - a) / (f(b) - f(a)) * f(a)

--- a/lib/BracketingNonlinearSolve/src/bisection.jl
+++ b/lib/BracketingNonlinearSolve/src/bisection.jl
@@ -22,7 +22,7 @@ end
 function SciMLBase.__solve(
         prob::IntervalNonlinearProblem, alg::Bisection, args...;
         maxiters = 1000, abstol = nothing, verbose::NonlinearVerbosity = NonlinearVerbosity(), kwargs...
-)
+    )
     @assert !SciMLBase.isinplace(prob) "`Bisection` only supports out-of-place problems."
 
     f = Base.Fix2(prob.f, prob.p)
@@ -30,7 +30,8 @@ function SciMLBase.__solve(
     fl, fr = f(left), f(right)
 
     abstol = NonlinearSolveBase.get_tolerance(
-        left, abstol, promote_type(eltype(left), eltype(right)))
+        left, abstol, promote_type(eltype(left), eltype(right))
+    )
 
     if iszero(fl)
         return build_exact_solution(prob, alg, left, fl, ReturnCode.ExactSolutionLeft)
@@ -41,9 +42,11 @@ function SciMLBase.__solve(
     end
 
     if sign(fl) == sign(fr)
-        @SciMLMessage("The interval is not an enclosing interval, opposite signs at the \
+        @SciMLMessage(
+            "The interval is not an enclosing interval, opposite signs at the \
         boundaries are required.",
-        verbose, :non_enclosing_interval)
+            verbose, :non_enclosing_interval
+        )
         return build_bracketing_solution(prob, alg, left, fl, left, right, ReturnCode.InitialFailure)
     end
 

--- a/lib/BracketingNonlinearSolve/src/brent.jl
+++ b/lib/BracketingNonlinearSolve/src/brent.jl
@@ -8,7 +8,7 @@ struct Brent <: AbstractBracketingAlgorithm end
 function SciMLBase.__solve(
         prob::IntervalNonlinearProblem, alg::Brent, args...;
         maxiters = 1000, abstol = nothing, verbose = NonlinearVerbosity(), kwargs...
-)
+    )
     @assert !SciMLBase.isinplace(prob) "`Brent` only supports out-of-place problems."
 
     if verbose isa Bool
@@ -39,9 +39,11 @@ function SciMLBase.__solve(
     end
 
     if sign(fl) == sign(fr)
-        @SciMLMessage("The interval is not an enclosing interval, opposite signs at the \
+        @SciMLMessage(
+            "The interval is not an enclosing interval, opposite signs at the \
         boundaries are required.",
-            verbose, :non_enclosing_interval)
+            verbose, :non_enclosing_interval
+        )
         return build_bracketing_solution(prob, alg, left, fl, left, right, ReturnCode.InitialFailure)
     end
 
@@ -68,12 +70,14 @@ function SciMLBase.__solve(
             s = right - fr * (right - left) / (fr - fl)
         end
 
-        if (s < min((3 * left + right) / 4, right) ||
-            s > max((3 * left + right) / 4, right)) ||
-           (cond && abs(s - right) ≥ abs(right - c) / 2) ||
-           (!cond && abs(s - right) ≥ abs(c - d) / 2) ||
-           (cond && abs(right - c) ≤ ϵ) ||
-           (!cond && abs(c - d) ≤ ϵ)
+        if (
+                s < min((3 * left + right) / 4, right) ||
+                    s > max((3 * left + right) / 4, right)
+            ) ||
+                (cond && abs(s - right) ≥ abs(right - c) / 2) ||
+                (!cond && abs(s - right) ≥ abs(c - d) / 2) ||
+                (cond && abs(right - c) ≤ ϵ) ||
+                (!cond && abs(c - d) ≤ ϵ)
             # Bisection method
             s = (left + right) / 2
             if s == left || s == right

--- a/lib/BracketingNonlinearSolve/src/common.jl
+++ b/lib/BracketingNonlinearSolve/src/common.jl
@@ -31,8 +31,8 @@ function newton_quadratic(f::F, a, b, d, k) where {F}
 
     for _ in 1:k
         rᵢ = rᵢ₋₁ -
-             (f(a) + B * (rᵢ₋₁ - a) + A * (rᵢ₋₁ - a) * (rᵢ₋₁ - b)) /
-             (B + A * (2 * rᵢ₋₁ - a - b))
+            (f(a) + B * (rᵢ₋₁ - a) + A * (rᵢ₋₁ - a) * (rᵢ₋₁ - b)) /
+            (B + A * (2 * rᵢ₋₁ - a - b))
         rᵢ₋₁ = rᵢ
     end
 

--- a/lib/BracketingNonlinearSolve/src/falsi.jl
+++ b/lib/BracketingNonlinearSolve/src/falsi.jl
@@ -8,7 +8,7 @@ struct Falsi <: AbstractBracketingAlgorithm end
 function SciMLBase.__solve(
         prob::IntervalNonlinearProblem, alg::Falsi, args...;
         maxiters = 1000, abstol = nothing, verbose = NonlinearVerbosity(), kwargs...
-)
+    )
     @assert !SciMLBase.isinplace(prob) "`False` only supports out-of-place problems."
 
     if verbose isa Bool
@@ -27,7 +27,8 @@ function SciMLBase.__solve(
     fl, fr = f(left), f(right)
 
     abstol = NonlinearSolveBase.get_tolerance(
-        left, abstol, promote_type(eltype(left), eltype(right)))
+        left, abstol, promote_type(eltype(left), eltype(right))
+    )
 
     if iszero(fl)
         return build_exact_solution(prob, alg, left, fl, ReturnCode.ExactSolutionLeft)
@@ -38,9 +39,11 @@ function SciMLBase.__solve(
     end
 
     if sign(fl) == sign(fr)
-        @SciMLMessage("The interval is not an enclosing interval, opposite signs at the \
+        @SciMLMessage(
+            "The interval is not an enclosing interval, opposite signs at the \
         boundaries are required.",
-            verbose, :non_enclosing_interval)
+            verbose, :non_enclosing_interval
+        )
         return build_bracketing_solution(prob, alg, left, fl, left, right, ReturnCode.InitialFailure)
     end
 

--- a/lib/BracketingNonlinearSolve/src/itp.jl
+++ b/lib/BracketingNonlinearSolve/src/itp.jl
@@ -59,7 +59,7 @@ end
 function SciMLBase.__solve(
         prob::IntervalNonlinearProblem, alg::ITP, args...;
         maxiters = 1000, abstol = nothing, verbose::NonlinearVerbosity = NonlinearVerbosity(), kwargs...
-)
+    )
     @assert !SciMLBase.isinplace(prob) "`ITP` only supports out-of-place problems."
 
     f = Base.Fix2(prob.f, prob.p)
@@ -79,9 +79,11 @@ function SciMLBase.__solve(
     end
 
     if sign(fl) == sign(fr)
-        @SciMLMessage("The interval is not an enclosing interval, opposite signs at the \
+        @SciMLMessage(
+            "The interval is not an enclosing interval, opposite signs at the \
         boundaries are required.",
-            verbose, :non_enclosing_interval)
+            verbose, :non_enclosing_interval
+        )
         return build_bracketing_solution(prob, alg, left, fl, left, right, ReturnCode.InitialFailure)
     end
 

--- a/lib/BracketingNonlinearSolve/src/muller.jl
+++ b/lib/BracketingNonlinearSolve/src/muller.jl
@@ -27,8 +27,10 @@ end
 
 Muller() = Muller(nothing)
 
-function SciMLBase.__solve(prob::IntervalNonlinearProblem, alg::Muller, args...;
-        abstol = nothing, maxiters = 1000, kwargs...)
+function SciMLBase.__solve(
+        prob::IntervalNonlinearProblem, alg::Muller, args...;
+        abstol = nothing, maxiters = 1000, kwargs...
+    )
     @assert !SciMLBase.isinplace(prob) "`Muller` only supports out-of-place problems."
     xᵢ₋₂, xᵢ = prob.tspan
     xᵢ₋₁ = isnothing(alg.middle) ? (xᵢ₋₂ + xᵢ) / 2 : alg.middle
@@ -39,8 +41,11 @@ function SciMLBase.__solve(prob::IntervalNonlinearProblem, alg::Muller, args...;
 
     xᵢ₊₁, fxᵢ₊₁ = xᵢ₋₂, fxᵢ₋₂
 
-    abstol = abs(NonlinearSolveBase.get_tolerance(
-        xᵢ₋₂, abstol, promote_type(eltype(xᵢ₋₂), eltype(xᵢ))))
+    abstol = abs(
+        NonlinearSolveBase.get_tolerance(
+            xᵢ₋₂, abstol, promote_type(eltype(xᵢ₋₂), eltype(xᵢ))
+        )
+    )
 
     for _ in 1:maxiters
         q = (xᵢ - xᵢ₋₁) / (xᵢ₋₁ - xᵢ₋₂)
@@ -61,16 +66,20 @@ function SciMLBase.__solve(prob::IntervalNonlinearProblem, alg::Muller, args...;
 
         # Termination Check
         if abstol ≥ abs(fxᵢ₊₁)
-            return SciMLBase.build_solution(prob, alg, xᵢ₊₁, fxᵢ₊₁;
+            return SciMLBase.build_solution(
+                prob, alg, xᵢ₊₁, fxᵢ₊₁;
                 retcode = ReturnCode.Success,
-                left = xᵢ₊₁, right = xᵢ₊₁)
+                left = xᵢ₊₁, right = xᵢ₊₁
+            )
         end
 
         xᵢ₋₂, xᵢ₋₁, xᵢ = xᵢ₋₁, xᵢ, xᵢ₊₁
         fxᵢ₋₂, fxᵢ₋₁, fxᵢ = fxᵢ₋₁, fxᵢ, fxᵢ₊₁
     end
 
-    return SciMLBase.build_solution(prob, alg, xᵢ₊₁, fxᵢ₊₁;
+    return SciMLBase.build_solution(
+        prob, alg, xᵢ₊₁, fxᵢ₊₁;
         retcode = ReturnCode.MaxIters,
-        left = xᵢ₊₁, right = xᵢ₊₁)
+        left = xᵢ₊₁, right = xᵢ₊₁
+    )
 end

--- a/lib/BracketingNonlinearSolve/src/ridder.jl
+++ b/lib/BracketingNonlinearSolve/src/ridder.jl
@@ -8,7 +8,7 @@ struct Ridder <: AbstractBracketingAlgorithm end
 function SciMLBase.__solve(
         prob::IntervalNonlinearProblem, alg::Ridder, args...;
         maxiters = 1000, abstol = nothing, verbose::NonlinearVerbosity = NonlinearVerbosity(), kwargs...
-)
+    )
     @assert !SciMLBase.isinplace(prob) "`Ridder` only supports out-of-place problems."
 
     f = Base.Fix2(prob.f, prob.p)
@@ -28,9 +28,11 @@ function SciMLBase.__solve(
     end
 
     if sign(fl) == sign(fr)
-        @SciMLMessage("The interval is not an enclosing interval, opposite signs at the \
+        @SciMLMessage(
+            "The interval is not an enclosing interval, opposite signs at the \
         boundaries are required.",
-            verbose, :non_enclosing_interval)
+            verbose, :non_enclosing_interval
+        )
         return build_bracketing_solution(prob, alg, left, fl, left, right, ReturnCode.InitialFailure)
     end
 

--- a/lib/BracketingNonlinearSolve/src/utils.jl
+++ b/lib/BracketingNonlinearSolve/src/utils.jl
@@ -2,7 +2,7 @@
 Builder for exact bracketing problems solution.
 """
 function build_exact_solution(prob, alg, u, resid, retcode)
-    SciMLBase.build_solution(
+    return SciMLBase.build_solution(
         prob, alg, u, resid; retcode = retcode, left = u, right = u
     )
 end
@@ -12,7 +12,7 @@ Builder for bracketing problems solution.
 Ensure that left/right are in the same order as tspan for consistency.
 """
 function build_bracketing_solution(prob, alg, u, resid, bound1, bound2, retcode)
-    if xor(bound1 < bound2, prob.tspan[1] < prob.tspan[2])
+    return if xor(bound1 < bound2, prob.tspan[1] < prob.tspan[2])
         SciMLBase.build_solution(
             prob, alg, u, resid; retcode = retcode, left = bound2, right = bound1
         )

--- a/lib/BracketingNonlinearSolve/test/adjoint_tests.jl
+++ b/lib/BracketingNonlinearSolve/test/adjoint_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Simple Adjoint Test" tags=[:adjoint] begin
+@testitem "Simple Adjoint Test" tags = [:adjoint] begin
     using ForwardDiff, Zygote, BracketingNonlinearSolve
 
     ff(u, p) = u^2 .- p[1]

--- a/lib/BracketingNonlinearSolve/test/muller_tests.jl
+++ b/lib/BracketingNonlinearSolve/test/muller_tests.jl
@@ -44,7 +44,7 @@
         prob = IntervalNonlinearProblem{false}(h, tspan)
         sol = solve(prob, Muller())
 
-        @test sol.u≈0 atol=1e-15
+        @test sol.u ≈ 0 atol = 1.0e-15
 
         tspan = (-1.0, 1.0)
         prob = IntervalNonlinearProblem{false}(h, tspan)

--- a/lib/BracketingNonlinearSolve/test/qa_tests.jl
+++ b/lib/BracketingNonlinearSolve/test/qa_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Aqua" tags=[:core] begin
+@testitem "Aqua" tags = [:core] begin
     using Aqua, BracketingNonlinearSolve
 
     Aqua.test_all(
@@ -11,12 +11,12 @@
     Aqua.test_ambiguities(BracketingNonlinearSolve; recursive = false)
 end
 
-@testitem "Explicit Imports" tags=[:core] begin
+@testitem "Explicit Imports" tags = [:core] begin
     import ForwardDiff
     using ExplicitImports, BracketingNonlinearSolve
 
     @test check_no_implicit_imports(BracketingNonlinearSolve; skip = (Base, Core)) ===
-          nothing
+        nothing
     @test check_no_stale_explicit_imports(BracketingNonlinearSolve) === nothing
     @test check_all_qualified_accesses_via_owners(BracketingNonlinearSolve) === nothing
 end

--- a/lib/BracketingNonlinearSolve/test/rootfind_tests.jl
+++ b/lib/BracketingNonlinearSolve/test/rootfind_tests.jl
@@ -5,21 +5,22 @@
     quadratic_f2(u, p) = @. p[1] * u * u - p[2]
 end
 
-@testitem "Interval Nonlinear Problems" setup=[RootfindingTestSnippet] tags=[:core] begin
+@testitem "Interval Nonlinear Problems" setup = [RootfindingTestSnippet] tags = [:core] begin
     using ForwardDiff
 
     @testset for alg in (
-        Alefeld(), Bisection(), Brent(), Falsi(), ITP(), Muller(), Ridder(), nothing)
+            Alefeld(), Bisection(), Brent(), Falsi(), ITP(), Muller(), Ridder(), nothing,
+        )
         tspan = (1.0, 20.0)
 
         function g(p)
             probN = IntervalNonlinearProblem{false}(quadratic_f, typeof(p).(tspan), p)
-            return solve(probN, alg; abstol = 1e-9).left
+            return solve(probN, alg; abstol = 1.0e-9).left
         end
 
         @testset for p in 1.1:0.1:100.0
-            @test g(p)≈sqrt(p) atol=1e-3 rtol=1e-3
-            @test ForwardDiff.derivative(g, p)≈1/(2*sqrt(p)) atol=1e-3 rtol=1e-3
+            @test g(p) ≈ sqrt(p) atol = 1.0e-3 rtol = 1.0e-3
+            @test ForwardDiff.derivative(g, p) ≈ 1 / (2 * sqrt(p)) atol = 1.0e-3 rtol = 1.0e-3
         end
 
         t = (p) -> [sqrt(p[2] / p[1])]
@@ -27,35 +28,35 @@ end
 
         function g2(p)
             probN = IntervalNonlinearProblem{false}(quadratic_f2, tspan, p)
-            sol = solve(probN, alg; abstol = 1e-9)
+            sol = solve(probN, alg; abstol = 1.0e-9)
             return [sol.u]
         end
 
-        @test g2(p)≈[sqrt(p[2]/p[1])] atol=1e-3 rtol=1e-3
-        @test ForwardDiff.jacobian(g2, p)≈ForwardDiff.jacobian(t, p) atol=1e-3 rtol=1e-3
+        @test g2(p) ≈ [sqrt(p[2] / p[1])] atol = 1.0e-3 rtol = 1.0e-3
+        @test ForwardDiff.jacobian(g2, p) ≈ ForwardDiff.jacobian(t, p) atol = 1.0e-3 rtol = 1.0e-3
 
         probB = IntervalNonlinearProblem{false}(quadratic_f, (1.0, 2.0), 2.0)
-        sol = solve(probB, alg; abstol = 1e-9)
-        @test sol.left≈sqrt(2.0) atol=1e-3 rtol=1e-3
+        sol = solve(probB, alg; abstol = 1.0e-9)
+        @test sol.left ≈ sqrt(2.0) atol = 1.0e-3 rtol = 1.0e-3
 
         if !(alg isa Bisection || alg isa Falsi)
             probB = IntervalNonlinearProblem{false}(quadratic_f, (sqrt(2.0), 10.0), 2.0)
-            sol = solve(probB, alg; abstol = 1e-9)
-            @test sol.left≈sqrt(2.0) atol=1e-3 rtol=1e-3
+            sol = solve(probB, alg; abstol = 1.0e-9)
+            @test sol.left ≈ sqrt(2.0) atol = 1.0e-3 rtol = 1.0e-3
 
             probB = IntervalNonlinearProblem{false}(quadratic_f, (0.0, sqrt(2.0)), 2.0)
-            sol = solve(probB, alg; abstol = 1e-9)
-            @test sol.left≈sqrt(2.0) atol=1e-3 rtol=1e-3
+            sol = solve(probB, alg; abstol = 1.0e-9)
+            @test sol.left ≈ sqrt(2.0) atol = 1.0e-3 rtol = 1.0e-3
         end
     end
 end
 
-@testitem "Tolerance Tests Interval Methods" setup=[RootfindingTestSnippet] tags=[:core] begin
-    prob=IntervalNonlinearProblem(quadratic_f, (1.0, 20.0), 2.0)
-    ϵ=eps(Float64) # least possible tol for all methods
+@testitem "Tolerance Tests Interval Methods" setup = [RootfindingTestSnippet] tags = [:core] begin
+    prob = IntervalNonlinearProblem(quadratic_f, (1.0, 20.0), 2.0)
+    ϵ = eps(Float64) # least possible tol for all methods
 
     @testset for alg in (Bisection(), Falsi(), ITP(), Muller(), nothing)
-        @testset for abstol in [0.1, 0.01, 0.001, 0.0001, 1e-5, 1e-6]
+        @testset for abstol in [0.1, 0.01, 0.001, 0.0001, 1.0e-5, 1.0e-6]
             sol = solve(prob, alg; abstol)
             result_tol = abs(sol.u - sqrt(2))
             @test result_tol < abstol
@@ -77,9 +78,9 @@ end
     end
 end
 
-@testitem "Zero-Tolerance Tests Interval Methods" setup=[RootfindingTestSnippet] tags=[:core] begin
-    prob=IntervalNonlinearProblem(quadratic_f, (1.0, 20.0), 2.0)
-    prob_lin=IntervalNonlinearProblem(linear_f, (-1.0, 1.0), 0.0)
+@testitem "Zero-Tolerance Tests Interval Methods" setup = [RootfindingTestSnippet] tags = [:core] begin
+    prob = IntervalNonlinearProblem(quadratic_f, (1.0, 20.0), 2.0)
+    prob_lin = IntervalNonlinearProblem(linear_f, (-1.0, 1.0), 0.0)
 
     @testset for alg in (Alefeld(), Bisection(), Brent(), ITP(), Ridder(), nothing)
         sol = solve(prob, alg; abstol = 0.0)
@@ -99,9 +100,10 @@ end
     end
 end
 
-@testitem "Flipped Signs and Reversed Tspan" setup=[RootfindingTestSnippet] tags=[:core] begin
+@testitem "Flipped Signs and Reversed Tspan" setup = [RootfindingTestSnippet] tags = [:core] begin
     @testset for alg in (
-        Alefeld(), Bisection(), Brent(), Falsi(), ITP(), Muller(), Ridder(), nothing)
+            Alefeld(), Bisection(), Brent(), Falsi(), ITP(), Muller(), Ridder(), nothing,
+        )
         f1(u, p) = u * u - p
         f2(u, p) = p - u * u
 

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseChainRulesCoreExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseChainRulesCoreExt.jl
@@ -8,24 +8,30 @@ using SciMLBase: AbstractSensitivityAlgorithm
 import ChainRulesCore
 import ChainRulesCore: NoTangent, Tangent
 
-function ChainRulesCore.frule(::typeof(NonlinearSolveBase.solve_up), prob,
+function ChainRulesCore.frule(
+        ::typeof(NonlinearSolveBase.solve_up), prob,
         sensealg::Union{Nothing, AbstractSensitivityAlgorithm},
         u0, p, args...; originator = SciMLBase.ChainRulesOriginator(),
-        kwargs...)
-    NonlinearSolveBase._solve_forward(
+        kwargs...
+    )
+    return NonlinearSolveBase._solve_forward(
         prob, sensealg, u0, p,
         originator, args...;
-        kwargs...)
+        kwargs...
+    )
 end
 
-function ChainRulesCore.rrule(::typeof(NonlinearSolveBase.solve_up), prob::AbstractNonlinearProblem,
-    sensealg::Union{Nothing, AbstractSensitivityAlgorithm},
-    u0, p, args...; originator = SciMLBase.ChainRulesOriginator(),
-    kwargs...)
+function ChainRulesCore.rrule(
+        ::typeof(NonlinearSolveBase.solve_up), prob::AbstractNonlinearProblem,
+        sensealg::Union{Nothing, AbstractSensitivityAlgorithm},
+        u0, p, args...; originator = SciMLBase.ChainRulesOriginator(),
+        kwargs...
+    )
     primal, inner_thunking_pb = NonlinearSolveBase._solve_adjoint(
         prob, sensealg, u0, p,
         originator, args...;
-        kwargs...)
+        kwargs...
+    )
 
     # when using mooncake ∂sol would be a NamedTuple Tangent with cotangents of all the solution struct's fields.
     # However the pullback for this rule - "steadystatebackpass" as defined in SciMLSensitivity/src/concrete_solve.jl/
@@ -33,7 +39,7 @@ function ChainRulesCore.rrule(::typeof(NonlinearSolveBase.solve_up), prob::Abstr
     # When using Mooncake, we pass in sol.u to inner_thunking_pb directly as this is the only field relevant to the solution's cotangent (given solve_up, AbstractNonlinearProblem setting).
 
     function solve_up_adjoint(∂sol)
-        return inner_thunking_pb(∂sol isa Tangent{Any,<:NamedTuple} ? ∂sol.u : ∂sol)
+        return inner_thunking_pb(∂sol isa Tangent{Any, <:NamedTuple} ? ∂sol.u : ∂sol)
     end
     return primal, solve_up_adjoint
 end

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseEnzymeExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseEnzymeExt.jl
@@ -11,8 +11,10 @@ module NonlinearSolveBaseEnzymeExt
             config::Enzyme.EnzymeRules.RevConfigWidth{1},
             func::Const{typeof(NonlinearSolveBase.solve_up)}, ::Type{Duplicated{RT}}, prob,
             sensealg::Union{
-                Const{Nothing}, Const{<:SciMLBase.AbstractSensitivityAlgorithm}},
-            u0, p, args...; kwargs...) where {RT}
+                Const{Nothing}, Const{<:SciMLBase.AbstractSensitivityAlgorithm},
+            },
+            u0, p, args...; kwargs...
+        ) where {RT}
         @inline function copy_or_reuse(val, idx)
             if Enzyme.EnzymeRules.overwritten(config)[idx] && ismutable(val)
                 return deepcopy(val)
@@ -29,18 +31,22 @@ module NonlinearSolveBaseEnzymeExt
             copy_or_reuse(prob.val, 2), copy_or_reuse(sensealg.val, 3),
             copy_or_reuse(u0.val, 4), copy_or_reuse(p.val, 5),
             SciMLBase.EnzymeOriginator(), ntuple(arg_copy, Val(length(args)))...;
-            kwargs...)
+            kwargs...
+        )
 
         dres = Enzyme.make_zero(res[1])::RT
         tup = (dres, res[2])
         return Enzyme.EnzymeRules.AugmentedReturn{RT, RT, Any}(res[1], dres, tup::Any)
     end
 
-    function Enzyme.EnzymeRules.reverse(config::Enzyme.EnzymeRules.RevConfigWidth{1},
+    function Enzyme.EnzymeRules.reverse(
+            config::Enzyme.EnzymeRules.RevConfigWidth{1},
             func::Const{typeof(NonlinearSolveBase.solve_up)}, ::Type{Duplicated{RT}}, tape, prob,
             sensealg::Union{
-                Const{Nothing}, Const{<:SciMLBase.AbstractSensitivityAlgorithm}},
-            u0, p, args...; kwargs...) where {RT}
+                Const{Nothing}, Const{<:SciMLBase.AbstractSensitivityAlgorithm},
+            },
+            u0, p, args...; kwargs...
+        ) where {RT}
         dres, clos = tape
         dres = dres::RT
         dargs = clos(dres)

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseForwardDiffExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseForwardDiffExt.jl
@@ -8,31 +8,32 @@ using DifferentiationInterface: DifferentiationInterface
 using FastClosures: @closure
 using ForwardDiff: ForwardDiff, Dual, pickchunksize
 using SciMLBase: SciMLBase, AbstractNonlinearProblem, IntervalNonlinearProblem,
-                 NonlinearProblem, NonlinearLeastSquaresProblem, remake
+    NonlinearProblem, NonlinearLeastSquaresProblem, remake
 
 using NonlinearSolveBase: NonlinearSolveBase, ImmutableNonlinearProblem, Utils, InternalAPI,
-                          NonlinearSolvePolyAlgorithm, NonlinearSolveForwardDiffCache
+    NonlinearSolvePolyAlgorithm, NonlinearSolveForwardDiffCache
 
 const DI = DifferentiationInterface
 
 const GENERAL_SOLVER_TYPES = [
-    Nothing, NonlinearSolvePolyAlgorithm
+    Nothing, NonlinearSolvePolyAlgorithm,
 ]
 
 const DualNonlinearProblem = NonlinearProblem{
     <:Union{Number, <:AbstractArray}, iip,
-    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}}
+    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}},
 } where {iip, T, V, P}
 const DualNonlinearLeastSquaresProblem = NonlinearLeastSquaresProblem{
     <:Union{Number, <:AbstractArray}, iip,
-    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}}
+    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}},
 } where {iip, T, V, P}
 const DualAbstractNonlinearProblem = Union{
-    DualNonlinearProblem, DualNonlinearLeastSquaresProblem
+    DualNonlinearProblem, DualNonlinearLeastSquaresProblem,
 }
 
 function NonlinearSolveBase.additional_incompatible_backend_check(
-        prob::AbstractNonlinearProblem, ::Union{AutoForwardDiff, AutoPolyesterForwardDiff})
+        prob::AbstractNonlinearProblem, ::Union{AutoForwardDiff, AutoPolyesterForwardDiff}
+    )
     return !ForwardDiff.can_dual(eltype(prob.u0))
 end
 
@@ -43,10 +44,10 @@ Utils.value(x::AbstractArray{<:Dual}) = Utils.value.(x)
 function NonlinearSolveBase.nonlinearsolve_forwarddiff_solve(
         prob::Union{
             IntervalNonlinearProblem, NonlinearProblem,
-            ImmutableNonlinearProblem, NonlinearLeastSquaresProblem
+            ImmutableNonlinearProblem, NonlinearLeastSquaresProblem,
         },
         alg, args...; kwargs...
-)
+    )
     p = Utils.value(prob.p)
     if prob isa IntervalNonlinearProblem
         tspan = Utils.value.(prob.tspan)
@@ -59,7 +60,7 @@ function NonlinearSolveBase.nonlinearsolve_forwarddiff_solve(
     uu = sol.u
 
     fn = prob isa NonlinearLeastSquaresProblem ?
-         NonlinearSolveBase.nlls_generate_vjp_function(prob, sol, uu) : prob.f
+        NonlinearSolveBase.nlls_generate_vjp_function(prob, sol, uu) : prob.f
 
     Jₚ = NonlinearSolveBase.nonlinearsolve_∂f_∂p(prob, fn, uu, p)
     Jᵤ = NonlinearSolveBase.nonlinearsolve_∂f_∂u(prob, fn, uu, p)
@@ -100,7 +101,8 @@ end
 function NonlinearSolveBase.nonlinearsolve_∂f_∂u(prob, f::F, u, p) where {F}
     if SciMLBase.isinplace(prob)
         return ForwardDiff.jacobian(
-            @closure((du, u)->f(du, u, p)), Utils.safe_similar(u), u)
+            @closure((du, u) -> f(du, u, p)), Utils.safe_similar(u), u
+        )
     end
     u isa Number && return ForwardDiff.derivative(Base.Fix2(f, p), u)
     return ForwardDiff.jacobian(Base.Fix2(f, p), u)
@@ -109,23 +111,23 @@ end
 function NonlinearSolveBase.nonlinearsolve_dual_solution(
         u::Number, partials,
         ::Union{<:AbstractArray{<:Dual{T, V, P}}, Dual{T, V, P}}
-) where {T, V, P}
+    ) where {T, V, P}
     return Dual{T, V, P}(u, partials)
 end
 
 function NonlinearSolveBase.nonlinearsolve_dual_solution(
         u::AbstractArray, partials,
         ::Union{<:AbstractArray{<:Dual{T, V, P}}, Dual{T, V, P}}
-) where {T, V, P}
+    ) where {T, V, P}
     return map(((uᵢ, pᵢ),) -> Dual{T, V, P}(uᵢ, pᵢ), zip(u, Utils.restructure(u, partials)))
 end
 
 for algType in GENERAL_SOLVER_TYPES
     @eval function SciMLBase.__solve(
             prob::DualAbstractNonlinearProblem, alg::$(algType), args...; kwargs...
-    )
+        )
         sol,
-        partials = NonlinearSolveBase.nonlinearsolve_forwarddiff_solve(
+            partials = NonlinearSolveBase.nonlinearsolve_forwarddiff_solve(
             prob, alg, args...; kwargs...
         )
         dual_soln = NonlinearSolveBase.nonlinearsolve_dual_solution(sol.u, partials, prob.p)
@@ -138,7 +140,7 @@ end
 function InternalAPI.reinit!(
         cache::NonlinearSolveForwardDiffCache, args...;
         p = cache.p, u0 = NonlinearSolveBase.get_u(cache.cache), kwargs...
-)
+    )
     InternalAPI.reinit!(
         cache.cache; p = NonlinearSolveBase.nodual_value(p),
         u0 = NonlinearSolveBase.nodual_value(u0), kwargs...
@@ -152,7 +154,7 @@ end
 for algType in GENERAL_SOLVER_TYPES
     @eval function SciMLBase.__init(
             prob::DualAbstractNonlinearProblem, alg::$(algType), args...; kwargs...
-    )
+        )
         p = NonlinearSolveBase.nodual_value(prob.p)
         newprob = SciMLBase.remake(prob; u0 = NonlinearSolveBase.nodual_value(prob.u0), p)
         cache = init(newprob, alg, args...; kwargs...)
@@ -168,7 +170,7 @@ function CommonSolve.solve!(cache::NonlinearSolveForwardDiffCache)
     uu = sol.u
 
     fn = prob isa NonlinearLeastSquaresProblem ?
-         NonlinearSolveBase.nlls_generate_vjp_function(prob, sol, uu) : prob.f
+        NonlinearSolveBase.nlls_generate_vjp_function(prob, sol, uu) : prob.f
 
     Jₚ = NonlinearSolveBase.nonlinearsolve_∂f_∂p(prob, fn, uu, cache.values_p)
     Jᵤ = NonlinearSolveBase.nonlinearsolve_∂f_∂u(prob, fn, uu, cache.values_p)

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseLineSearchExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseLineSearchExt.jl
@@ -7,7 +7,7 @@ using NonlinearSolveBase: NonlinearSolveBase, InternalAPI
 
 function NonlinearSolveBase.callback_into_cache!(
         topcache, cache::AbstractLineSearchCache, args...
-)
+    )
     return LineSearch.callback_into_cache!(cache, NonlinearSolveBase.get_fu(topcache))
 end
 

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseLinearSolveExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseLinearSolveExt.jl
@@ -14,13 +14,13 @@ using NonlinearSolveBase: NonlinearSolveBase, LinearSolveJLCache, LinearSolveRes
 function (cache::LinearSolveJLCache)(;
         A = nothing, b = nothing, linu = nothing,
         reuse_A_if_factorization = false, kwargs...
-)
+    )
     cache.stats.nsolve += 1
 
     update_A!(cache, A, reuse_A_if_factorization)
     b !== nothing && setproperty!(cache.lincache, :b, b)
     linu !== nothing && NonlinearSolveBase.set_lincache_u!(cache, linu)
-    
+
     linres = solve!(cache.lincache)
     if linres.retcode === ReturnCode.Failure
         return LinearSolveResult(; linres.u, success = false)
@@ -53,9 +53,10 @@ function update_A!(cache::LinearSolveJLCache, ::LinearSolve.AbstractFactorizatio
     return cache
 end
 function update_A!(
-        cache::LinearSolveJLCache, alg::LinearSolve.DefaultLinearSolver, A, reuse)
+        cache::LinearSolveJLCache, alg::LinearSolve.DefaultLinearSolver, A, reuse
+    )
     if alg ==
-       LinearSolve.DefaultLinearSolver(LinearSolve.DefaultAlgorithmChoice.KrylovJL_GMRES)
+            LinearSolve.DefaultLinearSolver(LinearSolve.DefaultAlgorithmChoice.KrylovJL_GMRES)
         # Force a reset of the cache. This is not properly handled in LinearSolve.jl
         set_lincache_A!(cache.lincache, A)
         return cache
@@ -68,7 +69,7 @@ end
 
 function set_lincache_A!(lincache, new_A)
     if !LinearSolve.default_alias_A(lincache.alg, new_A, lincache.b) &&
-       ArrayInterface.can_setindex(lincache.A)
+            ArrayInterface.can_setindex(lincache.A)
         copyto!(lincache.A, new_A)
         lincache.A = lincache.A # important!! triggers special code in `setproperty!`
         return
@@ -78,7 +79,7 @@ function set_lincache_A!(lincache, new_A)
 end
 
 function LinearSolve.update_tolerances!(cache::LinearSolveJLCache; kwargs...)
-    LinearSolve.update_tolerances!(cache.lincache; kwargs...)
+    return LinearSolve.update_tolerances!(cache.lincache; kwargs...)
 end
 
 end

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseMooncakeExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseMooncakeExt.jl
@@ -6,21 +6,22 @@ using Mooncake: rrule!!, CoDual, zero_fcodual, @is_primitive,
     @from_chainrules, @zero_adjoint, @mooncake_overlay, MinimalCtx,
     NoPullback
 
-@from_chainrules MinimalCtx Tuple{typeof(NonlinearSolveBase.solve_up),
+@from_chainrules MinimalCtx Tuple{
+    typeof(NonlinearSolveBase.solve_up),
     SciMLBase.AbstractNonlinearProblem,
-    Union{Nothing,SciMLBase.AbstractSensitivityAlgorithm},
+    Union{Nothing, SciMLBase.AbstractSensitivityAlgorithm},
     Any,
     Any,
-    Any
+    Any,
 } true
 
 # Dispatch for auto-alg
 @from_chainrules MinimalCtx Tuple{
     typeof(NonlinearSolveBase.solve_up),
     SciMLBase.AbstractNonlinearProblem,
-    Union{Nothing,SciMLBase.AbstractSensitivityAlgorithm},
+    Union{Nothing, SciMLBase.AbstractSensitivityAlgorithm},
     Any,
-    Any
+    Any,
 } true
 
 end

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseReverseDiffExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseReverseDiffExt.jl
@@ -6,61 +6,83 @@ import ReverseDiff
 import ArrayInterface
 
 # `ReverseDiff.TrackedArray`
-function NonlinearSolveBase.solve_up(prob::SciMLBase.NonlinearProblem,
+function NonlinearSolveBase.solve_up(
+        prob::SciMLBase.NonlinearProblem,
         sensealg::Union{
             SciMLBase.AbstractOverloadingSensitivityAlgorithm,
-            Nothing}, u0::ReverseDiff.TrackedArray,
-        p::ReverseDiff.TrackedArray, args...; kwargs...)
-    ReverseDiff.track(NonlinearSolveBase.solve_up, prob, sensealg, u0, p, args...; kwargs...)
+            Nothing,
+        }, u0::ReverseDiff.TrackedArray,
+        p::ReverseDiff.TrackedArray, args...; kwargs...
+    )
+    return ReverseDiff.track(NonlinearSolveBase.solve_up, prob, sensealg, u0, p, args...; kwargs...)
 end
 
-function NonlinearSolveBase.solve_up(prob::SciMLBase.NonlinearProblem,
+function NonlinearSolveBase.solve_up(
+        prob::SciMLBase.NonlinearProblem,
         sensealg::Union{
             SciMLBase.AbstractOverloadingSensitivityAlgorithm,
-            Nothing}, u0, p::ReverseDiff.TrackedArray,
-        args...; kwargs...)
-    ReverseDiff.track(NonlinearSolveBase.solve_up, prob, sensealg, u0, p, args...; kwargs...)
+            Nothing,
+        }, u0, p::ReverseDiff.TrackedArray,
+        args...; kwargs...
+    )
+    return ReverseDiff.track(NonlinearSolveBase.solve_up, prob, sensealg, u0, p, args...; kwargs...)
 end
 
-function NonlinearSolveBase.solve_up(prob::SciMLBase.NonlinearProblem,
+function NonlinearSolveBase.solve_up(
+        prob::SciMLBase.NonlinearProblem,
         sensealg::Union{
             SciMLBase.AbstractOverloadingSensitivityAlgorithm,
-            Nothing}, u0::ReverseDiff.TrackedArray, p,
-        args...; kwargs...)
-    ReverseDiff.track(NonlinearSolveBase.solve_up, prob, sensealg, u0, p, args...; kwargs...)
+            Nothing,
+        }, u0::ReverseDiff.TrackedArray, p,
+        args...; kwargs...
+    )
+    return ReverseDiff.track(NonlinearSolveBase.solve_up, prob, sensealg, u0, p, args...; kwargs...)
 end
 
 # `AbstractArray{<:ReverseDiff.TrackedReal}`
-function NonlinearSolveBase.solve_up(prob::SciMLBase.NonlinearProblem,
+function NonlinearSolveBase.solve_up(
+        prob::SciMLBase.NonlinearProblem,
         sensealg::Union{
             SciMLBase.AbstractOverloadingSensitivityAlgorithm,
-            Nothing},
+            Nothing,
+        },
         u0::AbstractArray{<:ReverseDiff.TrackedReal},
         p::AbstractArray{<:ReverseDiff.TrackedReal}, args...;
-        kwargs...)
-    NonlinearSolveBase.solve_up(prob, sensealg, ArrayInterface.aos_to_soa(u0),
+        kwargs...
+    )
+    return NonlinearSolveBase.solve_up(
+        prob, sensealg, ArrayInterface.aos_to_soa(u0),
         ArrayInterface.aos_to_soa(p), args...;
-        kwargs...)
+        kwargs...
+    )
 end
 
-function NonlinearSolveBase.solve_up(prob::SciMLBase.NonlinearProblem,
+function NonlinearSolveBase.solve_up(
+        prob::SciMLBase.NonlinearProblem,
         sensealg::Union{
             SciMLBase.AbstractOverloadingSensitivityAlgorithm,
-            Nothing}, u0,
+            Nothing,
+        }, u0,
         p::AbstractArray{<:ReverseDiff.TrackedReal},
-        args...; kwargs...)
-    NonlinearSolveBase.solve_up(
-        prob, sensealg, u0, ArrayInterface.aos_to_soa(p), args...; kwargs...)
+        args...; kwargs...
+    )
+    return NonlinearSolveBase.solve_up(
+        prob, sensealg, u0, ArrayInterface.aos_to_soa(p), args...; kwargs...
+    )
 end
 
-function NonlinearSolveBase.solve_up(prob::SciMLBase.NonlinearProblem,
+function NonlinearSolveBase.solve_up(
+        prob::SciMLBase.NonlinearProblem,
         sensealg::Union{
             SciMLBase.AbstractOverloadingSensitivityAlgorithm,
-            Nothing}, u0::ReverseDiff.TrackedArray,
+            Nothing,
+        }, u0::ReverseDiff.TrackedArray,
         p::AbstractArray{<:ReverseDiff.TrackedReal},
-        args...; kwargs...)
-    NonlinearSolveBase.solve_up(
-        prob, sensealg, u0, ArrayInterface.aos_to_soa(p), args...; kwargs...)
+        args...; kwargs...
+    )
+    return NonlinearSolveBase.solve_up(
+        prob, sensealg, u0, ArrayInterface.aos_to_soa(p), args...; kwargs...
+    )
 end
 
 # function NonlinearSolveBase.solve_up(prob::SciMLBase.DEProblem,
@@ -86,9 +108,11 @@ end
 # Required becase ReverseDiff.@grad function SciMLBase.solve_up is not supported!
 import NonlinearSolveBase: solve_up
 ReverseDiff.@grad function solve_up(prob, sensealg, u0, p, args...; kwargs...)
-    out = NonlinearSolveBase._solve_adjoint(prob, sensealg, ReverseDiff.value(u0),
+    out = NonlinearSolveBase._solve_adjoint(
+        prob, sensealg, ReverseDiff.value(u0),
         ReverseDiff.value(p),
-        SciMLBase.ReverseDiffOriginator(), args...; kwargs...)
+        SciMLBase.ReverseDiffOriginator(), args...; kwargs...
+    )
     function actual_adjoint(_args...)
         original_adjoint = out[2](_args...)
         if isempty(args) # alg is missing

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseSparseMatrixColoringsExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseSparseMatrixColoringsExt.jl
@@ -4,7 +4,7 @@ using ADTypes: ADTypes, AbstractADType
 using SciMLBase: SciMLBase, NonlinearFunction
 
 using SparseMatrixColorings: ConstantColoringAlgorithm, GreedyColoringAlgorithm,
-                             LargestFirst
+    LargestFirst
 
 using NonlinearSolveBase: NonlinearSolveBase, Utils
 
@@ -12,12 +12,17 @@ Utils.is_extension_loaded(::Val{:SparseMatrixColorings}) = true
 
 function NonlinearSolveBase.select_fastest_coloring_algorithm(
         ::Val{:SparseMatrixColorings},
-        prototype, f::NonlinearFunction, ad::AbstractADType)
+        prototype, f::NonlinearFunction, ad::AbstractADType
+    )
     prototype === nothing && return GreedyColoringAlgorithm(LargestFirst())
     if SciMLBase.has_colorvec(f)
-        return ConstantColoringAlgorithm{ifelse(
-            ADTypes.mode(ad) isa ADTypes.ReverseMode, :row, :column)}(
-            prototype, f.colorvec)
+        return ConstantColoringAlgorithm{
+            ifelse(
+                ADTypes.mode(ad) isa ADTypes.ReverseMode, :row, :column
+            ),
+        }(
+            prototype, f.colorvec
+        )
     end
     return GreedyColoringAlgorithm(LargestFirst())
 end

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseTrackerExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseTrackerExt.jl
@@ -4,40 +4,53 @@ using NonlinearSolveBase
 import SciMLBase: SciMLBase, value
 import Tracker
 
-function NonlinearSolveBase.solve_up(prob::SciMLBase.NonlinearProblem,
+function NonlinearSolveBase.solve_up(
+        prob::SciMLBase.NonlinearProblem,
         sensealg::Union{
             SciMLBase.AbstractOverloadingSensitivityAlgorithm,
-            Nothing}, u0::Tracker.TrackedArray,
-        p::Tracker.TrackedArray, args...; kwargs...)
-    Tracker.track(NonlinearSolveBase.solve_up, prob, sensealg, u0, p, args...; kwargs...)
+            Nothing,
+        }, u0::Tracker.TrackedArray,
+        p::Tracker.TrackedArray, args...; kwargs...
+    )
+    return Tracker.track(NonlinearSolveBase.solve_up, prob, sensealg, u0, p, args...; kwargs...)
 end
 
-function NonlinearSolveBase.solve_up(prob::SciMLBase.NonlinearProblem,
+function NonlinearSolveBase.solve_up(
+        prob::SciMLBase.NonlinearProblem,
         sensealg::Union{
             SciMLBase.AbstractOverloadingSensitivityAlgorithm,
-            Nothing}, u0::Tracker.TrackedArray, p, args...;
-        kwargs...)
-    Tracker.track(NonlinearSolveBase.solve_up, prob, sensealg, u0, p, args...; kwargs...)
+            Nothing,
+        }, u0::Tracker.TrackedArray, p, args...;
+        kwargs...
+    )
+    return Tracker.track(NonlinearSolveBase.solve_up, prob, sensealg, u0, p, args...; kwargs...)
 end
 
-function NonlinearSolveBase.solve_up(prob::SciMLBase.NonlinearProblem,
+function NonlinearSolveBase.solve_up(
+        prob::SciMLBase.NonlinearProblem,
         sensealg::Union{
             SciMLBase.AbstractOverloadingSensitivityAlgorithm,
-            Nothing}, u0, p::Tracker.TrackedArray, args...;
-        kwargs...)
-    Tracker.track(NonlinearSolveBase.solve_up, prob, sensealg, u0, p, args...; kwargs...)
+            Nothing,
+        }, u0, p::Tracker.TrackedArray, args...;
+        kwargs...
+    )
+    return Tracker.track(NonlinearSolveBase.solve_up, prob, sensealg, u0, p, args...; kwargs...)
 end
 
-Tracker.@grad function NonlinearSolveBase.solve_up(prob,
-        sensealg::Union{Nothing,
-            SciMLBase.AbstractOverloadingSensitivityAlgorithm
+Tracker.@grad function NonlinearSolveBase.solve_up(
+        prob,
+        sensealg::Union{
+            Nothing,
+            SciMLBase.AbstractOverloadingSensitivityAlgorithm,
         },
         u0, p, args...;
-        kwargs...)
+        kwargs...
+    )
     sol,
-    pb_f = NonlinearSolveBase._solve_adjoint(
+        pb_f = NonlinearSolveBase._solve_adjoint(
         prob, sensealg, Tracker.data(u0), Tracker.data(p),
-        SciMLBase.TrackerOriginator(), args...; kwargs...)
+        SciMLBase.TrackerOriginator(), args...; kwargs...
+    )
 
     if sol isa AbstractArray
         !hasfield(typeof(sol), :u) && return sol, pb_f # being safe here

--- a/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
+++ b/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
@@ -6,7 +6,7 @@ using FastClosures: @closure
 using Preferences: @load_preference, @set_preferences!
 
 using ADTypes: ADTypes, AbstractADType, AutoSparse, AutoForwardDiff, NoSparsityDetector,
-               KnownJacobianSparsityDetector
+    KnownJacobianSparsityDetector
 using Adapt: WrappedArray
 using ArrayInterface: ArrayInterface
 using DifferentiationInterface: DifferentiationInterface, Constant
@@ -17,20 +17,20 @@ using EnzymeCore: EnzymeCore
 using MaybeInplace: @bb
 using RecursiveArrayTools: RecursiveArrayTools, AbstractVectorOfArray, ArrayPartition
 using SciMLBase: SciMLBase, ReturnCode, AbstractODEIntegrator, AbstractNonlinearProblem,
-                 AbstractNonlinearAlgorithm, _concrete_solve_adjoint, _concrete_solve_forward,
-                 NonlinearProblem, NonlinearLeastSquaresProblem,
-                 NonlinearFunction, NLStats, LinearProblem,
-                 LinearAliasSpecifier, ImmutableNonlinearProblem, NonlinearAliasSpecifier,
-                 promote_u0, get_concrete_u0, get_concrete_p,
-                 has_kwargs, extract_alg, promote_u0, checkkwargs, SteadyStateProblem,
-                 NoDefaultAlgorithmError, NonSolverError, KeywordArgError, AbstractDEAlgorithm
+    AbstractNonlinearAlgorithm, _concrete_solve_adjoint, _concrete_solve_forward,
+    NonlinearProblem, NonlinearLeastSquaresProblem,
+    NonlinearFunction, NLStats, LinearProblem,
+    LinearAliasSpecifier, ImmutableNonlinearProblem, NonlinearAliasSpecifier,
+    promote_u0, get_concrete_u0, get_concrete_p,
+    has_kwargs, extract_alg, promote_u0, checkkwargs, SteadyStateProblem,
+    NoDefaultAlgorithmError, NonSolverError, KeywordArgError, AbstractDEAlgorithm
 import SciMLBase: solve, init, __init, __solve, wrap_sol, get_root_indp, isinplace, remake
 
 using SciMLJacobianOperators: JacobianOperator, StatefulJacobianOperator
 using SciMLOperators: AbstractSciMLOperator, IdentityOperator
 using SciMLLogging: SciMLLogging, @SciMLMessage, @verbosity_specifier,
-                    AbstractVerbositySpecifier, AbstractVerbosityPreset,
-                    None, Minimal, Standard, Detailed, All, Silent, InfoLevel, WarnLevel
+    AbstractVerbositySpecifier, AbstractVerbosityPreset,
+    None, Minimal, Standard, Detailed, All, Silent, InfoLevel, WarnLevel
 
 using SymbolicIndexingInterface: SymbolicIndexingInterface
 import SciMLStructures
@@ -75,26 +75,32 @@ include("forward_diff.jl")
 # Unexported Public API
 @compat(public, (L2_NORM, Linf_NORM, NAN_CHECK, UNITLESS_ABS2, get_tolerance))
 @compat(public, (nonlinearsolve_forwarddiff_solve, nonlinearsolve_dual_solution))
-@compat(public,
-    (select_forward_mode_autodiff, select_reverse_mode_autodiff, select_jacobian_autodiff))
+@compat(
+    public,
+    (select_forward_mode_autodiff, select_reverse_mode_autodiff, select_jacobian_autodiff)
+)
 
 # public for NonlinearSolve.jl and subpackages to use
 @compat(public, (InternalAPI, supports_line_search, supports_trust_region, set_du!))
 @compat(public, (construct_linear_solver, needs_square_A, needs_concrete_A))
 @compat(public, (construct_jacobian_cache, reused_jacobian))
-@compat(public,
-    (assert_extension_supported_termination_condition,
-    construct_extension_function_wrapper, construct_extension_jac))
+@compat(
+    public,
+    (
+        assert_extension_supported_termination_condition,
+        construct_extension_function_wrapper, construct_extension_jac,
+    )
+)
 
 export TraceMinimal, TraceWithJacobianConditionNumber, TraceAll
 
 export RelTerminationMode, AbsTerminationMode,
-       NormTerminationMode, RelNormTerminationMode, AbsNormTerminationMode,
-       RelNormSafeTerminationMode, AbsNormSafeTerminationMode,
-       RelNormSafeBestTerminationMode, AbsNormSafeBestTerminationMode
+    NormTerminationMode, RelNormTerminationMode, AbsNormTerminationMode,
+    RelNormSafeTerminationMode, AbsNormSafeTerminationMode,
+    RelNormSafeBestTerminationMode, AbsNormSafeBestTerminationMode
 
 export DescentResult, SteepestDescent, NewtonDescent, DampedNewtonDescent, Dogleg,
-       GeodesicAcceleration
+    GeodesicAcceleration
 
 export NonlinearSolvePolyAlgorithm
 

--- a/lib/NonlinearSolveBase/src/common_defaults.jl
+++ b/lib/NonlinearSolveBase/src/common_defaults.jl
@@ -3,8 +3,10 @@ function UNITLESS_ABS2(x::AbstractArray)
     return mapreduce(UNITLESS_ABS2, Utils.abs2_and_sum, x; init = Utils.zero_init(x))
 end
 function UNITLESS_ABS2(x::Union{AbstractVectorOfArray, ArrayPartition})
-    return mapreduce(UNITLESS_ABS2, Utils.abs2_and_sum,
-        Utils.get_internal_array(x); init = Utils.zero_init(x))
+    return mapreduce(
+        UNITLESS_ABS2, Utils.abs2_and_sum,
+        Utils.get_internal_array(x); init = Utils.zero_init(x)
+    )
 end
 
 NAN_CHECK(x::Number) = isnan(x)
@@ -41,7 +43,7 @@ function get_tolerance(::Nothing, ::Type{T}) where {T}
 end
 function get_tolerance(::Nothing, ::Type{Float64})
     # trimming hangs up on the literal_pow to rational numbers here
-    η = real(oneunit(Float64)) * 3e-13
+    η = real(oneunit(Float64)) * 3.0e-13
     return get_tolerance(η, Float64)
 end
 

--- a/lib/NonlinearSolveBase/src/descent/common.jl
+++ b/lib/NonlinearSolveBase/src/descent/common.jl
@@ -28,7 +28,7 @@ end
 function DescentResult(;
         δu = missing, u = missing, success::Bool = true, linsolve_success::Bool = true,
         extras = (;)
-)
+    )
     @assert δu !== missing || u !== missing
     return DescentResult(δu, u, success, linsolve_success, extras)
 end

--- a/lib/NonlinearSolveBase/src/descent/damped_newton.jl
+++ b/lib/NonlinearSolveBase/src/descent/damped_newton.jl
@@ -48,13 +48,13 @@ function InternalAPI.init(
         timer = get_timer_output(),
         alias_J::Bool = true, shared::Val = Val(1),
         kwargs...
-)
+    )
     length(fu) != length(u) &&
         @assert pre_inverted isa Val{false} "Precomputed Inverse for Non-Square Jacobian doesn't make sense."
 
     @bb δu = similar(u)
     δus = Utils.unwrap_val(shared) ≤ 1 ? nothing : map(2:Utils.unwrap_val(shared)) do i
-        @bb δu_ = similar(u)
+            @bb δu_ = similar(u)
     end
 
     normal_form_damping = returns_norm_form_damping(alg.damping_fn)
@@ -150,7 +150,7 @@ end
 function InternalAPI.solve!(
         cache::DampedNewtonDescentCache, J, fu, u, idx::Val = Val(1);
         skip_solve::Bool = false, new_jacobian::Bool = true, kwargs...
-)
+    )
     δu = SciMLBase.get_du(cache, idx)
     skip_solve && return DescentResult(; δu)
 

--- a/lib/NonlinearSolveBase/src/descent/dogleg.jl
+++ b/lib/NonlinearSolveBase/src/descent/dogleg.jl
@@ -15,8 +15,10 @@ end
 supports_trust_region(::Dogleg) = true
 get_linear_solver(alg::Dogleg) = get_linear_solver(alg.newton_descent)
 
-function Dogleg(; linsolve = nothing, damping = Val(false),
-        damping_fn = missing, initial_damping = missing, kwargs...)
+function Dogleg(;
+        linsolve = nothing, damping = Val(false),
+        damping_fn = missing, initial_damping = missing, kwargs...
+    )
     if !Utils.unwrap_val(damping)
         return Dogleg(NewtonDescent(; linsolve), SteepestDescent(; linsolve))
     end
@@ -51,7 +53,7 @@ function InternalAPI.init(
         pre_inverted::Val = Val(false), linsolve_kwargs = (;),
         abstol = nothing, reltol = nothing, internalnorm::F = L2_NORM,
         shared::Val = Val(1), kwargs...
-) where {F}
+    ) where {F}
     newton_cache = InternalAPI.init(
         prob, alg.newton_descent, J, fu, u;
         pre_inverted, linsolve_kwargs, abstol, reltol, shared, kwargs...
@@ -63,14 +65,14 @@ function InternalAPI.init(
 
     @bb δu = similar(u)
     δus = Utils.unwrap_val(shared) ≤ 1 ? nothing : map(2:Utils.unwrap_val(shared)) do i
-        @bb δu_ = similar(u)
+            @bb δu_ = similar(u)
     end
     @bb δu_cache_1 = similar(u)
     @bb δu_cache_2 = similar(u)
     @bb δu_cache_mul = similar(u)
 
     normal_form = prob isa NonlinearLeastSquaresProblem &&
-                  needs_square_A(alg.newton_descent.linsolve, u)
+        needs_square_A(alg.newton_descent.linsolve, u)
 
     Jᵀδu_cache = !normal_form ? J * Utils.safe_vec(δu) : nothing
 
@@ -84,8 +86,8 @@ end
 function InternalAPI.solve!(
         cache::DoglegCache, J, fu, u, idx::Val = Val(1);
         trust_region = nothing, skip_solve::Bool = false, kwargs...
-)
-    @assert trust_region!==nothing "Trust Region must be specified for Dogleg. Use \
+    )
+    @assert trust_region !== nothing "Trust Region must be specified for Dogleg. Use \
                                     `NewtonDescent` or `SteepestDescent` if you don't \
                                     want to use a Trust Region."
 

--- a/lib/NonlinearSolveBase/src/descent/geodesic_acceleration.jl
+++ b/lib/NonlinearSolveBase/src/descent/geodesic_acceleration.jl
@@ -51,7 +51,7 @@ end
 
 function InternalAPI.reinit_self!(cache::GeodesicAccelerationCache; p = cache.p, kwargs...)
     cache.p = p
-    cache.last_step_accepted = false
+    return cache.last_step_accepted = false
 end
 
 @internal_caches GeodesicAccelerationCache :descent_cache
@@ -74,11 +74,11 @@ function InternalAPI.init(
         shared::Val = Val(1), pre_inverted::Val = Val(false), linsolve_kwargs = (;),
         abstol = nothing, reltol = nothing,
         internalnorm::F = L2_NORM, kwargs...
-) where {F}
+    ) where {F}
     T = promote_type(eltype(u), eltype(fu))
     @bb δu = similar(u)
     δus = Utils.unwrap_val(shared) ≤ 1 ? nothing : map(2:Utils.unwrap_val(shared)) do i
-        @bb δu_ = similar(u)
+            @bb δu_ = similar(u)
     end
     descent_cache = InternalAPI.init(
         prob, alg.descent, J, fu, u;
@@ -98,7 +98,7 @@ end
 function InternalAPI.solve!(
         cache::GeodesicAccelerationCache, J, fu, u, idx::Val = Val(1);
         skip_solve::Bool = false, kwargs...
-)
+    )
     a = get_acceleration(cache, idx)
     v = get_velocity(cache, idx)
     δu = SciMLBase.get_du(cache, idx)
@@ -112,7 +112,7 @@ function InternalAPI.solve!(
     @bb @. cache.u_cache = u + cache.h * v
     cache.fu_cache = Utils.evaluate_f!!(cache.f, cache.fu_cache, cache.u_cache, cache.p)
 
-    J !== nothing && @bb(cache.Jv=J × vec(v))
+    J !== nothing && @bb(cache.Jv = J × vec(v))
     Jv = Utils.restructure(cache.fu_cache, cache.Jv)
     @bb @. cache.fu_cache = (2 / cache.h) * ((cache.fu_cache - fu) / cache.h - Jv)
 

--- a/lib/NonlinearSolveBase/src/descent/newton.jl
+++ b/lib/NonlinearSolveBase/src/descent/newton.jl
@@ -30,16 +30,16 @@ function InternalAPI.init(
         shared = Val(1), pre_inverted::Val = Val(false), linsolve_kwargs = (;),
         abstol = nothing, reltol = nothing,
         timer = get_timer_output(), kwargs...
-)
+    )
     @bb δu = similar(u)
     δus = Utils.unwrap_val(shared) ≤ 1 ? nothing : map(2:Utils.unwrap_val(shared)) do i
-        @bb δu_ = similar(u)
+            @bb δu_ = similar(u)
     end
 
     if Utils.unwrap_val(pre_inverted)
         lincache = nothing
     else
-        if haskey(kwargs, :verbose) 
+        if haskey(kwargs, :verbose)
             linsolve_kwargs = merge((verbose = kwargs[:verbose].linear_verbosity,), linsolve_kwargs)
         end
 
@@ -58,13 +58,13 @@ function InternalAPI.init(
         shared = Val(1), pre_inverted::Val = Val(false), linsolve_kwargs = (;),
         abstol = nothing, reltol = nothing,
         timer = get_timer_output(), kwargs...
-)
+    )
     length(fu) != length(u) &&
         @assert !Utils.unwrap_val(pre_inverted) "Precomputed Inverse for Non-Square Jacobian doesn't make sense."
 
     @bb δu = similar(u)
     δus = Utils.unwrap_val(shared) ≤ 1 ? nothing : map(2:N) do i
-        @bb δu_ = similar(u)
+            @bb δu_ = similar(u)
     end
     normal_form = needs_square_A(alg.linsolve, u)
     if normal_form
@@ -78,7 +78,8 @@ function InternalAPI.init(
 
     if haskey(kwargs, :verbose)
         linsolve_kwargs = merge(
-            (verbose = kwargs[:verbose].linear_verbosity,), linsolve_kwargs)
+            (verbose = kwargs[:verbose].linear_verbosity,), linsolve_kwargs
+        )
     end
 
     lincache = construct_linear_solver(
@@ -94,11 +95,11 @@ end
 function InternalAPI.solve!(
         cache::NewtonDescentCache, J, fu, u, idx::Val = Val(1);
         skip_solve::Bool = false, new_jacobian::Bool = true, kwargs...
-)
+    )
     δu = SciMLBase.get_du(cache, idx)
     skip_solve && return DescentResult(; δu)
     if preinverted_jacobian(cache) && !normal_form(cache)
-        @assert J!==nothing "`J` must be provided when `preinverted_jacobian = Val(true)`."
+        @assert J !== nothing "`J` must be provided when `preinverted_jacobian = Val(true)`."
         @bb δu = J × vec(fu)
     else
         if normal_form(cache)

--- a/lib/NonlinearSolveBase/src/descent/steepest.jl
+++ b/lib/NonlinearSolveBase/src/descent/steepest.jl
@@ -28,21 +28,22 @@ function InternalAPI.init(
         abstol = nothing, reltol = nothing,
         timer = get_timer_output(),
         kwargs...
-)
+    )
     if Utils.unwrap_val(pre_inverted)
-        @assert length(fu)==length(u) "Non-Square Jacobian Inverse doesn't make sense."
+        @assert length(fu) == length(u) "Non-Square Jacobian Inverse doesn't make sense."
     end
     @bb δu = similar(u)
     δus = Utils.unwrap_val(shared) ≤ 1 ? nothing : map(2:Utils.unwrap_val(shared)) do i
-        @bb δu_ = similar(u)
+            @bb δu_ = similar(u)
     end
     if Utils.unwrap_val(pre_inverted)
 
         if haskey(kwargs, :verbose)
             linsolve_kwargs = merge(
-                (verbose = kwargs[:verbose].linear_verbosity,), linsolve_kwargs)
+                (verbose = kwargs[:verbose].linear_verbosity,), linsolve_kwargs
+            )
         end
-        
+
         lincache = construct_linear_solver(
             alg, alg.linsolve, transpose(J), Utils.safe_vec(fu), Utils.safe_vec(u);
             stats, abstol, reltol, linsolve_kwargs...
@@ -56,7 +57,7 @@ end
 function InternalAPI.solve!(
         cache::SteepestDescentCache, J, fu, u, idx::Val = Val(1);
         new_jacobian::Bool = true, kwargs...
-)
+    )
     δu = SciMLBase.get_du(cache, idx)
     if Utils.unwrap_val(cache.preinverted_jacobian)
         A = J === nothing ? nothing : transpose(J)
@@ -70,7 +71,7 @@ function InternalAPI.solve!(
             return DescentResult(; δu, success = false, linsolve_success = false)
         end
     else
-        @assert J!==nothing "`J` must be provided when `preinverted_jacobian = Val(false)`."
+        @assert J !== nothing "`J` must be provided when `preinverted_jacobian = Val(false)`."
         @bb δu = transpose(J) × vec(fu)
     end
     @bb @. δu *= -1

--- a/lib/NonlinearSolveBase/src/forward_diff.jl
+++ b/lib/NonlinearSolveBase/src/forward_diff.jl
@@ -8,8 +8,8 @@
 end
 
 function NonlinearSolveBase.get_abstol(cache::NonlinearSolveForwardDiffCache)
-    NonlinearSolveBase.get_abstol(cache.cache)
+    return NonlinearSolveBase.get_abstol(cache.cache)
 end
 function NonlinearSolveBase.get_reltol(cache::NonlinearSolveForwardDiffCache)
-    NonlinearSolveBase.get_reltol(cache.cache)
+    return NonlinearSolveBase.get_reltol(cache.cache)
 end

--- a/lib/NonlinearSolveBase/src/initialization.jl
+++ b/lib/NonlinearSolveBase/src/initialization.jl
@@ -1,19 +1,21 @@
 struct NonlinearSolveDefaultInit <: SciMLBase.DAEInitializationAlgorithm end
 
 function run_initialization!(cache, initializealg = cache.initializealg, prob = cache.prob)
-    _run_initialization!(cache, initializealg, prob, SciMLBase.isinplace(cache))
+    return _run_initialization!(cache, initializealg, prob, SciMLBase.isinplace(cache))
 end
 
 function _run_initialization!(cache, ::NonlinearSolveDefaultInit, prob, isinplace::Bool)
     if SciMLBase.has_initialization_data(prob.f) &&
-       prob.f.initialization_data isa SciMLBase.OverrideInitData
+            prob.f.initialization_data isa SciMLBase.OverrideInitData
         return _run_initialization!(cache, SciMLBase.OverrideInit(), prob, isinplace)
     end
     return cache, true
 end
 
-function _run_initialization!(cache, initalg::SciMLBase.OverrideInit, prob,
-        isinplace::Bool)
+function _run_initialization!(
+        cache, initalg::SciMLBase.OverrideInit, prob,
+        isinplace::Bool
+    )
     if cache isa AbstractNonlinearSolveCache && isdefined(cache.alg, :autodiff)
         autodiff = cache.alg.autodiff
     else
@@ -25,7 +27,8 @@ function _run_initialization!(cache, initalg::SciMLBase.OverrideInit, prob,
     end
     u0, p, success = SciMLBase.get_initial_values(
         prob, cache, prob.f, initalg, Val(isinplace); nlsolve_alg = alg,
-        abstol = get_abstol(cache), reltol = get_reltol(cache))
+        abstol = get_abstol(cache), reltol = get_reltol(cache)
+    )
     cache = update_initial_values!(cache, u0, p)
     if cache isa AbstractNonlinearSolveCache && isdefined(cache, :retcode) && !success
         cache.retcode = ReturnCode.InitialFailure
@@ -35,10 +38,10 @@ function _run_initialization!(cache, initalg::SciMLBase.OverrideInit, prob,
 end
 
 function get_abstol(prob::AbstractNonlinearProblem)
-    get_tolerance(get(prob.kwargs, :abstol, nothing), eltype(SII.state_values(prob)))
+    return get_tolerance(get(prob.kwargs, :abstol, nothing), eltype(SII.state_values(prob)))
 end
 function get_reltol(prob::AbstractNonlinearProblem)
-    get_tolerance(get(prob.kwargs, :reltol, nothing), eltype(SII.state_values(prob)))
+    return get_tolerance(get(prob.kwargs, :reltol, nothing), eltype(SII.state_values(prob)))
 end
 
 initialization_alg(initprob, autodiff) = nothing
@@ -54,6 +57,7 @@ function update_initial_values!(prob::AbstractNonlinearProblem, u0, p)
 end
 
 function _run_initialization!(
-        cache::AbstractNonlinearSolveCache, ::SciMLBase.NoInit, prob, isinplace)
+        cache::AbstractNonlinearSolveCache, ::SciMLBase.NoInit, prob, isinplace
+    )
     return cache, true
 end

--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -1,4 +1,3 @@
-
 """
     construct_jacobian_cache(
         prob, alg, f, fu, u = prob.u0, p = prob.p;
@@ -35,10 +34,12 @@ function construct_jacobian_cache(
         prob, alg, f::NonlinearFunction, fu, u = prob.u0, p = prob.p; stats,
         autodiff = nothing, vjp_autodiff = nothing, jvp_autodiff = nothing,
         linsolve = missing
-)
+    )
     has_analytic_jac = SciMLBase.has_jac(f)
-    linsolve_needs_jac = !concrete_jac(alg) && (linsolve === missing ||
-                          (linsolve === nothing || needs_concrete_A(linsolve)))
+    linsolve_needs_jac = !concrete_jac(alg) && (
+        linsolve === missing ||
+            (linsolve === nothing || needs_concrete_A(linsolve))
+    )
     needs_jac = linsolve_needs_jac || concrete_jac(alg)
 
     fu_cache = Utils.safe_similar(fu)
@@ -94,7 +95,7 @@ function construct_jacobian_cache(
         prob, alg, f::NonlinearFunction, fu::Number, u::Number = prob.u0, p = prob.p; stats,
         autodiff = nothing, vjp_autodiff = nothing, jvp_autodiff = nothing,
         linsolve = missing
-)
+    )
     if SciMLBase.has_jac(f) || SciMLBase.has_vjp(f) || SciMLBase.has_jvp(f)
         return JacobianCache(fu, f, fu, p, stats, autodiff, nothing)
     end
@@ -121,7 +122,7 @@ end
 end
 
 function InternalAPI.reinit!(cache::JacobianCache; p = cache.p, kwargs...)
-    cache.p = p
+    return cache.p = p
 end
 
 # Deprecations
@@ -136,7 +137,7 @@ reused_jacobian(cache::JacobianCache{<:JacobianOperator}, u) = StatefulJacobianO
 ## Numbers
 function (cache::JacobianCache{<:Number})(u)
     cache.stats.njacs += 1
-    
+
     (; f, J, p) = cache
     cache.J = if SciMLBase.has_jac(f)
         f.jac(u, p)
@@ -179,7 +180,7 @@ end
 
 # Sparse Automatic Differentiation
 function construct_concrete_adtype(f::NonlinearFunction, ad::AbstractADType)
-    if f.sparsity === nothing
+    return if f.sparsity === nothing
         if f.jac_prototype === nothing
             if SciMLBase.has_colorvec(f)
                 @warn "`colorvec` is provided but `sparsity` and `jac_prototype` is not \
@@ -206,7 +207,7 @@ function construct_concrete_adtype(f::NonlinearFunction, ad::AbstractADType)
         if f.sparsity isa AbstractMatrix
             if f.jac_prototype !== f.sparsity
                 if f.jac_prototype !== nothing &&
-                   sparse_or_structured_prototype(f.jac_prototype)
+                        sparse_or_structured_prototype(f.jac_prototype)
                     throw(ArgumentError("`sparsity::AbstractMatrix` and a sparse or \
                                          structured `jac_prototype` cannot be both \
                                          provided. Pass only `jac_prototype`."))
@@ -255,7 +256,8 @@ function construct_concrete_adtype(::NonlinearFunction, ad::AutoSparse)
 end
 
 function select_fastest_coloring_algorithm(
-        prototype, f::NonlinearFunction, ad::AbstractADType)
+        prototype, f::NonlinearFunction, ad::AbstractADType
+    )
     if !Utils.is_extension_loaded(Val(:SparseMatrixColorings))
         @warn "`SparseMatrixColorings` must be explicitly imported for sparse automatic \
                differentiation to work. Proceeding with Dense Automatic Differentiation."

--- a/lib/NonlinearSolveBase/src/linear_solve.jl
+++ b/lib/NonlinearSolveBase/src/linear_solve.jl
@@ -73,12 +73,14 @@ function construct_linear_solver(alg, linsolve, A, b, u; stats, kwargs...)
     linprob = LinearProblem(A, b; u0 = u_cache)
     # unlias here, we will later use these as caches
     lincache = init(
-        linprob, linsolve; alias = LinearAliasSpecifier(alias_A = false, alias_b = false), kwargs...)
+        linprob, linsolve; alias = LinearAliasSpecifier(alias_A = false, alias_b = false), kwargs...
+    )
     return LinearSolveJLCache(lincache, linsolve, stats)
 end
 
 function (cache::NativeJLLinearSolveCache)(;
-        A = nothing, b = nothing, linu = nothing, kwargs...)
+        A = nothing, b = nothing, linu = nothing, kwargs...
+    )
     cache.stats.nsolve += 1
     cache.stats.nfactors += 1
 
@@ -86,7 +88,7 @@ function (cache::NativeJLLinearSolveCache)(;
     b === nothing || (cache.b = b)
 
     if linu !== nothing && ArrayInterface.can_setindex(linu) &&
-       applicable(ldiv!, linu, cache.A, cache.b) && applicable(ldiv!, cache.A, linu)
+            applicable(ldiv!, linu, cache.A, cache.b) && applicable(ldiv!, cache.A, linu)
         ldiv!(linu, cache.A, cache.b)
         res = linu
     else
@@ -101,14 +103,14 @@ function fix_incompatible_linsolve_arguments(A, b, u::SArray)
     (Core.Compiler.return_type(\, Tuple{typeof(A), typeof(b)}) <: typeof(u)) && return u
     @warn lazy"Solving Linear System A::$(typeof(A)) x::$(typeof(u)) = b::$(typeof(u)) is not \
            properly supported. Converting `x` to a mutable array. Check the return type \
-           of the nonlinear function provided for optimal performance." maxlog=1
+           of the nonlinear function provided for optimal performance." maxlog = 1
     return MArray(u)
 end
 
 set_lincache_u!(cache, u) = setproperty!(cache.lincache, :u, u)
 function set_lincache_u!(cache, u::SArray)
     cache.lincache.u isa MArray && return set_lincache_u!(cache, MArray(u))
-    cache.lincache.u = u
+    return cache.lincache.u = u
 end
 
 function wrap_preconditioners(Pl, Pr, u)

--- a/lib/NonlinearSolveBase/src/public.jl
+++ b/lib/NonlinearSolveBase/src/public.jl
@@ -25,7 +25,7 @@ function pickchunksize end
 abstract type AbstractNonlinearTerminationMode end
 abstract type AbstractSafeNonlinearTerminationMode <: AbstractNonlinearTerminationMode end
 abstract type AbstractSafeBestNonlinearTerminationMode <:
-              AbstractSafeNonlinearTerminationMode end
+AbstractSafeNonlinearTerminationMode end
 
 #! format: off
 const TERM_DOCS = Dict(
@@ -92,10 +92,10 @@ for norm_type in (:RelNorm, :AbsNorm), safety in (:Safe, :SafeBest)
     supertype_name = Symbol(:Abstract, safety, :NonlinearTerminationMode)
 
     doctring = safety == :Safe ?
-               "Essentially [`$(norm_type)TerminationMode`](@ref) + terminate if there \
+        "Essentially [`$(norm_type)TerminationMode`](@ref) + terminate if there \
                 has been no improvement for the last `patience_steps` + terminate if the \
                 solution blows up (diverges)." :
-               "Essentially [`$(norm_type)SafeTerminationMode`](@ref), but caches the best\
+        "Essentially [`$(norm_type)SafeTerminationMode`](@ref), but caches the best\
                 solution found so far."
 
     @eval begin
@@ -122,15 +122,20 @@ for norm_type in (:RelNorm, :AbsNorm), safety in (:Safe, :SafeBest)
             min_max_factor
             max_stalled_steps <: Union{Nothing, Int}
 
-            function $(struct_name)(internalnorm::F; protective_threshold = nothing,
+            function $(struct_name)(
+                    internalnorm::F; protective_threshold = nothing,
                     patience_steps = 100, patience_objective_multiplier = 3,
-                    min_max_factor = 1.3, max_stalled_steps = nothing) where {F}
+                    min_max_factor = 1.3, max_stalled_steps = nothing
+                ) where {F}
                 norm = Utils.standardize_norm(internalnorm)
-                return new{typeof(norm), typeof(protective_threshold),
+                return new{
+                    typeof(norm), typeof(protective_threshold),
                     typeof(patience_objective_multiplier),
-                    typeof(min_max_factor), typeof(max_stalled_steps)}(
+                    typeof(min_max_factor), typeof(max_stalled_steps),
+                }(
                     norm, protective_threshold, patience_steps,
-                    patience_objective_multiplier, min_max_factor, max_stalled_steps)
+                    patience_objective_multiplier, min_max_factor, max_stalled_steps
+                )
             end
         end
     end

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -44,8 +44,10 @@ problems.
     For more information, see the documentation for SciMLSensitivity:
     https://docs.sciml.ai/SciMLSensitivity/stable/
 """
-function solve(prob::AbstractNonlinearProblem, args...; sensealg = nothing,
-        u0 = nothing, p = nothing, wrap = Val(true), verbose = NonlinearVerbosity(), kwargs...)
+function solve(
+        prob::AbstractNonlinearProblem, args...; sensealg = nothing,
+        u0 = nothing, p = nothing, wrap = Val(true), verbose = NonlinearVerbosity(), kwargs...
+    )
     if sensealg === nothing && haskey(prob.kwargs, :sensealg)
         sensealg = prob.kwargs[:sensealg]
     end
@@ -83,18 +85,23 @@ function solve(prob::AbstractNonlinearProblem, args...; sensealg = nothing,
     u0 = u0 !== nothing ? u0 : prob.u0
     p = p !== nothing ? p : prob.p
 
-    if wrap isa Val{true}
-        wrap_sol(solve_up(prob,
-            sensealg,
-            u0,
-            p,
-            args...;
-            alias = alias_spec,
-            originator = SciMLBase.set_mooncakeoriginator_if_mooncake(SciMLBase.ChainRulesOriginator()),
-            verbose,
-            kwargs...))
+    return if wrap isa Val{true}
+        wrap_sol(
+            solve_up(
+                prob,
+                sensealg,
+                u0,
+                p,
+                args...;
+                alias = alias_spec,
+                originator = SciMLBase.set_mooncakeoriginator_if_mooncake(SciMLBase.ChainRulesOriginator()),
+                verbose,
+                kwargs...
+            )
+        )
     else
-        solve_up(prob,
+        solve_up(
+            prob,
             sensealg,
             u0,
             p,
@@ -102,15 +109,18 @@ function solve(prob::AbstractNonlinearProblem, args...; sensealg = nothing,
             alias = alias_spec,
             originator = SciMLBase.set_mooncakeoriginator_if_mooncake(SciMLBase.ChainRulesOriginator()),
             verbose,
-            kwargs...)
+            kwargs...
+        )
     end
 end
 
-function solve_up(prob::AbstractNonlinearProblem, sensealg, u0, p,
+function solve_up(
+        prob::AbstractNonlinearProblem, sensealg, u0, p,
         args...; originator = SciMLBase.ChainRulesOriginator(),
-        kwargs...)
+        kwargs...
+    )
     alg = extract_alg(args, kwargs, has_kwargs(prob) ? prob.kwargs : kwargs)
-    if isnothing(alg) || !(alg isa AbstractNonlinearSolveAlgorithm) # Default algorithm handling
+    return if isnothing(alg) || !(alg isa AbstractNonlinearSolveAlgorithm) # Default algorithm handling
         _prob = get_concrete_problem(prob; u0 = u0, p = p, kwargs...)
         solve_call(_prob, args...; kwargs...)
     else
@@ -124,11 +134,13 @@ function solve_up(prob::AbstractNonlinearProblem, sensealg, u0, p,
     end
 end
 
-function solve_call(_prob, args...; merge_callbacks = true, kwargshandle = nothing,
-        kwargs...)
+function solve_call(
+        _prob, args...; merge_callbacks = true, kwargshandle = nothing,
+        kwargs...
+    )
     kwargshandle = kwargshandle === nothing ? KeywordArgError : kwargshandle
     kwargshandle = has_kwargs(_prob) && haskey(_prob.kwargs, :kwargshandle) ?
-                   _prob.kwargs[:kwargshandle] : kwargshandle
+        _prob.kwargs[:kwargshandle] : kwargshandle
 
     if has_kwargs(_prob)
         kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
@@ -138,9 +150,9 @@ function solve_call(_prob, args...; merge_callbacks = true, kwargshandle = nothi
 
     # Check bounds support for problems with bounds
     if (_prob isa SciMLBase.NonlinearProblem || _prob isa SciMLBase.NonlinearLeastSquaresProblem) &&
-       (hasfield(typeof(_prob), :lb) && hasfield(typeof(_prob), :ub)) &&
-       (_prob.lb !== nothing || _prob.ub !== nothing) &&
-       length(args) > 0 && !SciMLBase.allowsbounds(args[1])
+            (hasfield(typeof(_prob), :lb) && hasfield(typeof(_prob), :ub)) &&
+            (_prob.lb !== nothing || _prob.ub !== nothing) &&
+            length(args) > 0 && !SciMLBase.allowsbounds(args[1])
         error("Algorithm $(args[1]) does not support bounds. Use an algorithm with allowsbounds(alg) == true.")
     end
 
@@ -160,25 +172,30 @@ function solve_call(_prob, args...; merge_callbacks = true, kwargshandle = nothi
         end
     end
 
-    if hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) &&
-       _prob.f.f isa EvalFunc
-        Base.invokelatest(__solve, _prob, args...; kwargs...)#::T
+    return if hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) &&
+            _prob.f.f isa EvalFunc
+        Base.invokelatest(__solve, _prob, args...; kwargs...) #::T
     else
-        __solve(_prob, args...; kwargs...)#::T
+        __solve(_prob, args...; kwargs...) #::T
     end
 end
 
-function solve_call(prob::SteadyStateProblem,
+function solve_call(
+        prob::SteadyStateProblem,
         alg::AbstractNonlinearAlgorithm, args...;
-        kwargs...)
-    solve_call(NonlinearProblem(prob),
+        kwargs...
+    )
+    return solve_call(
+        NonlinearProblem(prob),
         alg, args...;
-        kwargs...)
+        kwargs...
+    )
 end
 
 function init(
         prob::AbstractNonlinearProblem, args...; sensealg = nothing,
-        u0 = nothing, p = nothing, verbose = NonlinearVerbosity(), kwargs...)
+        u0 = nothing, p = nothing, verbose = NonlinearVerbosity(), kwargs...
+    )
     if sensealg === nothing && has_kwargs(prob) && haskey(prob.kwargs, :sensealg)
         sensealg = prob.kwargs[:sensealg]
     end
@@ -216,13 +233,15 @@ function init(
     u0 = u0 !== nothing ? u0 : prob.u0
     p = p !== nothing ? p : prob.p
 
-    init_up(prob, sensealg, u0, p, args...; alias = alias_spec, verbose, kwargs...)
+    return init_up(prob, sensealg, u0, p, args...; alias = alias_spec, verbose, kwargs...)
 end
 
-function init_up(prob::AbstractNonlinearProblem,
-        sensealg, u0, p, args...; kwargs...)
+function init_up(
+        prob::AbstractNonlinearProblem,
+        sensealg, u0, p, args...; kwargs...
+    )
     alg = extract_alg(args, kwargs, has_kwargs(prob) ? prob.kwargs : kwargs)
-    if isnothing(alg) || !(alg isa AbstractNonlinearAlgorithm) # Default algorithm handling
+    return if isnothing(alg) || !(alg isa AbstractNonlinearAlgorithm) # Default algorithm handling
         _prob = get_concrete_problem(prob; u0 = u0, p = p, kwargs...)
         init_call(_prob, args...; kwargs...)
     else
@@ -231,7 +250,7 @@ function init_up(prob::AbstractNonlinearProblem,
             tstops = get(prob.kwargs, :tstops, nothing)
         end
         if !(tstops isa Union{Nothing, AbstractArray, Tuple, Real}) &&
-           !SciMLBase.allows_late_binding_tstops(alg)
+                !SciMLBase.allows_late_binding_tstops(alg)
             throw(LateBindingTstopsNotSupportedError())
         end
         _prob = get_concrete_problem(prob; u0 = u0, p = p, kwargs...)
@@ -244,26 +263,29 @@ function init_up(prob::AbstractNonlinearProblem,
     end
 end
 
-function init_call(_prob, args...; merge_callbacks=true, kwargshandle=nothing,
-    kwargs...)
+function init_call(
+        _prob, args...; merge_callbacks = true, kwargshandle = nothing,
+        kwargs...
+    )
     kwargshandle = kwargshandle === nothing ? KeywordArgError : kwargshandle
     kwargshandle = has_kwargs(_prob) && haskey(_prob.kwargs, :kwargshandle) ?
-                   _prob.kwargs[:kwargshandle] : kwargshandle
+        _prob.kwargs[:kwargshandle] : kwargshandle
     if has_kwargs(_prob)
         kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
     end
 
     checkkwargs(kwargshandle; kwargs...)
-    if hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) &&
-           _prob.f.f isa EvalFunc
-        Base.invokelatest(__init, _prob, args...; kwargs...)#::T
+    return if hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) &&
+            _prob.f.f isa EvalFunc
+        Base.invokelatest(__init, _prob, args...; kwargs...) #::T
     else
-        __init(_prob, args...; kwargs...)#::T
+        __init(_prob, args...; kwargs...) #::T
     end
 end
 
 function SciMLBase.__solve(
-        prob::AbstractNonlinearProblem, alg::AbstractNonlinearSolveAlgorithm, args...; kwargs...)
+        prob::AbstractNonlinearProblem, alg::AbstractNonlinearSolveAlgorithm, args...; kwargs...
+    )
     cache = SciMLBase.__init(prob, alg, args...; kwargs...)
     sol = CommonSolve.solve!(cache)
 
@@ -303,15 +325,18 @@ function CommonSolve.solve!(cache::AbstractNonlinearSolveCache)
 end
 
 @generated function CommonSolve.solve!(cache::NonlinearSolvePolyAlgorithmCache{Val{N}}) where {N}
-    calls = [quote
-        1 ≤ cache.current ≤ $(N) || error("Current choices shouldn't get here!")
-    end]
+    calls = [
+        quote
+            1 ≤ cache.current ≤ $(N) || error("Current choices shouldn't get here!")
+        end,
+    ]
 
     cache_syms = [gensym("cache") for i in 1:N]
     sol_syms = [gensym("sol") for i in 1:N]
     u_result_syms = [gensym("u_result") for i in 1:N]
 
-    push!(calls,
+    push!(
+        calls,
         quote
             if cache.retcode == ReturnCode.InitialFailure
                 u = $(SII.state_values)(cache)
@@ -320,10 +345,12 @@ end
                     retcode = cache.retcode
                 )
             end
-        end)
+        end
+    )
 
     for i in 1:N
-        push!(calls,
+        push!(
+            calls,
             quote
                 $(cache_syms[i]) = cache.caches[$(i)]
                 if $(i) == cache.current
@@ -349,27 +376,33 @@ end
                     end
                     cache.current = $(i + 1)
                 end
-            end)
+            end
+        )
     end
 
     resids = map(Base.Fix2(Symbol, :resid), cache_syms)
     for (sym, resid) in zip(cache_syms, resids)
         push!(calls, :($(resid) = @isdefined($(sym)) ? $(sym).resid : nothing))
     end
-    push!(calls, quote
-        fus = tuple($(Tuple(resids)...))
-        minfu, idx = findmin_caches(cache.prob, fus)
-    end)
+    push!(
+        calls, quote
+            fus = tuple($(Tuple(resids)...))
+            minfu, idx = findmin_caches(cache.prob, fus)
+        end
+    )
     for i in 1:N
-        push!(calls,
+        push!(
+            calls,
             quote
                 if idx == $(i)
                     u = cache.alias_u0 ? $(u_result_syms[i]) :
                         NonlinearSolveBase.get_u(cache.caches[$(i)])
                 end
-            end)
+            end
+        )
     end
-    push!(calls,
+    push!(
+        calls,
         quote
             retcode = cache.caches[idx].retcode
             if cache.alias_u0
@@ -380,21 +413,24 @@ end
                 cache.prob, cache.alg, u, fus[idx];
                 retcode, cache.stats, cache.caches[idx].trace
             )
-        end)
+        end
+    )
 
     return Expr(:block, calls...)
 end
 
 function SciMLBase.__solve(
         prob::AbstractNonlinearProblem, alg::NonlinearSolvePolyAlgorithm,
-        args...; kwargs...)
-    __generated_polysolve(prob, alg, args...; kwargs...)
+        args...; kwargs...
+    )
+    return __generated_polysolve(prob, alg, args...; kwargs...)
 end
 
 function SciMLBase.__solve(
         prob::AbstractNonlinearProblem, args...; default_set = false, second_time = false,
-        kwargs...)
-    if second_time
+        kwargs...
+    )
+    return if second_time
         throw(NoDefaultAlgorithmError())
     elseif length(args) > 0 && !(first(args) isa AbstractNonlinearAlgorithm)
         throw(NonSolverError())
@@ -403,12 +439,16 @@ function SciMLBase.__solve(
     end
 end
 
-function __init(prob::AbstractNonlinearProblem, args...; default_set = false, second_time = false,
-        kwargs...)
-    if second_time
+function __init(
+        prob::AbstractNonlinearProblem, args...; default_set = false, second_time = false,
+        kwargs...
+    )
+    return if second_time
         throw(NoDefaultAlgorithmError())
-    elseif length(args) > 0 && !(first(args) isa
-             Union{Nothing, AbstractDEAlgorithm, AbstractNonlinearAlgorithm})
+    elseif length(args) > 0 && !(
+            first(args) isa
+                Union{Nothing, AbstractDEAlgorithm, AbstractNonlinearAlgorithm}
+        )
         throw(NonSolverError())
     else
         __init(prob, nothing, args...; default_set = false, second_time = true, kwargs...)
@@ -419,7 +459,7 @@ end
         prob::AbstractNonlinearProblem, alg::NonlinearSolvePolyAlgorithm{Val{N}}, args...;
         stats = NLStats(0, 0, 0, 0, 0), alias = NonlinearAliasSpecifier(alias_u0 = false), verbose = NonlinearVerbosity(),
         initializealg = NonlinearSolveDefaultInit(), kwargs...
-) where {N}
+    ) where {N}
 
     if verbose isa Bool
         if verbose
@@ -430,38 +470,46 @@ end
     elseif verbose isa AbstractVerbosityPreset
         verbose = NonlinearVerbosity(verbose)
     end
-    
+
     sol_syms = [gensym("sol") for _ in 1:N]
     prob_syms = [gensym("prob") for _ in 1:N]
     u_result_syms = [gensym("u_result") for _ in 1:N]
-    calls = [quote
-        alias_u0 = alias.alias_u0
-        current = alg.start_index
-        if alias_u0 && !ArrayInterface.ismutable(prob.u0)
-            @SciMLMessage("`alias_u0` has been set to `true`, but `u0` is
+    calls = [
+        quote
+            alias_u0 = alias.alias_u0
+            current = alg.start_index
+            if alias_u0 && !ArrayInterface.ismutable(prob.u0)
+                @SciMLMessage("`alias_u0` has been set to `true`, but `u0` is
             immutable (checked using `ArrayInterface.ismutable``).", verbose, :alias_u0_immutable)
-            alias_u0 = false  # If immutable don't care about aliasing
-        end
-    end]
+                alias_u0 = false  # If immutable don't care about aliasing
+            end
+        end,
+    ]
 
-    push!(calls,
+    push!(
+        calls,
         quote
             prob, success = $(run_initialization!)(prob, initializealg, prob)
             if !success
                 u = $(SII.state_values)(prob)
                 return build_solution_less_specialize(
                     prob, alg, u, $(Utils.evaluate_f)(prob, u);
-                    retcode = $(ReturnCode.InitialFailure))
+                    retcode = $(ReturnCode.InitialFailure)
+                )
             end
-        end)
+        end
+    )
 
-    push!(calls, quote
-        u0 = prob.u0
-        u0_aliased = alias_u0 ? zero(u0) : u0
-    end)
+    push!(
+        calls, quote
+            u0 = prob.u0
+            u0_aliased = alias_u0 ? zero(u0) : u0
+        end
+    )
     for i in 1:N
         cur_sol = sol_syms[i]
-        push!(calls,
+        push!(
+            calls,
             quote
                 if current == $(i)
                     if alias_u0
@@ -475,7 +523,7 @@ end
                         stats, alias_u0, verbose, kwargs...
                     )
                     if SciMLBase.successful_retcode($(cur_sol)) &&
-                       $(cur_sol).retcode !== ReturnCode.StalledSuccess
+                            $(cur_sol).retcode !== ReturnCode.StalledSuccess
                         if alias_u0
                             copyto!(u0, $(cur_sol).u)
                             $(u_result_syms[i]) = u0
@@ -493,7 +541,8 @@ end
                     end
                     current = $(i + 1)
                 end
-            end)
+            end
+        )
     end
 
     resids = map(Base.Fix2(Symbol, :resid), sol_syms)
@@ -501,13 +550,16 @@ end
         push!(calls, :($(resid) = @isdefined($(sym)) ? $(sym).resid : nothing))
     end
 
-    push!(calls, quote
-        resids = tuple($(Tuple(resids)...))
-        minfu, idx = findmin_resids(prob, resids)
-    end)
+    push!(
+        calls, quote
+            resids = tuple($(Tuple(resids)...))
+            minfu, idx = findmin_resids(prob, resids)
+        end
+    )
 
     for i in 1:N
-        push!(calls,
+        push!(
+            calls,
             quote
                 if idx == $(i)
                     if alias_u0
@@ -522,7 +574,8 @@ end
                         $(sol_syms[i]).trace, original = $(sol_syms[i])
                     )
                 end
-            end)
+            end
+        )
     end
     push!(calls, :(error("Current choices shouldn't get here!")))
 
@@ -561,7 +614,7 @@ function CommonSolve.step!(cache::AbstractNonlinearSolveCache, args...; kwargs..
         cache.total_time += time() - time_start
 
         if !cache.force_stop && cache.retcode == ReturnCode.Default &&
-           cache.total_time ≥ cache.maxtime
+                cache.total_time ≥ cache.maxtime
             cache.retcode = ReturnCode.MaxTime
             cache.force_stop = true
         end
@@ -588,10 +641,10 @@ end
 end
 
 function get_abstol(cache::NonlinearSolveNoInitCache)
-    get(cache.kwargs, :abstol, get_tolerance(nothing, eltype(cache.prob.u0)))
+    return get(cache.kwargs, :abstol, get_tolerance(nothing, eltype(cache.prob.u0)))
 end
 function get_reltol(cache::NonlinearSolveNoInitCache)
-    get(cache.kwargs, :reltol, get_tolerance(nothing, eltype(cache.prob.u0)))
+    return get(cache.kwargs, :reltol, get_tolerance(nothing, eltype(cache.prob.u0)))
 end
 
 SII.parameter_values(cache::NonlinearSolveNoInitCache) = SII.parameter_values(cache.prob)
@@ -605,23 +658,24 @@ get_u(cache::NonlinearSolveNoInitCache) = SII.state_values(cache.prob)
 
 function SciMLBase.reinit!(
         cache::NonlinearSolveNoInitCache, u0 = cache.prob.u0; p = cache.prob.p, kwargs...
-)
+    )
     cache.prob = SciMLBase.remake(cache.prob; u0, p)
     cache.kwargs = merge(cache.kwargs, kwargs)
     return cache
 end
 
 function Base.show(io::IO, ::MIME"text/plain", cache::NonlinearSolveNoInitCache)
-    print(io, "NonlinearSolveNoInitCache(alg = $(cache.alg))")
+    return print(io, "NonlinearSolveNoInitCache(alg = $(cache.alg))")
 end
 
 function SciMLBase.__init(
         prob::AbstractNonlinearProblem, alg::AbstractNonlinearSolveAlgorithm, args...;
         initializealg = NonlinearSolveDefaultInit(), verbose = NonlinearVerbosity(),
         kwargs...
-)
+    )
     cache = NonlinearSolveNoInitCache(
-        prob, alg, args, kwargs, initializealg, ReturnCode.Default, verbose)
+        prob, alg, args, kwargs, initializealg, ReturnCode.Default, verbose
+    )
     run_initialization!(cache)
     return cache
 end
@@ -630,13 +684,16 @@ function CommonSolve.solve!(cache::NonlinearSolveNoInitCache)
     if cache.retcode == ReturnCode.InitialFailure
         u = SII.state_values(cache)
         return SciMLBase.build_solution(
-            cache.prob, cache.alg, u, Utils.evaluate_f(cache.prob, u); cache.retcode)
+            cache.prob, cache.alg, u, Utils.evaluate_f(cache.prob, u); cache.retcode
+        )
     end
     return CommonSolve.solve(cache.prob, cache.alg, cache.args...; cache.kwargs...)
 end
 
-function _solve_adjoint(prob, sensealg, u0, p, originator, args...; merge_callbacks = true,
-        kwargs...)
+function _solve_adjoint(
+        prob, sensealg, u0, p, originator, args...; merge_callbacks = true,
+        kwargs...
+    )
     alg = extract_alg(args, kwargs, prob.kwargs)
     _prob = get_concrete_problem(prob; u0 = u0, p = p, kwargs...)
 
@@ -644,16 +701,20 @@ function _solve_adjoint(prob, sensealg, u0, p, originator, args...; merge_callba
         kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
     end
 
-    if length(args) > 1
-        _concrete_solve_adjoint(_prob, alg, sensealg, u0, p, originator,
-            Base.tail(args)...; kwargs...)
+    return if length(args) > 1
+        _concrete_solve_adjoint(
+            _prob, alg, sensealg, u0, p, originator,
+            Base.tail(args)...; kwargs...
+        )
     else
         _concrete_solve_adjoint(_prob, alg, sensealg, u0, p, originator; kwargs...)
     end
 end
 
-function _solve_forward(prob, sensealg, u0, p, originator, args...; merge_callbacks = true,
-        kwargs...)
+function _solve_forward(
+        prob, sensealg, u0, p, originator, args...; merge_callbacks = true,
+        kwargs...
+    )
     alg = extract_alg(args, kwargs, prob.kwargs)
     _prob = get_concrete_problem(prob; u0 = u0, p = p, kwargs...)
 
@@ -661,9 +722,11 @@ function _solve_forward(prob, sensealg, u0, p, originator, args...; merge_callba
         kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
     end
 
-    if length(args) > 1
-        _concrete_solve_forward(_prob, alg, sensealg, u0, p, originator,
-            Base.tail(args)...; kwargs...)
+    return if length(args) > 1
+        _concrete_solve_forward(
+            _prob, alg, sensealg, u0, p, originator,
+            Base.tail(args)...; kwargs...
+        )
     else
         _concrete_solve_forward(_prob, alg, sensealg, u0, p, originator; kwargs...)
     end
@@ -678,7 +741,7 @@ function get_concrete_problem(prob::NonlinearProblem; kwargs...)
     p = get_concrete_p(prob, kwargs)
     u0 = get_concrete_u0(prob, true, nothing, kwargs)
     u0 = promote_u0(u0, p, nothing)
-    remake(prob; u0 = u0, p = p)
+    return remake(prob; u0 = u0, p = p)
 end
 
 function get_concrete_problem(prob::NonlinearLeastSquaresProblem; kwargs...)
@@ -690,7 +753,7 @@ function get_concrete_problem(prob::NonlinearLeastSquaresProblem; kwargs...)
     p = get_concrete_p(prob, kwargs)
     u0 = get_concrete_u0(prob, true, nothing, kwargs)
     u0 = promote_u0(u0, p, nothing)
-    remake(prob; u0 = u0, p = p)
+    return remake(prob; u0 = u0, p = p)
 end
 
 function get_concrete_problem(prob::ImmutableNonlinearProblem; kwargs...)
@@ -709,7 +772,7 @@ function get_concrete_problem(prob::SteadyStateProblem; kwargs...)
     p = get_concrete_p(prob, kwargs)
     u0 = get_concrete_u0(prob, true, Inf, kwargs)
     u0 = promote_u0(u0, p, nothing)
-    remake(prob; u0 = u0, p = p)
+    return remake(prob; u0 = u0, p = p)
 end
 
 
@@ -738,17 +801,19 @@ function build_null_solution(
         save_everystep = true,
         save_on = true,
         save_start = save_everystep || isempty(saveat) ||
-                         saveat isa Number || prob.tspan[1] in saveat,
+            saveat isa Number || prob.tspan[1] in saveat,
         save_end = true,
-        kwargs...)
+        kwargs...
+    )
     prob, success = hack_null_solution_init(prob)
     retcode = success ? ReturnCode.Success : ReturnCode.InitialFailure
-    SciMLBase.build_solution(prob, nothing, Float64[], nothing; retcode)
+    return SciMLBase.build_solution(prob, nothing, Float64[], nothing; retcode)
 end
 
 function build_null_solution(
         prob::NonlinearLeastSquaresProblem,
-        args...; abstol = 1e-6, kwargs...)
+        args...; abstol = 1.0e-6, kwargs...
+    )
     prob, success = hack_null_solution_init(prob)
     retcode = success ? ReturnCode.Success : ReturnCode.InitialFailure
 
@@ -763,7 +828,7 @@ function build_null_solution(
         retcode = norm(resid) < abstol ? ReturnCode.Success : ReturnCode.Failure
     end
 
-    SciMLBase.build_solution(prob, nothing, Float64[], resid; retcode)
+    return SciMLBase.build_solution(prob, nothing, Float64[], resid; retcode)
 end
 
 function hack_null_solution_init(prob::Union{NonlinearProblem, NonlinearLeastSquaresProblem, SteadyStateProblem})

--- a/lib/NonlinearSolveBase/src/timer_outputs.jl
+++ b/lib/NonlinearSolveBase/src/timer_outputs.jl
@@ -39,8 +39,8 @@ Enable `TimerOutput` for all `NonlinearSolve` algorithms. This is useful for deb
 but has some overhead, so it is disabled by default.
 """
 function enable_timer_outputs()
-    @set_preferences!("enable_timer_outputs"=>true)
-    @info "Timer Outputs Enabled. Restart the Julia session for this to take effect."
+    @set_preferences!("enable_timer_outputs" => true)
+    return @info "Timer Outputs Enabled. Restart the Julia session for this to take effect."
 end
 
 """
@@ -50,6 +50,6 @@ Disable `TimerOutput` for all `NonlinearSolve` algorithms. This should be used w
 `NonlinearSolve` is being used in performance-critical code.
 """
 function disable_timer_outputs()
-    @set_preferences!("enable_timer_outputs"=>false)
-    @info "Timer Outputs Disabled. Restart the Julia session for this to take effect."
+    @set_preferences!("enable_timer_outputs" => false)
+    return @info "Timer Outputs Disabled. Restart the Julia session for this to take effect."
 end

--- a/lib/NonlinearSolveBase/src/verbosity.jl
+++ b/lib/NonlinearSolveBase/src/verbosity.jl
@@ -65,9 +65,11 @@ verbose = NonlinearVerbosity(
 NonlinearVerbosity
 
 @verbosity_specifier NonlinearVerbosity begin
-    toggles = (:linear_verbosity, :non_enclosing_interval, :alias_u0_immutable,
+    toggles = (
+        :linear_verbosity, :non_enclosing_interval, :alias_u0_immutable,
         :linsolve_failed_noncurrent, :termination_condition, :threshold_state, :forcing,
-        :sensitivity_vjp_choice)
+        :sensitivity_vjp_choice,
+    )
 
     presets = (
         None = (
@@ -78,7 +80,7 @@ NonlinearVerbosity
             termination_condition = Silent(),
             threshold_state = Silent(),
             forcing = Silent(),
-            sensitivity_vjp_choice = Silent()
+            sensitivity_vjp_choice = Silent(),
         ),
         Minimal = (
             linear_verbosity = None(),
@@ -88,7 +90,7 @@ NonlinearVerbosity
             termination_condition = Silent(),
             threshold_state = Silent(),
             forcing = Silent(),
-            sensitivity_vjp_choice = Silent()
+            sensitivity_vjp_choice = Silent(),
         ),
         Standard = (
             linear_verbosity = None(),
@@ -98,7 +100,7 @@ NonlinearVerbosity
             termination_condition = WarnLevel(),
             threshold_state = WarnLevel(),
             forcing = InfoLevel(),
-            sensitivity_vjp_choice = WarnLevel()
+            sensitivity_vjp_choice = WarnLevel(),
         ),
         Detailed = (
             linear_verbosity = Detailed(),
@@ -108,7 +110,7 @@ NonlinearVerbosity
             termination_condition = WarnLevel(),
             threshold_state = WarnLevel(),
             forcing = InfoLevel(),
-            sensitivity_vjp_choice = WarnLevel()
+            sensitivity_vjp_choice = WarnLevel(),
         ),
         All = (
             linear_verbosity = Detailed(),
@@ -118,14 +120,16 @@ NonlinearVerbosity
             termination_condition = WarnLevel(),
             threshold_state = InfoLevel(),
             forcing = InfoLevel(),
-            sensitivity_vjp_choice = WarnLevel()
-        )
+            sensitivity_vjp_choice = WarnLevel(),
+        ),
     )
 
     groups = (
-        error_control = (:non_enclosing_interval, :alias_u0_immutable,
-            :linsolve_failed_noncurrent, :termination_condition),
+        error_control = (
+            :non_enclosing_interval, :alias_u0_immutable,
+            :linsolve_failed_noncurrent, :termination_condition,
+        ),
         numerical = (:threshold_state, :forcing),
-        sensitivity = (:sensitivity_vjp_choice,)
+        sensitivity = (:sensitivity_vjp_choice,),
     )
 end

--- a/lib/NonlinearSolveBase/src/wrappers.jl
+++ b/lib/NonlinearSolveBase/src/wrappers.jl
@@ -1,6 +1,6 @@
 function assert_extension_supported_termination_condition(
         termination_condition, alg; abs_norm_supported = true
-)
+    )
     no_termination_condition = termination_condition === nothing
     no_termination_condition && return nothing
     abs_norm_supported && termination_condition isa AbsNormTerminationMode && return nothing
@@ -11,14 +11,14 @@ function construct_extension_function_wrapper(
         prob::AbstractNonlinearProblem; alias_u0::Bool = false,
         can_handle_oop::Val = Val(false), can_handle_scalar::Val = Val(false),
         make_fixed_point::Val = Val(false), force_oop::Val = Val(false)
-)
+    )
     if can_handle_oop isa Val{false} && can_handle_scalar isa Val{true}
         error("Incorrect Specification: OOP not supported but scalar supported.")
     end
 
     resid = Utils.evaluate_f(prob, prob.u0)
     u0 = can_handle_scalar isa Val{true} || !(prob.u0 isa Number) ?
-         Utils.maybe_unaliased(prob.u0, alias_u0) : [prob.u0]
+        Utils.maybe_unaliased(prob.u0, alias_u0) : [prob.u0]
 
     fₚ = if make_fixed_point isa Val{true}
         if SciMLBase.isinplace(prob)
@@ -90,7 +90,7 @@ function construct_extension_jac(
         prob, alg, u0, fu;
         can_handle_oop::Val = Val(false), can_handle_scalar::Val = Val(false),
         autodiff = nothing, initial_jacobian = Val(false), kwargs...
-)
+    )
     autodiff = select_jacobian_autodiff(prob, autodiff)
 
     Jₚ = construct_jacobian_cache(
@@ -99,7 +99,7 @@ function construct_extension_jac(
     )
 
     J_no_scalar = can_handle_scalar isa Val{false} && prob.u0 isa Number ?
-                  @closure(u->[Jₚ(u[1])]) : Jₚ
+        @closure(u -> [Jₚ(u[1])]) : Jₚ
 
     J_final(J, u) = copyto!(J, J_no_scalar(u))
     J_final(u) = J_no_scalar(u)

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -23,8 +23,10 @@ using InteractiveUtils, Test
 
         @test check_no_implicit_imports(NonlinearSolveBase; skip = (Base, Core)) === nothing
         # Ignore SciMLLogging types used by @verbosity_specifier macro (ExplicitImports can't track macro usage)
-        @test check_no_stale_explicit_imports(NonlinearSolveBase;
-            ignore = (:AbstractVerbositySpecifier, :All, :Detailed, :Minimal, :None, :Standard, :SciMLLogging)) === nothing
+        @test check_no_stale_explicit_imports(
+            NonlinearSolveBase;
+            ignore = (:AbstractVerbositySpecifier, :All, :Detailed, :Minimal, :None, :Standard, :SciMLLogging)
+        ) === nothing
         @test check_all_qualified_accesses_via_owners(NonlinearSolveBase) === nothing
     end
 
@@ -44,7 +46,7 @@ using InteractiveUtils, Test
             u_unaliased = nothing
             T = Float64
             cache = NonlinearSolveBase.NonlinearTerminationModeCache(
-                u_unaliased, SciMLBase.ReturnCode.Default, 1e-8, 1e-8, Inf, mode,
+                u_unaliased, SciMLBase.ReturnCode.Default, 1.0e-8, 1.0e-8, Inf, mode,
                 nothing, nothing, 0, nothing, nothing, nothing, nothing, nothing, false
             )
             du = [1.0, 1.0]

--- a/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl
+++ b/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl
@@ -15,17 +15,17 @@ using CommonSolve: CommonSolve
 using LinearSolve: LinearSolve  # Trigger Linear Solve extension in NonlinearSolveBase
 using MaybeInplace: @bb
 using NonlinearSolveBase: NonlinearSolveBase, AbstractNonlinearSolveAlgorithm,
-                          AbstractNonlinearSolveCache, AbstractDampingFunction,
-                          AbstractDampingFunctionCache, AbstractTrustRegionMethod,
-                          AbstractTrustRegionMethodCache,
-                          Utils, InternalAPI, get_timer_output, @static_timeit,
-                          update_trace!, L2_NORM, NonlinearSolvePolyAlgorithm,
-                          NewtonDescent, DampedNewtonDescent, GeodesicAcceleration,
-                          Dogleg, NonlinearSolveForwardDiffCache, NonlinearVerbosity,
-                          @SciMLMessage, None, reused_jacobian, AbstractVerbosityPreset
+    AbstractNonlinearSolveCache, AbstractDampingFunction,
+    AbstractDampingFunctionCache, AbstractTrustRegionMethod,
+    AbstractTrustRegionMethodCache,
+    Utils, InternalAPI, get_timer_output, @static_timeit,
+    update_trace!, L2_NORM, NonlinearSolvePolyAlgorithm,
+    NewtonDescent, DampedNewtonDescent, GeodesicAcceleration,
+    Dogleg, NonlinearSolveForwardDiffCache, NonlinearVerbosity,
+    @SciMLMessage, None, reused_jacobian, AbstractVerbosityPreset
 using SciMLBase: SciMLBase, AbstractNonlinearProblem, NLStats, ReturnCode,
-                 NonlinearFunction,
-                 NonlinearLeastSquaresProblem, NonlinearProblem, NoSpecialize
+    NonlinearFunction,
+    NonlinearLeastSquaresProblem, NonlinearProblem, NoSpecialize
 using SciMLJacobianOperators: VecJacOperator, JacVecOperator, StatefulJacobianOperator
 
 using FiniteDiff: FiniteDiff    # Default Finite Difference Method
@@ -45,7 +45,7 @@ include("forward_diff.jl")
     nonlinear_functions = (
         (NonlinearFunction{false, NoSpecialize}((u, p) -> u .* u .- p), 0.1),
         (NonlinearFunction{false, NoSpecialize}((u, p) -> u .* u .- p), [0.1]),
-        (NonlinearFunction{true, NoSpecialize}((du, u, p) -> du .= u .* u .- p), [0.1])
+        (NonlinearFunction{true, NoSpecialize}((du, u, p) -> du .= u .* u .- p), [0.1]),
     )
 
     nonlinear_problems = NonlinearProblem[]
@@ -56,22 +56,25 @@ include("forward_diff.jl")
     nonlinear_functions = (
         (NonlinearFunction{false, NoSpecialize}((u, p) -> (u .^ 2 .- p)[1:1]), [0.1, 0.0]),
         (
-            NonlinearFunction{false, NoSpecialize}((
-                u, p) -> vcat(u .* u .- p, u .* u .- p)),
-            [0.1, 0.1]
+            NonlinearFunction{false, NoSpecialize}(
+                (
+                    u, p,
+                ) -> vcat(u .* u .- p, u .* u .- p)
+            ),
+            [0.1, 0.1],
         ),
         (
             NonlinearFunction{true, NoSpecialize}(
                 (du, u, p) -> du[1] = u[1] * u[1] - p, resid_prototype = zeros(1)
             ),
-            [0.1, 0.0]
+            [0.1, 0.0],
         ),
         (
             NonlinearFunction{true, NoSpecialize}(
                 (du, u, p) -> du .= vcat(u .* u .- p, u .* u .- p), resid_prototype = zeros(4)
             ),
-            [0.1, 0.1]
-        )
+            [0.1, 0.1],
+        ),
     )
 
     nlls_problems = NonlinearLeastSquaresProblem[]
@@ -86,12 +89,12 @@ include("forward_diff.jl")
         @sync begin
             for prob in nonlinear_problems, alg in nlp_algs
 
-                Threads.@spawn CommonSolve.solve(prob, alg; abstol = 1e-2, verbose = false)
+                Threads.@spawn CommonSolve.solve(prob, alg; abstol = 1.0e-2, verbose = false)
             end
 
             for prob in nlls_problems, alg in nlls_algs
 
-                Threads.@spawn CommonSolve.solve(prob, alg; abstol = 1e-2, verbose = false)
+                Threads.@spawn CommonSolve.solve(prob, alg; abstol = 1.0e-2, verbose = false)
             end
         end
     end

--- a/lib/NonlinearSolveFirstOrder/src/eisenstat_walker.jl
+++ b/lib/NonlinearSolveFirstOrder/src/eisenstat_walker.jl
@@ -25,7 +25,7 @@ to prevent ηₖ from shrinking too fast.
 end
 
 function EisenstatWalkerForcing2(; η₀ = 0.5, ηₘₐₓ = 0.9, γ = 0.9, α = 2, safeguard = true, safeguard_threshold = 0.1)
-    EisenstatWalkerForcing2(η₀, ηₘₐₓ, γ, α, safeguard, safeguard_threshold)
+    return EisenstatWalkerForcing2(η₀, ηₘₐₓ, γ, α, safeguard, safeguard_threshold)
 end
 
 
@@ -39,7 +39,6 @@ end
 end
 
 
-
 function pre_step_forcing!(cache::EisenstatWalkerForcing2Cache, descend_cache::NonlinearSolveBase.NewtonDescentCache, J, u, fu, iter)
     @SciMLMessage("Eisenstat-Walker forcing residual norm $(cache.rnorm) with rate estimate $(cache.rnorm / cache.rnorm_prev).", cache.verbosity, :forcing)
 
@@ -47,7 +46,7 @@ function pre_step_forcing!(cache::EisenstatWalkerForcing2Cache, descend_cache::N
     if iter == 0
         cache.η = cache.p.η₀
         @SciMLMessage("Eisenstat-Walker initial iteration to η=$(cache.η).", cache.verbosity, :forcing)
-        LinearSolve.update_tolerances!(descend_cache.lincache; reltol=cache.η)
+        LinearSolve.update_tolerances!(descend_cache.lincache; reltol = cache.η)
         return nothing
     end
 
@@ -62,7 +61,7 @@ function pre_step_forcing!(cache::EisenstatWalkerForcing2Cache, descend_cache::N
 
     # Safeguard 2 to prevent over-solving
     if cache.p.safeguard
-        ηsg = γ*ηprev^α
+        ηsg = γ * ηprev^α
         if ηsg > cache.p.safeguard_threshold && ηsg > cache.η
             cache.η = ηsg
         end
@@ -74,27 +73,25 @@ function pre_step_forcing!(cache::EisenstatWalkerForcing2Cache, descend_cache::N
     @SciMLMessage("Eisenstat-Walker iter $iter update to η=$(cache.η).", cache.verbosity, :forcing)
 
     # Communicate new relative tolerance to linear solve
-    LinearSolve.update_tolerances!(descend_cache.lincache; reltol=cache.η)
+    LinearSolve.update_tolerances!(descend_cache.lincache; reltol = cache.η)
 
     return nothing
 end
 
 
-
 function post_step_forcing!(cache::EisenstatWalkerForcing2Cache, J, u, fu, δu, iter)
     # Cache previous residual norm
     cache.rnorm_prev = cache.rnorm
-    cache.rnorm = cache.internalnorm(fu)
+    return cache.rnorm = cache.internalnorm(fu)
 
     # @SciMLMessage("Eisenstat-Walker sanity check: $(cache.internalnorm(fu + J*δu)) ≤ $(cache.η * cache.internalnorm(fu)).", cache.verbosity, :linear_verbosity)
 end
 
 
-
 function InternalAPI.init(
         prob::AbstractNonlinearProblem, alg::EisenstatWalkerForcing2, f, fu, u, p,
         args...; verbose, internalnorm::F = L2_NORM, kwargs...
-) where {F}
+    ) where {F}
     fu_norm = internalnorm(fu)
 
     return EisenstatWalkerForcing2Cache(
@@ -103,9 +100,8 @@ function InternalAPI.init(
 end
 
 
-
 function InternalAPI.reinit!(
         cache::EisenstatWalkerForcing2Cache; p = cache.p, kwargs...
-)
-    cache.p = p
+    )
+    return cache.p = p
 end

--- a/lib/NonlinearSolveFirstOrder/src/forward_diff.jl
+++ b/lib/NonlinearSolveFirstOrder/src/forward_diff.jl
@@ -1,18 +1,18 @@
 const DualNonlinearProblem = NonlinearProblem{
     <:Union{Number, <:AbstractArray}, iip,
-    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}}
+    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}},
 } where {iip, T, V, P}
 const DualNonlinearLeastSquaresProblem = NonlinearLeastSquaresProblem{
     <:Union{Number, <:AbstractArray}, iip,
-    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}}
+    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}},
 } where {iip, T, V, P}
 const DualAbstractNonlinearProblem = Union{
-    DualNonlinearProblem, DualNonlinearLeastSquaresProblem
+    DualNonlinearProblem, DualNonlinearLeastSquaresProblem,
 }
 
 function SciMLBase.__init(
         prob::DualAbstractNonlinearProblem, alg::GeneralizedFirstOrderAlgorithm, args...; kwargs...
-)
+    )
     p = NonlinearSolveBase.nodual_value(prob.p)
     newprob = SciMLBase.remake(prob; u0 = NonlinearSolveBase.nodual_value(prob.u0), p)
     cache = init(newprob, alg, args...; kwargs...)
@@ -23,9 +23,9 @@ end
 
 function SciMLBase.__solve(
         prob::DualAbstractNonlinearProblem, alg::GeneralizedFirstOrderAlgorithm, args...; kwargs...
-)
+    )
     sol,
-    partials = NonlinearSolveBase.nonlinearsolve_forwarddiff_solve(
+        partials = NonlinearSolveBase.nonlinearsolve_forwarddiff_solve(
         prob, alg, args...; kwargs...
     )
     dual_soln = NonlinearSolveBase.nonlinearsolve_dual_solution(sol.u, partials, prob.p)

--- a/lib/NonlinearSolveFirstOrder/src/gauss_newton.jl
+++ b/lib/NonlinearSolveFirstOrder/src/gauss_newton.jl
@@ -11,7 +11,7 @@ for large-scale and numerically-difficult nonlinear systems.
 function GaussNewton(;
         concrete_jac = nothing, linsolve = nothing, linesearch = missing,
         autodiff = nothing, vjp_autodiff = nothing, jvp_autodiff = nothing
-)
+    )
     return GeneralizedFirstOrderAlgorithm(;
         linesearch,
         descent = NewtonDescent(; linsolve),

--- a/lib/NonlinearSolveFirstOrder/src/poly_algs.jl
+++ b/lib/NonlinearSolveFirstOrder/src/poly_algs.jl
@@ -24,7 +24,7 @@ function RobustMultiNewton(
         concrete_jac = nothing,
         linsolve = nothing,
         autodiff = nothing, vjp_autodiff = nothing, jvp_autodiff = nothing
-) where {T}
+    ) where {T}
     common_kwargs = (; concrete_jac, linsolve, autodiff, vjp_autodiff, jvp_autodiff)
     if T <: Complex # Let's atleast have something here for complex numbers
         algs = (
@@ -37,7 +37,7 @@ function RobustMultiNewton(
             NewtonRaphson(; common_kwargs...),
             NewtonRaphson(; common_kwargs..., linesearch = BackTracking()),
             TrustRegion(; common_kwargs..., radius_update_scheme = RUS.NLsolve),
-            TrustRegion(; common_kwargs..., radius_update_scheme = RUS.Fan)
+            TrustRegion(; common_kwargs..., radius_update_scheme = RUS.Fan),
         )
     end
     return NonlinearSolvePolyAlgorithm(algs)

--- a/lib/NonlinearSolveFirstOrder/src/pseudo_transient.jl
+++ b/lib/NonlinearSolveFirstOrder/src/pseudo_transient.jl
@@ -18,10 +18,10 @@ This implementation specifically uses "switched evolution relaxation"
     you are going to need more iterations to converge but it can be more stable.
 """
 function PseudoTransient(;
-        concrete_jac = nothing, linesearch = missing, alpha_initial = 1e-3,
+        concrete_jac = nothing, linesearch = missing, alpha_initial = 1.0e-3,
         linsolve = nothing,
         autodiff = nothing, jvp_autodiff = nothing, vjp_autodiff = nothing
-)
+    )
     return GeneralizedFirstOrderAlgorithm(;
         linesearch,
         descent = DampedNewtonDescent(;
@@ -55,13 +55,19 @@ Cache for the [`SwitchedEvolutionRelaxation`](@ref) method.
     internalnorm
 end
 
-function NonlinearSolveBase.requires_normal_form_jacobian(::Union{
-        SwitchedEvolutionRelaxation, SwitchedEvolutionRelaxationCache})
+function NonlinearSolveBase.requires_normal_form_jacobian(
+        ::Union{
+            SwitchedEvolutionRelaxation, SwitchedEvolutionRelaxationCache,
+        }
+    )
     return false
 end
 
-function NonlinearSolveBase.requires_normal_form_rhs(::Union{
-        SwitchedEvolutionRelaxation, SwitchedEvolutionRelaxationCache})
+function NonlinearSolveBase.requires_normal_form_rhs(
+        ::Union{
+            SwitchedEvolutionRelaxation, SwitchedEvolutionRelaxationCache,
+        }
+    )
     return false
 end
 
@@ -69,7 +75,7 @@ function InternalAPI.init(
         prob::AbstractNonlinearProblem, f::SwitchedEvolutionRelaxation,
         initial_damping, J, fu, u, args...;
         internalnorm::F = L2_NORM, kwargs...
-) where {F}
+    ) where {F}
     T = promote_type(eltype(u), eltype(fu))
     return SwitchedEvolutionRelaxationCache(
         internalnorm(fu), T(inv(initial_damping)), internalnorm
@@ -80,7 +86,7 @@ end
 
 function InternalAPI.solve!(
         damping::SwitchedEvolutionRelaxationCache, J, fu, args...; kwargs...
-)
+    )
     res_norm = damping.internalnorm(fu)
     damping.α⁻¹ *= res_norm / damping.res_norm
     damping.res_norm = res_norm

--- a/lib/NonlinearSolveFirstOrder/src/raphson.jl
+++ b/lib/NonlinearSolveFirstOrder/src/raphson.jl
@@ -31,7 +31,7 @@ function NewtonRaphson(;
         concrete_jac = nothing, linsolve = nothing, linesearch = missing,
         autodiff = nothing, vjp_autodiff = nothing, jvp_autodiff = nothing,
         forcing = nothing,
-)
+    )
     return GeneralizedFirstOrderAlgorithm(;
         linesearch,
         descent = NewtonDescent(; linsolve),

--- a/lib/NonlinearSolveFirstOrder/src/trust_region.jl
+++ b/lib/NonlinearSolveFirstOrder/src/trust_region.jl
@@ -30,7 +30,7 @@ function TrustRegion(;
         shrink_factor::Real = 1 // 4, expand_factor::Real = 2 // 1,
         max_shrink_times::Int = 32,
         autodiff = nothing, vjp_autodiff = nothing, jvp_autodiff = nothing,
-)
+    )
     descent = Dogleg(; linsolve)
     trustregion = GenericTrustRegionScheme(;
         method = radius_update_scheme, step_threshold, shrink_threshold, expand_threshold,
@@ -57,90 +57,90 @@ Simply put the desired scheme as follows:
 `sol = solve(prob, alg = TrustRegion(radius_update_scheme = RadiusUpdateSchemes.Hei))`.
 """
 module RadiusUpdateSchemes
-# The weird definitions here are needed to main compatibility with the older enum variants
+    # The weird definitions here are needed to main compatibility with the older enum variants
 
-abstract type AbstractRadiusUpdateScheme end
+    abstract type AbstractRadiusUpdateScheme end
 
-function Base.show(io::IO, rus::AbstractRadiusUpdateScheme)
-    print(io, "RadiusUpdateSchemes.$(string(nameof(typeof(rus)))[3:end])")
-end
+    function Base.show(io::IO, rus::AbstractRadiusUpdateScheme)
+        return print(io, "RadiusUpdateSchemes.$(string(nameof(typeof(rus)))[3:end])")
+    end
 
-const T = AbstractRadiusUpdateScheme
+    const T = AbstractRadiusUpdateScheme
 
-struct __Simple <: AbstractRadiusUpdateScheme end
-"""
-    RadiusUpdateSchemes.Simple
+    struct __Simple <: AbstractRadiusUpdateScheme end
+    """
+        RadiusUpdateSchemes.Simple
 
-The simple or conventional radius update scheme. This scheme is chosen by default and
-follows the conventional approach to update the trust region radius, i.e. if the trial
-step is accepted it increases the radius by a fixed factor (bounded by a maximum radius)
-and if the trial step is rejected, it shrinks the radius by a fixed factor.
-"""
-const Simple = __Simple()
+    The simple or conventional radius update scheme. This scheme is chosen by default and
+    follows the conventional approach to update the trust region radius, i.e. if the trial
+    step is accepted it increases the radius by a fixed factor (bounded by a maximum radius)
+    and if the trial step is rejected, it shrinks the radius by a fixed factor.
+    """
+    const Simple = __Simple()
 
-struct __NLsolve <: AbstractRadiusUpdateScheme end
-"""
-    RadiusUpdateSchemes.NLsolve
+    struct __NLsolve <: AbstractRadiusUpdateScheme end
+    """
+        RadiusUpdateSchemes.NLsolve
 
-The same updating scheme as in NLsolve's (https://github.com/JuliaNLSolvers/NLsolve.jl)
-trust region dogleg implementation.
-"""
-const NLsolve = __NLsolve()
+    The same updating scheme as in NLsolve's (https://github.com/JuliaNLSolvers/NLsolve.jl)
+    trust region dogleg implementation.
+    """
+    const NLsolve = __NLsolve()
 
-struct __NocedalWright <: AbstractRadiusUpdateScheme end
-"""
-    RadiusUpdateSchemes.NocedalWright
+    struct __NocedalWright <: AbstractRadiusUpdateScheme end
+    """
+        RadiusUpdateSchemes.NocedalWright
 
-Trust region updating scheme as in Nocedal and Wright [see Alg 11.5, page 291].
-"""
-const NocedalWright = __NocedalWright()
+    Trust region updating scheme as in Nocedal and Wright [see Alg 11.5, page 291].
+    """
+    const NocedalWright = __NocedalWright()
 
-struct __Hei <: AbstractRadiusUpdateScheme end
-"""
-    RadiusUpdateSchemes.Hei
+    struct __Hei <: AbstractRadiusUpdateScheme end
+    """
+        RadiusUpdateSchemes.Hei
 
-This scheme is proposed in [hei2003self](@citet). The trust region radius depends on the
-size (norm) of the current step size. The hypothesis is to let the radius converge to zero
-as the iterations progress, which is more reliable and robust for ill-conditioned as well
-as degenerate problems.
-"""
-const Hei = __Hei()
+    This scheme is proposed in [hei2003self](@citet). The trust region radius depends on the
+    size (norm) of the current step size. The hypothesis is to let the radius converge to zero
+    as the iterations progress, which is more reliable and robust for ill-conditioned as well
+    as degenerate problems.
+    """
+    const Hei = __Hei()
 
-struct __Yuan <: AbstractRadiusUpdateScheme end
-"""
-    RadiusUpdateSchemes.Yuan
+    struct __Yuan <: AbstractRadiusUpdateScheme end
+    """
+        RadiusUpdateSchemes.Yuan
 
-This scheme is proposed by [yuan2015recent](@citet). Similar to Hei's scheme, the
-trust region is updated in a way so that it converges to zero, however here, the radius
-depends on the size (norm) of the current gradient of the objective (merit) function. The
-hypothesis is that the step size is bounded by the gradient size, so it makes sense to let
-the radius depend on the gradient.
-"""
-const Yuan = __Yuan()
+    This scheme is proposed by [yuan2015recent](@citet). Similar to Hei's scheme, the
+    trust region is updated in a way so that it converges to zero, however here, the radius
+    depends on the size (norm) of the current gradient of the objective (merit) function. The
+    hypothesis is that the step size is bounded by the gradient size, so it makes sense to let
+    the radius depend on the gradient.
+    """
+    const Yuan = __Yuan()
 
-struct __Bastin <: AbstractRadiusUpdateScheme end
-"""
-    RadiusUpdateSchemes.Bastin
+    struct __Bastin <: AbstractRadiusUpdateScheme end
+    """
+        RadiusUpdateSchemes.Bastin
 
-This scheme is proposed by [bastin2010retrospective](@citet). The scheme is called a
-retrospective update scheme as it uses the model function at the current iteration to
-compute the ratio of the actual reduction and the predicted reduction in the previous trial
-step, and use this ratio to update the trust region radius. The hypothesis is to exploit the
-information made available during the optimization process in order to vary the accuracy
-of the objective function computation.
-"""
-const Bastin = __Bastin()
+    This scheme is proposed by [bastin2010retrospective](@citet). The scheme is called a
+    retrospective update scheme as it uses the model function at the current iteration to
+    compute the ratio of the actual reduction and the predicted reduction in the previous trial
+    step, and use this ratio to update the trust region radius. The hypothesis is to exploit the
+    information made available during the optimization process in order to vary the accuracy
+    of the objective function computation.
+    """
+    const Bastin = __Bastin()
 
-struct __Fan <: AbstractRadiusUpdateScheme end
-"""
-    RadiusUpdateSchemes.Fan
+    struct __Fan <: AbstractRadiusUpdateScheme end
+    """
+        RadiusUpdateSchemes.Fan
 
-This scheme is proposed by [fan2006convergence](@citet). It is very much similar to Hei's
-and Yuan's schemes as it lets the trust region radius depend on the current size (norm) of
-the objective (merit) function itself. These new update schemes are known to improve local
-convergence.
-"""
-const Fan = __Fan()
+    This scheme is proposed by [fan2006convergence](@citet). It is very much similar to Hei's
+    and Yuan's schemes as it lets the trust region radius depend on the current size (norm) of
+    the objective (merit) function itself. These new update schemes are known to improve local
+    convergence.
+    """
+    const Fan = __Fan()
 
 end
 
@@ -203,7 +203,7 @@ function InternalAPI.init(
         prob::AbstractNonlinearProblem, alg::GenericTrustRegionScheme, f, fu, u, p,
         args...; stats, internalnorm::F = L2_NORM, vjp_autodiff = nothing,
         jvp_autodiff = nothing, kwargs...
-) where {F}
+    ) where {F}
     T = promote_type(eltype(u), eltype(fu))
     u0_norm = internalnorm(u)
     fu_norm = internalnorm(fu)
@@ -221,13 +221,13 @@ function InternalAPI.init(
 
     # Scheme Specific Setup
     p1, p2, p3, p4 = get_parameters(T, alg.method)
-    ϵ = T(1e-8)
+    ϵ = T(1.0e-8)
 
     vjp_operator = alg.method isa RUS.__Yuan || alg.method isa RUS.__Bastin ?
-                   VecJacOperator(prob, fu, u; autodiff = vjp_autodiff) : nothing
+        VecJacOperator(prob, fu, u; autodiff = vjp_autodiff) : nothing
 
     jvp_operator = alg.method isa RUS.__Bastin ?
-                   JacVecOperator(prob, fu, u; autodiff = jvp_autodiff) : nothing
+        JacVecOperator(prob, fu, u; autodiff = jvp_autodiff) : nothing
 
     if alg.method isa RUS.__Yuan
         Jᵀfu_cache = StatefulJacobianOperator(vjp_operator, u, prob.p) * Utils.safe_vec(fu)
@@ -289,20 +289,20 @@ end
 
 function InternalAPI.reinit!(
         cache::GenericTrustRegionSchemeCache; p = cache.p, u0 = nothing, kwargs...
-)
+    )
     cache.p = p
     if u0 !== nothing
         u0_norm = cache.internalnorm(u0)
     end
     cache.last_step_accepted = false
-    cache.shrink_counter = 0
+    return cache.shrink_counter = 0
 end
 
 # Defaults
 for func in (
-    :max_trust_radius, :initial_trust_radius, :step_threshold, :shrink_threshold,
-    :shrink_factor, :expand_threshold, :expand_factor
-)
+        :max_trust_radius, :initial_trust_radius, :step_threshold, :shrink_threshold,
+        :shrink_factor, :expand_threshold, :expand_factor,
+    )
     @eval function $(func)(val, ::Type{T}, args...) where {T}
         iszero(val) && return $(func)(nothing, T, args...)
         return T(val)
@@ -310,15 +310,17 @@ for func in (
 end
 
 max_trust_radius(::Nothing, ::Type{T}, method, u, fu_norm) where {T} = T(Inf)
-function max_trust_radius(::Nothing, ::Type{T}, ::Union{RUS.__Simple, RUS.__NocedalWright},
-        u, fu_norm) where {T}
+function max_trust_radius(
+        ::Nothing, ::Type{T}, ::Union{RUS.__Simple, RUS.__NocedalWright},
+        u, fu_norm
+    ) where {T}
     u_min, u_max = extrema(u)
     return max(T(fu_norm), u_max - u_min)
 end
 
 function initial_trust_radius(
         ::Nothing, ::Type{T}, method, max_tr, u0_norm, fu_norm
-) where {T}
+    ) where {T}
     method isa RUS.__NLsolve && return T(ifelse(u0_norm > 0, u0_norm, 1))
     (method isa RUS.__Hei || method isa RUS.__Bastin) && return T(1)
     method isa RUS.__Fan && return T((fu_norm^0.99) / 10)
@@ -356,7 +358,7 @@ function get_parameters(::Type{T}, method) where {T}
     method isa RUS.__NLsolve && return (T(1 // 2), T(0), T(0), T(0))
     method isa RUS.__Hei && return (T(5), T(1 // 10), T(15 // 100), T(15 // 100))
     method isa RUS.__Yuan && return (T(2), T(1 // 6), T(6), T(0))
-    method isa RUS.__Fan && return (T(1 // 10), T(1 // 4), T(12), T(1e18))
+    method isa RUS.__Fan && return (T(1 // 10), T(1 // 4), T(12), T(1.0e18))
     method isa RUS.__Bastin && return (T(5 // 2), T(1 // 4), T(0), T(0))
     return (T(0), T(0), T(0), T(0))
 end
@@ -365,7 +367,7 @@ expand_factor(::Nothing, ::Type{T}, method) where {T} = T(2)
 
 function rfunc_adaptive_trust_region(
         r::R, c2::R, M::R, γ1::R, γ2::R, β::R
-) where {R <: Real}
+    ) where {R <: Real}
     return ifelse(
         r ≥ c2,
         (2 * (M - 1 - γ2) * atan(r - c2) + (1 + γ2)) / R(π),
@@ -375,7 +377,7 @@ end
 
 function InternalAPI.solve!(
         cache::GenericTrustRegionSchemeCache, J, fu, u, δu, descent_stats
-)
+    )
     T = promote_type(eltype(u), eltype(fu))
     @bb @. cache.u_cache = u + δu
     cache.fu_cache = Utils.evaluate_f!!(cache.f, cache.fu_cache, cache.u_cache, cache.p)
@@ -429,7 +431,7 @@ function InternalAPI.solve!(
         else
             cache.shrink_counter = 0
             if cache.ρ > cache.expand_threshold &&
-               abs(cache.internalnorm(δu) - cache.trust_region) < 1e-6 * cache.trust_region
+                    abs(cache.internalnorm(δu) - cache.trust_region) < 1.0e-6 * cache.trust_region
                 cache.trust_region = cache.expand_factor * cache.trust_region
             end
         end
@@ -449,7 +451,7 @@ function InternalAPI.solve!(
             cache.shrink_counter += 1
         else
             if cache.ρ ≥ cache.expand_threshold &&
-               2 * cache.internalnorm(δu) > cache.trust_region
+                    2 * cache.internalnorm(δu) > cache.trust_region
                 cache.p1 = cache.p3 * cache.p1
             end
             cache.shrink_counter = 0

--- a/lib/NonlinearSolveFirstOrder/test/least_squares_tests.jl
+++ b/lib/NonlinearSolveFirstOrder/test/least_squares_tests.jl
@@ -8,9 +8,9 @@ include("../../../common/common_nlls_testing.jl")
 
 linesearches = []
 for lsmethod in [
-    LineSearches.Static(), LineSearches.HagerZhang(), LineSearches.MoreThuente(),
-    LineSearches.StrongWolfe(), LineSearches.BackTracking()
-]
+        LineSearches.Static(), LineSearches.HagerZhang(), LineSearches.MoreThuente(),
+        LineSearches.StrongWolfe(), LineSearches.BackTracking(),
+    ]
     push!(linesearches, LineSearchesJL(; method = lsmethod))
 end
 push!(linesearches, BackTracking())
@@ -18,25 +18,26 @@ push!(linesearches, BackTracking())
 solvers = []
 for linsolve in [nothing, LUFactorization(), KrylovJL_GMRES(), KrylovJL_LSMR()]
     vjp_autodiffs = linsolve isa KrylovJL ? [nothing, AutoZygote(), AutoFiniteDiff()] :
-                    [nothing]
+        [nothing]
     for linesearch in linesearches, vjp_autodiff in vjp_autodiffs
 
         push!(solvers, GaussNewton(; linsolve, linesearch, vjp_autodiff))
     end
 end
-append!(solvers,
+append!(
+    solvers,
     [
         LevenbergMarquardt(),
         LevenbergMarquardt(; linsolve = LUFactorization()),
         LevenbergMarquardt(; linsolve = KrylovJL_GMRES()),
-        LevenbergMarquardt(; linsolve = KrylovJL_LSMR())
+        LevenbergMarquardt(; linsolve = KrylovJL_LSMR()),
     ]
 )
 for radius_update_scheme in [
-    RadiusUpdateSchemes.Simple, RadiusUpdateSchemes.NocedalWright,
-    RadiusUpdateSchemes.NLsolve, RadiusUpdateSchemes.Hei,
-    RadiusUpdateSchemes.Yuan, RadiusUpdateSchemes.Fan, RadiusUpdateSchemes.Bastin
-]
+        RadiusUpdateSchemes.Simple, RadiusUpdateSchemes.NocedalWright,
+        RadiusUpdateSchemes.NLsolve, RadiusUpdateSchemes.Hei,
+        RadiusUpdateSchemes.Yuan, RadiusUpdateSchemes.Fan, RadiusUpdateSchemes.Bastin,
+    ]
     push!(solvers, TrustRegion(; radius_update_scheme))
 end
 
@@ -44,15 +45,15 @@ export solvers
 
 end
 
-@testitem "General NLLS Solvers" setup=[CoreNLLSTesting] tags=[:core] begin
+@testitem "General NLLS Solvers" setup = [CoreNLLSTesting] tags = [:core] begin
     using LinearAlgebra
 
-    nlls_problems=[prob_oop, prob_iip, prob_oop_vjp, prob_iip_vjp]
+    nlls_problems = [prob_oop, prob_iip, prob_oop_vjp, prob_iip_vjp]
 
     for prob in nlls_problems, solver in solvers
 
-        sol=solve(prob, solver; maxiters = 10000, abstol = 1e-6)
+        sol = solve(prob, solver; maxiters = 10000, abstol = 1.0e-6)
         @test SciMLBase.successful_retcode(sol)
-        @test norm(sol.resid, 2) < 1e-6
+        @test norm(sol.resid, 2) < 1.0e-6
     end
 end

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Scalar Jacobians: Issue #451" tags=[:core] begin
+@testitem "Scalar Jacobians: Issue #451" tags = [:core] begin
     f(u, p) = u^2 - p
 
     jac_calls = 0
@@ -21,11 +21,13 @@
     @test jac_calls == 0
 end
 
-@testitem "Dual of BigFloat: Issue #512" tags=[:core] begin
+@testitem "Dual of BigFloat: Issue #512" tags = [:core] begin
     using NonlinearSolveFirstOrder, ForwardDiff
     fn_iip = NonlinearFunction{true}((du, u, p) -> du .= u .* u .- p)
-    u2 = [ForwardDiff.Dual(BigFloat(1.0), 5.0), ForwardDiff.Dual(BigFloat(1.0), 5.0),
-        ForwardDiff.Dual(BigFloat(1.0), 5.0)]
+    u2 = [
+        ForwardDiff.Dual(BigFloat(1.0), 5.0), ForwardDiff.Dual(BigFloat(1.0), 5.0),
+        ForwardDiff.Dual(BigFloat(1.0), 5.0),
+    ]
     prob_iip_bf = NonlinearProblem{true}(fn_iip, u2, ForwardDiff.Dual(BigFloat(2.0), 5.0))
     sol = solve(prob_iip_bf, NewtonRaphson())
     @test sol.retcode == ReturnCode.Success

--- a/lib/NonlinearSolveFirstOrder/test/qa_tests.jl
+++ b/lib/NonlinearSolveFirstOrder/test/qa_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Aqua" tags=[:core] begin
+@testitem "Aqua" tags = [:core] begin
     using Aqua, NonlinearSolveFirstOrder
 
     Aqua.test_all(
@@ -9,7 +9,7 @@
     Aqua.test_ambiguities(NonlinearSolveFirstOrder; recursive = false)
 end
 
-@testitem "Explicit Imports" tags=[:core] begin
+@testitem "Explicit Imports" tags = [:core] begin
     using ExplicitImports, NonlinearSolveFirstOrder
 
     @test check_no_implicit_imports(

--- a/lib/NonlinearSolveFirstOrder/test/rootfind_tests.jl
+++ b/lib/NonlinearSolveFirstOrder/test/rootfind_tests.jl
@@ -4,54 +4,56 @@ include("../../../common/common_rootfind_testing.jl")
 
 end
 
-@testitem "Eisenstadt-Walker Newton-Krylov" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "Eisenstadt-Walker Newton-Krylov" setup = [CoreRootfindTesting] tags = [:core] begin
     using LinearAlgebra, Random, LinearSolve
     using BenchmarkTools: @ballocated
     using StaticArrays: @SVector
 
     @testset for (concrete_jac, linsolve) in (
-        (Val(false), KrylovJL_CG(; precs = nothing)),
-        (Val(false), KrylovJL_GMRES(; precs = nothing)),
-        (
-            Val(true),
-            KrylovJL_GMRES(;
-                    precs = (A,
-                    p = nothing) -> (
-                        Diagonal(randn!(similar(A, size(A, 1)))), LinearAlgebra.I
+            (Val(false), KrylovJL_CG(; precs = nothing)),
+            (Val(false), KrylovJL_GMRES(; precs = nothing)),
+            (
+                Val(true),
+                KrylovJL_GMRES(;
+                    precs = (
+                        A,
+                        p = nothing,
+                    ) -> (
+                        Diagonal(randn!(similar(A, size(A, 1)))), LinearAlgebra.I,
                     )
+                ),
             ),
-        ),
-    )
+        )
         @testset "[OOP] u0: $(typeof(u0))" for u0 in ([1.0, 1.0], @SVector[1.0, 1.0])
-            solver = NewtonRaphson(; forcing=EisenstatWalkerForcing2(), linsolve, concrete_jac)
+            solver = NewtonRaphson(; forcing = EisenstatWalkerForcing2(), linsolve, concrete_jac)
             sol = solve_oop(quadratic_f, u0; solver)
             @test SciMLBase.successful_retcode(sol)
             err = maximum(abs, quadratic_f(sol.u, 2.0))
-            @test err < 1e-9
+            @test err < 1.0e-9
 
             cache = init(
-                NonlinearProblem{false}(quadratic_f, u0, 2.0), solver, abstol = 1e-9
+                NonlinearProblem{false}(quadratic_f, u0, 2.0), solver, abstol = 1.0e-9
             )
             @test (@ballocated solve!($cache)) < 200
         end
 
         @testset "[IIP] u0: $(typeof(u0))" for u0 in ([1.0, 1.0],)
-            solver = NewtonRaphson(; forcing=EisenstatWalkerForcing2(), linsolve, concrete_jac)
+            solver = NewtonRaphson(; forcing = EisenstatWalkerForcing2(), linsolve, concrete_jac)
 
             sol = solve_iip(quadratic_f!, u0; solver)
             @test SciMLBase.successful_retcode(sol)
             err = maximum(abs, quadratic_f(sol.u, 2.0))
-            @test err < 1e-9
+            @test err < 1.0e-9
 
             cache = init(
-                NonlinearProblem{true}(quadratic_f!, u0, 2.0), solver, abstol = 1e-9
+                NonlinearProblem{true}(quadratic_f!, u0, 2.0), solver, abstol = 1.0e-9
             )
             @test (@ballocated solve!($cache)) ≤ 64
         end
     end
 end
 
-@testitem "NewtonRaphson" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "NewtonRaphson" setup = [CoreRootfindTesting] tags = [:core] begin
     using ADTypes, LineSearch, LinearAlgebra, Random, LinearSolve
     using LineSearches: LineSearches
     using BenchmarkTools: @ballocated
@@ -63,32 +65,32 @@ end
         using Enzyme
     end
 
-    u0s=([1.0, 1.0], @SVector[1.0, 1.0], 1.0)
+    u0s = ([1.0, 1.0], @SVector[1.0, 1.0], 1.0)
 
     # Filter autodiff backends based on Julia version
-    autodiff_backends=[AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()]
+    autodiff_backends = [AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()]
     if isempty(VERSION.prerelease) && VERSION < v"1.12"
         push!(autodiff_backends, AutoEnzyme())
     end
 
     @testset for ad in autodiff_backends
         @testset "$(nameof(typeof(linesearch)))" for linesearch in (
-            LineSearchesJL(; method = LineSearches.Static(), autodiff = ad),
-            LineSearchesJL(; method = LineSearches.BackTracking(), autodiff = ad),
-            LineSearchesJL(; method = LineSearches.MoreThuente(), autodiff = ad),
-            LineSearchesJL(; method = LineSearches.StrongWolfe(), autodiff = ad),
-            LineSearchesJL(; method = LineSearches.HagerZhang(), autodiff = ad),
-            BackTracking(; autodiff = ad)
-        )
+                LineSearchesJL(; method = LineSearches.Static(), autodiff = ad),
+                LineSearchesJL(; method = LineSearches.BackTracking(), autodiff = ad),
+                LineSearchesJL(; method = LineSearches.MoreThuente(), autodiff = ad),
+                LineSearchesJL(; method = LineSearches.StrongWolfe(), autodiff = ad),
+                LineSearchesJL(; method = LineSearches.HagerZhang(), autodiff = ad),
+                BackTracking(; autodiff = ad),
+            )
             @testset "[OOP] u0: $(typeof(u0))" for u0 in u0s
                 solver = NewtonRaphson(; linesearch, autodiff = ad)
                 sol = solve_oop(quadratic_f, u0; solver)
                 @test SciMLBase.successful_retcode(sol)
                 err = maximum(abs, quadratic_f(sol.u, 2.0))
-                @test err < 1e-9
+                @test err < 1.0e-9
 
                 cache = init(
-                    NonlinearProblem{false}(quadratic_f, u0, 2.0), solver, abstol = 1e-9
+                    NonlinearProblem{false}(quadratic_f, u0, 2.0), solver, abstol = 1.0e-9
                 )
                 @test (@ballocated solve!($cache)) < 200
             end
@@ -97,19 +99,21 @@ end
                 ad isa AutoZygote && continue
 
                 @testset for (concrete_jac, linsolve) in (
-                    (Val(false), nothing),
-                    (Val(false), KrylovJL_GMRES(; precs = nothing)),
-                    (
-                        Val(true),
-                        KrylovJL_GMRES(;
-                            precs = (A,
-                            p = nothing) -> (
-                            Diagonal(randn!(similar(A, size(A, 1)))), LinearAlgebra.I
-                        )
-                        )
-                    ),
-                    (Val(false), \)
-                )
+                        (Val(false), nothing),
+                        (Val(false), KrylovJL_GMRES(; precs = nothing)),
+                        (
+                            Val(true),
+                            KrylovJL_GMRES(;
+                                precs = (
+                                    A,
+                                    p = nothing,
+                                ) -> (
+                                    Diagonal(randn!(similar(A, size(A, 1)))), LinearAlgebra.I,
+                                )
+                            ),
+                        ),
+                        (Val(false), \),
+                    )
                     solver = NewtonRaphson(;
                         linsolve, linesearch, autodiff = ad, concrete_jac
                     )
@@ -117,10 +121,10 @@ end
                     sol = solve_iip(quadratic_f!, u0; solver)
                     @test SciMLBase.successful_retcode(sol)
                     err = maximum(abs, quadratic_f(sol.u, 2.0))
-                    @test err < 1e-9
+                    @test err < 1.0e-9
 
                     cache = init(
-                        NonlinearProblem{true}(quadratic_f!, u0, 2.0), solver, abstol = 1e-9
+                        NonlinearProblem{true}(quadratic_f!, u0, 2.0), solver, abstol = 1.0e-9
                     )
                     @test (@ballocated solve!($cache)) ≤ 64
                 end
@@ -129,28 +133,28 @@ end
     end
 end
 
-@testitem "NewtonRaphson: Iterator Interface" setup=[CoreRootfindTesting] tags=[:core] begin
-    p=range(0.01, 2, length = 200)
+@testitem "NewtonRaphson: Iterator Interface" setup = [CoreRootfindTesting] tags = [:core] begin
+    p = range(0.01, 2, length = 200)
     @test nlprob_iterator_interface(quadratic_f, p, false, NewtonRaphson()) ≈ sqrt.(p)
     @test nlprob_iterator_interface(quadratic_f!, p, true, NewtonRaphson()) ≈ sqrt.(p)
 end
 
-@testitem "NewtonRaphson Termination Conditions" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "NewtonRaphson Termination Conditions" setup = [CoreRootfindTesting] tags = [:core] begin
     using StaticArrays: @SVector
 
     @testset "TC: $(nameof(typeof(termination_condition)))" for termination_condition in
-                                                                TERMINATION_CONDITIONS
+        TERMINATION_CONDITIONS
 
         @testset "u0: $(typeof(u0))" for u0 in ([1.0, 1.0], 1.0, @SVector([1.0, 1.0]))
             probN = NonlinearProblem(quadratic_f, u0, 2.0)
             sol = solve(probN, NewtonRaphson(); termination_condition)
             err = maximum(abs, quadratic_f(sol.u, 2.0))
-            @test err < 1e-9
+            @test err < 1.0e-9
         end
     end
 end
 
-@testitem "PseudoTransient" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "PseudoTransient" setup = [CoreRootfindTesting] tags = [:core] begin
     using ADTypes, Random, LinearSolve, LinearAlgebra
     using BenchmarkTools: @ballocated
     using StaticArrays: @SVector
@@ -161,13 +165,13 @@ end
         using Enzyme
     end
 
-    preconditioners=[
-        (u0)->nothing,
-        u0->((args...)->(Diagonal(rand!(similar(u0))), nothing))
+    preconditioners = [
+        (u0) -> nothing,
+        u0 -> ((args...) -> (Diagonal(rand!(similar(u0))), nothing)),
     ]
 
     # Filter autodiff backends based on Julia version
-    autodiff_backends=[AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()]
+    autodiff_backends = [AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()]
     if isempty(VERSION.prerelease) && VERSION < v"1.12"
         push!(autodiff_backends, AutoEnzyme())
     end
@@ -180,10 +184,10 @@ end
             sol = solve_oop(quadratic_f, u0; solver)
             @test SciMLBase.successful_retcode(sol)
             err = maximum(abs, quadratic_f(sol.u, 2.0))
-            @test err < 1e-9
+            @test err < 1.0e-9
 
             cache = init(
-                NonlinearProblem{false}(quadratic_f, u0, 2.0), solver, abstol = 1e-9
+                NonlinearProblem{false}(quadratic_f, u0, 2.0), solver, abstol = 1.0e-9
             )
             @test (@ballocated solve!($cache)) < 200
         end
@@ -192,29 +196,31 @@ end
             ad isa AutoZygote && continue
 
             @testset for (concrete_jac, linsolve) in (
-                (Val(false), nothing),
-                (Val(false), KrylovJL_GMRES(; precs = nothing)),
-                (
-                    Val(true),
-                    KrylovJL_GMRES(;
-                        precs = (A,
-                        p = nothing) -> (
-                        Diagonal(randn!(similar(A, size(A, 1)))), LinearAlgebra.I
-                    )
-                    )
-                ),
-                (Val(false), \)
-            )
+                    (Val(false), nothing),
+                    (Val(false), KrylovJL_GMRES(; precs = nothing)),
+                    (
+                        Val(true),
+                        KrylovJL_GMRES(;
+                            precs = (
+                                A,
+                                p = nothing,
+                            ) -> (
+                                Diagonal(randn!(similar(A, size(A, 1)))), LinearAlgebra.I,
+                            )
+                        ),
+                    ),
+                    (Val(false), \),
+                )
                 solver = PseudoTransient(;
                     alpha_initial = 10.0, linsolve, autodiff = ad, concrete_jac
                 )
                 sol = solve_iip(quadratic_f!, u0; solver)
                 @test SciMLBase.successful_retcode(sol)
                 err = maximum(abs, quadratic_f(sol.u, 2.0))
-                @test err < 1e-9
+                @test err < 1.0e-9
 
                 cache = init(
-                    NonlinearProblem{true}(quadratic_f!, u0, 2.0), solver, abstol = 1e-9
+                    NonlinearProblem{true}(quadratic_f!, u0, 2.0), solver, abstol = 1.0e-9
                 )
                 @test (@ballocated solve!($cache)) ≤ 64
             end
@@ -222,8 +228,8 @@ end
     end
 end
 
-@testitem "PseudoTransient: Iterator Interface" setup=[CoreRootfindTesting] tags=[:core] begin
-    p=range(0.01, 2, length = 200)
+@testitem "PseudoTransient: Iterator Interface" setup = [CoreRootfindTesting] tags = [:core] begin
+    p = range(0.01, 2, length = 200)
     @test nlprob_iterator_interface(
         quadratic_f, p, false, PseudoTransient(; alpha_initial = 10.0)
     ) ≈ sqrt.(p)
@@ -232,22 +238,22 @@ end
     ) ≈ sqrt.(p)
 end
 
-@testitem "PseudoTransient Termination Conditions" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "PseudoTransient Termination Conditions" setup = [CoreRootfindTesting] tags = [:core] begin
     using StaticArrays: @SVector
 
     @testset "TC: $(nameof(typeof(termination_condition)))" for termination_condition in
-                                                                TERMINATION_CONDITIONS
+        TERMINATION_CONDITIONS
 
         @testset "u0: $(typeof(u0))" for u0 in ([1.0, 1.0], 1.0, @SVector([1.0, 1.0]))
             probN = NonlinearProblem(quadratic_f, u0, 2.0)
             sol = solve(probN, PseudoTransient(); termination_condition)
             err = maximum(abs, quadratic_f(sol.u, 2.0))
-            @test err < 1e-9
+            @test err < 1.0e-9
         end
     end
 end
 
-@testitem "TrustRegion" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "TrustRegion" setup = [CoreRootfindTesting] tags = [:core] begin
     using ADTypes, LinearSolve, LinearAlgebra
     using BenchmarkTools: @ballocated
     using StaticArrays: @SVector
@@ -258,25 +264,26 @@ end
         using Enzyme
     end
 
-    radius_update_schemes=[
+    radius_update_schemes = [
         RadiusUpdateSchemes.Simple, RadiusUpdateSchemes.NocedalWright,
         RadiusUpdateSchemes.NLsolve, RadiusUpdateSchemes.Hei,
-        RadiusUpdateSchemes.Yuan, RadiusUpdateSchemes.Fan, RadiusUpdateSchemes.Bastin
+        RadiusUpdateSchemes.Yuan, RadiusUpdateSchemes.Fan, RadiusUpdateSchemes.Bastin,
     ]
 
     # Filter autodiff backends based on Julia version
-    autodiff_backends=[AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()]
+    autodiff_backends = [AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()]
     if isempty(VERSION.prerelease) && VERSION < v"1.12"
         push!(autodiff_backends, AutoEnzyme())
     end
 
     @testset for ad in autodiff_backends
         @testset for radius_update_scheme in radius_update_schemes,
-            linsolve in (nothing, LUFactorization(), KrylovJL_GMRES(), \)
+                linsolve in (nothing, LUFactorization(), KrylovJL_GMRES(), \)
 
             @testset "[OOP] u0: $(typeof(u0))" for u0 in (
-                [1.0, 1.0], 1.0, @SVector[1.0, 1.0], 1.0)
-                abstol = ifelse(linsolve isa KrylovJL, 1e-6, 1e-9)
+                    [1.0, 1.0], 1.0, @SVector[1.0, 1.0], 1.0,
+                )
+                abstol = ifelse(linsolve isa KrylovJL, 1.0e-6, 1.0e-9)
                 solver = TrustRegion(; radius_update_scheme, linsolve)
                 sol = solve_oop(quadratic_f, u0; solver, abstol)
                 @test SciMLBase.successful_retcode(sol)
@@ -290,7 +297,7 @@ end
             @testset "[IIP] u0: $(typeof(u0))" for u0 in ([1.0, 1.0],)
                 ad isa AutoZygote && continue
 
-                abstol = ifelse(linsolve isa KrylovJL, 1e-6, 1e-9)
+                abstol = ifelse(linsolve isa KrylovJL, 1.0e-6, 1.0e-9)
                 solver = TrustRegion(; radius_update_scheme, linsolve)
                 sol = solve_iip(quadratic_f!, u0; solver, abstol)
                 @test SciMLBase.successful_retcode(sol)
@@ -304,58 +311,58 @@ end
     end
 end
 
-@testitem "TrustRegion: Iterator Interface" setup=[CoreRootfindTesting] tags=[:core] begin
-    p=range(0.01, 2, length = 200)
+@testitem "TrustRegion: Iterator Interface" setup = [CoreRootfindTesting] tags = [:core] begin
+    p = range(0.01, 2, length = 200)
     @test nlprob_iterator_interface(quadratic_f, p, false, TrustRegion()) ≈ sqrt.(p)
     @test nlprob_iterator_interface(quadratic_f!, p, true, TrustRegion()) ≈ sqrt.(p)
 end
 
-@testitem "TrustRegion NewtonRaphson Fails" setup=[CoreRootfindTesting] tags=[:core] begin
-    u0=[-10.0, -1.0, 1.0, 2.0, 3.0, 4.0, 10.0]
-    p=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    sol=solve_oop(newton_fails, u0, p; solver = TrustRegion())
+@testitem "TrustRegion NewtonRaphson Fails" setup = [CoreRootfindTesting] tags = [:core] begin
+    u0 = [-10.0, -1.0, 1.0, 2.0, 3.0, 4.0, 10.0]
+    p = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    sol = solve_oop(newton_fails, u0, p; solver = TrustRegion())
     @test SciMLBase.successful_retcode(sol)
-    @test all(abs.(newton_fails(sol.u, p)) .< 1e-9)
+    @test all(abs.(newton_fails(sol.u, p)) .< 1.0e-9)
 end
 
-@testitem "TrustRegion: Kwargs" setup=[CoreRootfindTesting] tags=[:core] begin
-    max_trust_radius=[10.0, 100.0, 1000.0]
-    initial_trust_radius=[10.0, 1.0, 0.1]
-    step_threshold=[0.0, 0.01, 0.25]
-    shrink_threshold=[0.25, 0.3, 0.5]
-    expand_threshold=[0.5, 0.8, 0.9]
-    shrink_factor=[0.1, 0.3, 0.5]
-    expand_factor=[1.5, 2.0, 3.0]
-    max_shrink_times=[10, 20, 30]
+@testitem "TrustRegion: Kwargs" setup = [CoreRootfindTesting] tags = [:core] begin
+    max_trust_radius = [10.0, 100.0, 1000.0]
+    initial_trust_radius = [10.0, 1.0, 0.1]
+    step_threshold = [0.0, 0.01, 0.25]
+    shrink_threshold = [0.25, 0.3, 0.5]
+    expand_threshold = [0.5, 0.8, 0.9]
+    shrink_factor = [0.1, 0.3, 0.5]
+    expand_factor = [1.5, 2.0, 3.0]
+    max_shrink_times = [10, 20, 30]
 
-    list_of_options=zip(
+    list_of_options = zip(
         max_trust_radius, initial_trust_radius, step_threshold, shrink_threshold,
         expand_threshold, shrink_factor, expand_factor, max_shrink_times
     )
 
     for options in list_of_options
-        alg=TrustRegion(;
+        alg = TrustRegion(;
             max_trust_radius = options[1], initial_trust_radius = options[2],
             step_threshold = options[3], shrink_threshold = options[4],
             expand_threshold = options[5], shrink_factor = options[6],
             expand_factor = options[7], max_shrink_times = options[8]
         )
 
-        sol=solve_oop(quadratic_f, [1.0, 1.0], 2.0; solver = alg)
+        sol = solve_oop(quadratic_f, [1.0, 1.0], 2.0; solver = alg)
         @test SciMLBase.successful_retcode(sol)
-        err=maximum(abs, quadratic_f(sol.u, 2.0))
-        @test err < 1e-9
+        err = maximum(abs, quadratic_f(sol.u, 2.0))
+        @test err < 1.0e-9
     end
 end
 
-@testitem "TrustRegion OOP / IIP Consistency" setup=[CoreRootfindTesting] tags=[:core] begin
-    maxiterations=[2, 3, 4, 5]
-    u0=[1.0, 1.0]
+@testitem "TrustRegion OOP / IIP Consistency" setup = [CoreRootfindTesting] tags = [:core] begin
+    maxiterations = [2, 3, 4, 5]
+    u0 = [1.0, 1.0]
     @testset for radius_update_scheme in [
-        RadiusUpdateSchemes.Simple, RadiusUpdateSchemes.NocedalWright,
-        RadiusUpdateSchemes.NLsolve, RadiusUpdateSchemes.Hei,
-        RadiusUpdateSchemes.Yuan, RadiusUpdateSchemes.Fan, RadiusUpdateSchemes.Bastin
-    ]
+            RadiusUpdateSchemes.Simple, RadiusUpdateSchemes.NocedalWright,
+            RadiusUpdateSchemes.NLsolve, RadiusUpdateSchemes.Hei,
+            RadiusUpdateSchemes.Yuan, RadiusUpdateSchemes.Fan, RadiusUpdateSchemes.Bastin,
+        ]
         @testset for maxiters in maxiterations
             solver = TrustRegion(; radius_update_scheme)
             sol_iip = solve_iip(quadratic_f!, u0; solver, maxiters)
@@ -365,22 +372,22 @@ end
     end
 end
 
-@testitem "TrustRegion Termination Conditions" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "TrustRegion Termination Conditions" setup = [CoreRootfindTesting] tags = [:core] begin
     using StaticArrays: @SVector
 
     @testset "TC: $(nameof(typeof(termination_condition)))" for termination_condition in
-                                                                TERMINATION_CONDITIONS
+        TERMINATION_CONDITIONS
 
         @testset "u0: $(typeof(u0))" for u0 in ([1.0, 1.0], 1.0, @SVector([1.0, 1.0]))
             probN = NonlinearProblem(quadratic_f, u0, 2.0)
             sol = solve(probN, TrustRegion(); termination_condition)
             err = maximum(abs, quadratic_f(sol.u, 2.0))
-            @test err < 1e-9
+            @test err < 1.0e-9
         end
     end
 end
 
-@testitem "LevenbergMarquardt" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "LevenbergMarquardt" setup = [CoreRootfindTesting] tags = [:core] begin
     using ADTypes, LinearSolve, LinearAlgebra
     using BenchmarkTools: @ballocated
     using StaticArrays: SVector, @SVector
@@ -392,7 +399,7 @@ end
     end
 
     # Filter autodiff backends based on Julia version
-    autodiff_backends=[AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()]
+    autodiff_backends = [AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()]
     if isempty(VERSION.prerelease) && VERSION < v"1.12"
         push!(autodiff_backends, AutoEnzyme())
     end
@@ -410,11 +417,11 @@ end
             sol = solve_oop(quadratic_f, u0; solver)
             @test SciMLBase.successful_retcode(sol)
             err = maximum(abs, quadratic_f(sol.u, 2.0))
-            @test err < 1e-9
+            @test err < 1.0e-9
 
             cache = init(
                 NonlinearProblem{false}(quadratic_f, u0, 2.0),
-                LevenbergMarquardt(), abstol = 1e-9
+                LevenbergMarquardt(), abstol = 1.0e-9
             )
             @test (@ballocated solve!($cache)) < 200
         end
@@ -425,79 +432,79 @@ end
             sol = solve_iip(quadratic_f!, u0; solver)
             @test SciMLBase.successful_retcode(sol)
             err = maximum(abs, quadratic_f(sol.u, 2.0))
-            @test err < 1e-9
+            @test err < 1.0e-9
 
             cache = init(
                 NonlinearProblem{true}(quadratic_f!, u0, 2.0),
-                LevenbergMarquardt(), abstol = 1e-9
+                LevenbergMarquardt(), abstol = 1.0e-9
             )
             @test (@ballocated solve!($cache)) ≤ 64
         end
     end
 end
 
-@testitem "LevenbergMarquardt NewtonRaphson Fails" setup=[CoreRootfindTesting] tags=[:core] begin
-    u0=[-10.0, -1.0, 1.0, 2.0, 3.0, 4.0, 10.0]
-    p=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    sol=solve_oop(newton_fails, u0, p; solver = LevenbergMarquardt())
+@testitem "LevenbergMarquardt NewtonRaphson Fails" setup = [CoreRootfindTesting] tags = [:core] begin
+    u0 = [-10.0, -1.0, 1.0, 2.0, 3.0, 4.0, 10.0]
+    p = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    sol = solve_oop(newton_fails, u0, p; solver = LevenbergMarquardt())
     @test SciMLBase.successful_retcode(sol)
-    @test all(abs.(newton_fails(sol.u, p)) .< 1e-9)
+    @test all(abs.(newton_fails(sol.u, p)) .< 1.0e-9)
 end
 
-@testitem "LevenbergMarquardt: Iterator Interface" setup=[CoreRootfindTesting] tags=[:core] begin
-    p=range(0.01, 2, length = 200)
+@testitem "LevenbergMarquardt: Iterator Interface" setup = [CoreRootfindTesting] tags = [:core] begin
+    p = range(0.01, 2, length = 200)
     @test nlprob_iterator_interface(quadratic_f, p, false, LevenbergMarquardt()) ≈ sqrt.(p)
     @test nlprob_iterator_interface(quadratic_f!, p, true, LevenbergMarquardt()) ≈ sqrt.(p)
 end
 
-@testitem "LevenbergMarquardt Termination Conditions" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "LevenbergMarquardt Termination Conditions" setup = [CoreRootfindTesting] tags = [:core] begin
     using StaticArrays: @SVector
 
     @testset "TC: $(nameof(typeof(termination_condition)))" for termination_condition in
-                                                                TERMINATION_CONDITIONS
+        TERMINATION_CONDITIONS
 
         @testset "u0: $(typeof(u0))" for u0 in ([1.0, 1.0], 1.0, @SVector([1.0, 1.0]))
             probN = NonlinearProblem(quadratic_f, u0, 2.0)
             sol = solve(probN, LevenbergMarquardt(); termination_condition)
             err = maximum(abs, quadratic_f(sol.u, 2.0))
-            @test err < 1e-9
+            @test err < 1.0e-9
         end
     end
 end
 
-@testitem "LevenbergMarquardt: Kwargs" setup=[CoreRootfindTesting] tags=[:core] begin
-    damping_initial=[0.5, 2.0, 5.0]
-    damping_increase_factor=[1.5, 3.0, 10.0]
-    damping_decrease_factor=Float64[2, 5, 10.0]
-    finite_diff_step_geodesic=[0.02, 0.2, 0.3]
-    α_geodesic=[0.6, 0.8, 0.9]
-    b_uphill=Float64[0, 1, 2]
-    min_damping_D=[1e-12, 1e-9, 1e-4]
+@testitem "LevenbergMarquardt: Kwargs" setup = [CoreRootfindTesting] tags = [:core] begin
+    damping_initial = [0.5, 2.0, 5.0]
+    damping_increase_factor = [1.5, 3.0, 10.0]
+    damping_decrease_factor = Float64[2, 5, 10.0]
+    finite_diff_step_geodesic = [0.02, 0.2, 0.3]
+    α_geodesic = [0.6, 0.8, 0.9]
+    b_uphill = Float64[0, 1, 2]
+    min_damping_D = [1.0e-12, 1.0e-9, 1.0e-4]
 
-    list_of_options=zip(
+    list_of_options = zip(
         damping_initial, damping_increase_factor, damping_decrease_factor,
         finite_diff_step_geodesic, α_geodesic, b_uphill, min_damping_D
     )
     for options in list_of_options
-        alg=LevenbergMarquardt(;
+        alg = LevenbergMarquardt(;
             damping_initial = options[1], damping_increase_factor = options[2],
             damping_decrease_factor = options[3],
             finite_diff_step_geodesic = options[4], α_geodesic = options[5],
             b_uphill = options[6], min_damping_D = options[7]
         )
 
-        sol=solve_oop(quadratic_f, [1.0, 1.0], 2.0; solver = alg, maxiters = 10000)
+        sol = solve_oop(quadratic_f, [1.0, 1.0], 2.0; solver = alg, maxiters = 10000)
         @test SciMLBase.successful_retcode(sol)
-        err=maximum(abs, quadratic_f(sol.u, 2.0))
-        @test err < 1e-9
+        err = maximum(abs, quadratic_f(sol.u, 2.0))
+        @test err < 1.0e-9
     end
 end
 
-@testitem "Simple Sparse AutoDiff" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "Simple Sparse AutoDiff" setup = [CoreRootfindTesting] tags = [:core] begin
     using ADTypes, SparseConnectivityTracer, SparseMatrixColorings
 
     # Filter autodiff backends based on Julia version
-    autodiff_backends=[AutoForwardDiff(), AutoFiniteDiff(), AutoZygote()]
+    autodiff_backends = [AutoForwardDiff(), AutoFiniteDiff(), AutoZygote()]
     if isempty(VERSION.prerelease) && VERSION < v"1.12"
         push!(autodiff_backends, AutoEnzyme())
     end
@@ -511,67 +518,68 @@ end
             @testset "Newton Raphson" begin
                 sol = solve(prob, NewtonRaphson(; autodiff = ad))
                 err = maximum(abs, quadratic_f(sol.u, 2.0))
-                @test err < 1e-9
+                @test err < 1.0e-9
             end
 
             @testset "Trust Region" begin
                 sol = solve(prob, TrustRegion(; autodiff = ad))
                 err = maximum(abs, quadratic_f(sol.u, 2.0))
-                @test err < 1e-9
+                @test err < 1.0e-9
             end
         end
     end
 end
 
-@testitem "Custom JVP" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "Custom JVP" setup = [CoreRootfindTesting] tags = [:core] begin
     using LinearAlgebra, LinearSolve, ADTypes
 
     function F(u::Vector{Float64}, p::Vector{Float64})
-        Δ=Tridiagonal(-ones(99), 2*ones(100), -ones(99))
-        return u+0.1*u .* Δ*u-p
+        Δ = Tridiagonal(-ones(99), 2 * ones(100), -ones(99))
+        return u + 0.1 * u .* Δ * u - p
     end
 
     function F!(du::Vector{Float64}, u::Vector{Float64}, p::Vector{Float64})
-        Δ=Tridiagonal(-ones(99), 2*ones(100), -ones(99))
-        du.=u+0.1*u .* Δ*u-p
+        Δ = Tridiagonal(-ones(99), 2 * ones(100), -ones(99))
+        du .= u + 0.1 * u .* Δ * u - p
         return nothing
     end
 
     function JVP(v::Vector{Float64}, u::Vector{Float64}, p::Vector{Float64})
-        Δ=Tridiagonal(-ones(99), 2*ones(100), -ones(99))
-        return v+0.1*(u .* Δ*v+v .* Δ*u)
+        Δ = Tridiagonal(-ones(99), 2 * ones(100), -ones(99))
+        return v + 0.1 * (u .* Δ * v + v .* Δ * u)
     end
 
     function JVP!(
-            du::Vector{Float64}, v::Vector{Float64}, u::Vector{Float64}, p::Vector{Float64})
-        Δ=Tridiagonal(-ones(99), 2*ones(100), -ones(99))
-        du.=v+0.1*(u .* Δ*v+v .* Δ*u)
+            du::Vector{Float64}, v::Vector{Float64}, u::Vector{Float64}, p::Vector{Float64}
+        )
+        Δ = Tridiagonal(-ones(99), 2 * ones(100), -ones(99))
+        du .= v + 0.1 * (u .* Δ * v + v .* Δ * u)
         return nothing
     end
 
-    u0=rand(100)
+    u0 = rand(100)
 
-    prob=NonlinearProblem(NonlinearFunction{false}(F; jvp = JVP), u0, u0)
-    sol=solve(prob, NewtonRaphson(; linsolve = KrylovJL_GMRES()); abstol = 1e-13)
-    err=maximum(abs, sol.resid)
-    @test err < 1e-6
+    prob = NonlinearProblem(NonlinearFunction{false}(F; jvp = JVP), u0, u0)
+    sol = solve(prob, NewtonRaphson(; linsolve = KrylovJL_GMRES()); abstol = 1.0e-13)
+    err = maximum(abs, sol.resid)
+    @test err < 1.0e-6
 
-    sol=solve(
+    sol = solve(
         prob, TrustRegion(; linsolve = KrylovJL_GMRES(), vjp_autodiff = AutoFiniteDiff());
-        abstol = 1e-13
+        abstol = 1.0e-13
     )
-    err=maximum(abs, sol.resid)
-    @test err < 1e-6
+    err = maximum(abs, sol.resid)
+    @test err < 1.0e-6
 
-    prob=NonlinearProblem(NonlinearFunction{true}(F!; jvp = JVP!), u0, u0)
-    sol=solve(prob, NewtonRaphson(; linsolve = KrylovJL_GMRES()); abstol = 1e-13)
-    err=maximum(abs, sol.resid)
-    @test err < 1e-6
+    prob = NonlinearProblem(NonlinearFunction{true}(F!; jvp = JVP!), u0, u0)
+    sol = solve(prob, NewtonRaphson(; linsolve = KrylovJL_GMRES()); abstol = 1.0e-13)
+    err = maximum(abs, sol.resid)
+    @test err < 1.0e-6
 
-    sol=solve(
+    sol = solve(
         prob, TrustRegion(; linsolve = KrylovJL_GMRES(), vjp_autodiff = AutoFiniteDiff());
-        abstol = 1e-13
+        abstol = 1.0e-13
     )
-    err=maximum(abs, sol.resid)
-    @test err < 1e-6
+    err = maximum(abs, sol.resid)
+    @test err < 1.0e-6
 end

--- a/lib/NonlinearSolveFirstOrder/test/runtests.jl
+++ b/lib/NonlinearSolveFirstOrder/test/runtests.jl
@@ -5,11 +5,13 @@ using ReTestItems, NonlinearSolveFirstOrder, Hwloc, InteractiveUtils, Pkg
 const GROUP = lowercase(get(ENV, "GROUP", "All"))
 
 const RETESTITEMS_NWORKERS = parse(
-    Int, get(ENV, "RETESTITEMS_NWORKERS",
+    Int, get(
+        ENV, "RETESTITEMS_NWORKERS",
         string(min(ifelse(Sys.iswindows(), 0, Hwloc.num_physical_cores()), 4))
     )
 )
-const RETESTITEMS_NWORKER_THREADS = parse(Int,
+const RETESTITEMS_NWORKER_THREADS = parse(
+    Int,
     get(
         ENV, "RETESTITEMS_NWORKER_THREADS",
         string(max(Hwloc.num_virtual_cores() ÷ max(RETESTITEMS_NWORKERS, 1), 1))

--- a/lib/NonlinearSolveHomotopyContinuation/src/NonlinearSolveHomotopyContinuation.jl
+++ b/lib/NonlinearSolveHomotopyContinuation/src/NonlinearSolveHomotopyContinuation.jl
@@ -46,7 +46,7 @@ HomotopyContinuation.jl requires the taylor series of the polynomial system for 
 root method. This is automatically computed using TaylorSeries.jl.
 """
 @concrete struct HomotopyContinuationJL{AllRoots} <:
-                 NonlinearSolveBase.AbstractNonlinearSolveAlgorithm
+    NonlinearSolveBase.AbstractNonlinearSolveAlgorithm
     autodiff
     kwargs
 end
@@ -55,13 +55,13 @@ function HomotopyContinuationJL{AllRoots}(; autodiff = true, kwargs...) where {A
     if autodiff isa Bool
         autodiff = autodiff ? AutoForwardDiff() : AutoFiniteDiff()
     end
-    HomotopyContinuationJL{AllRoots}(autodiff, kwargs)
+    return HomotopyContinuationJL{AllRoots}(autodiff, kwargs)
 end
 
 HomotopyContinuationJL(; kwargs...) = HomotopyContinuationJL{false}(; kwargs...)
 
 function HomotopyContinuationJL(alg::HomotopyContinuationJL{R}; kwargs...) where {R}
-    HomotopyContinuationJL{R}(; autodiff = alg.autodiff, alg.kwargs..., kwargs...)
+    return HomotopyContinuationJL{R}(; autodiff = alg.autodiff, alg.kwargs..., kwargs...)
 end
 
 include("interface_types.jl")

--- a/lib/NonlinearSolveHomotopyContinuation/src/interface_types.jl
+++ b/lib/NonlinearSolveHomotopyContinuation/src/interface_types.jl
@@ -15,7 +15,7 @@ polynomial systems specified using `NonlinearProblem`.
 $(FIELDS)
 """
 @concrete struct HomotopySystemWrapper{variant <: HomotopySystemVariant} <:
-                 HC.AbstractSystem
+    HC.AbstractSystem
     """
     The wrapped polynomial function.
     """
@@ -61,13 +61,15 @@ function HC.ModelKit.evaluate!(u, sys::HomotopySystemWrapper{Scalar}, x, p = not
 end
 
 function HC.ModelKit.evaluate_and_jacobian!(
-        u, U, sys::HomotopySystemWrapper, x, p = nothing)
+        u, U, sys::HomotopySystemWrapper, x, p = nothing
+    )
     sys.jac(u, U, x, sys.p)
     return u, U
 end
 
 function update_taylorvars_from_taylorvector!(
-        vars, x::HC.ModelKit.TaylorVector)
+        vars, x::HC.ModelKit.TaylorVector
+    )
     for i in eachindex(x)
         xvar = x[i]
         realx = ntuple(Val(4)) do j
@@ -80,6 +82,7 @@ function update_taylorvars_from_taylorvector!(
         vars[2i - 1] = TaylorScalar(realx)
         vars[2i] = TaylorScalar(imagx)
     end
+    return
 end
 
 function update_taylorvars_from_taylorvector!(vars, x::AbstractVector)
@@ -87,6 +90,7 @@ function update_taylorvars_from_taylorvector!(vars, x::AbstractVector)
         vars[2i - 1] = TaylorScalar(real(x[i]), ntuple(Returns(0.0), Val(3)))
         vars[2i] = TaylorScalar(imag(x[i]), ntuple(Returns(0.0), Val(3)))
     end
+    return
 end
 
 function check_taylor_equality(vars, x::HC.ModelKit.TaylorVector)
@@ -105,25 +109,31 @@ function check_taylor_equality(vars, x::AbstractVector)
 end
 
 function update_maybe_taylorvector_from_taylorvars!(
-        u::Vector, vars, buffer, ::Val{N}) where {N}
+        u::Vector, vars, buffer, ::Val{N}
+    ) where {N}
     for i in eachindex(vars)
         rval = TaylorDiff.flatten(real(buffer[i]))
         ival = TaylorDiff.flatten(imag(buffer[i]))
         u[i] = rval[N] + im * ival[N]
     end
+    return
 end
 
 function update_maybe_taylorvector_from_taylorvars!(
-        u::HC.ModelKit.TaylorVector{M}, vars, buffer, ::Val{N}) where {M, N}
+        u::HC.ModelKit.TaylorVector{M}, vars, buffer, ::Val{N}
+    ) where {M, N}
     for i in eachindex(vars)
         rval = TaylorDiff.flatten(real(buffer[i]))
         ival = TaylorDiff.flatten(imag(buffer[i]))
         u[i] = ntuple(i -> rval[i] + im * ival[i], Val(length(rval)))
     end
+    return
 end
 
-function HC.ModelKit.taylor!(u::AbstractVector, ::Val{N},
-        sys::HomotopySystemWrapper{Inplace}, x, p = nothing) where {N}
+function HC.ModelKit.taylor!(
+        u::AbstractVector, ::Val{N},
+        sys::HomotopySystemWrapper{Inplace}, x, p = nothing
+    ) where {N}
     f = sys.f
     p = sys.p
     vars, buffer = sys.taylorvars
@@ -139,8 +149,10 @@ function HC.ModelKit.taylor!(u::AbstractVector, ::Val{N},
     return u
 end
 
-function HC.ModelKit.taylor!(u::AbstractVector, ::Val{N},
-        sys::HomotopySystemWrapper{OutOfPlace}, x, p = nothing) where {N}
+function HC.ModelKit.taylor!(
+        u::AbstractVector, ::Val{N},
+        sys::HomotopySystemWrapper{OutOfPlace}, x, p = nothing
+    ) where {N}
     f = sys.f
     p = sys.p
     vars = sys.taylorvars
@@ -156,8 +168,10 @@ function HC.ModelKit.taylor!(u::AbstractVector, ::Val{N},
     return u
 end
 
-function HC.ModelKit.taylor!(u::AbstractVector, ::Val{N},
-        sys::HomotopySystemWrapper{Scalar}, x, p = nothing) where {N}
+function HC.ModelKit.taylor!(
+        u::AbstractVector, ::Val{N},
+        sys::HomotopySystemWrapper{Scalar}, x, p = nothing
+    ) where {N}
     f = sys.f
     p = sys.p
     var = sys.taylorvars
@@ -231,8 +245,9 @@ function HC.ModelKit.evaluate_and_jacobian!(u, U, h::GuessHomotopy, x, t, p = no
 end
 
 function HC.ModelKit.taylor!(
-        u, v::Val{N}, H::GuessHomotopy, tx, t, incremental::Bool) where {N}
-    HC.ModelKit.taylor!(u, v, H, tx, t)
+        u, v::Val{N}, H::GuessHomotopy, tx, t, incremental::Bool
+    ) where {N}
+    return HC.ModelKit.taylor!(u, v, H, tx, t)
 end
 
 function HC.ModelKit.taylor!(u, ::Val{N}, h::GuessHomotopy, x, t, p = nothing) where {N}

--- a/lib/NonlinearSolveHomotopyContinuation/test/allroots.jl
+++ b/lib/NonlinearSolveHomotopyContinuation/test/allroots.jl
@@ -42,10 +42,10 @@ alg = HomotopyContinuationJL{true}(; threading = false)
         sort!(sol.u; by = x -> x.u)
         @test sol.u[1] isa NonlinearSolution
         @test SciMLBase.successful_retcode(sol.u[1])
-        @test sol.u[1].u≈2.0 atol=1e-10
+        @test sol.u[1].u ≈ 2.0 atol = 1.0e-10
         @test sol.u[2] isa NonlinearSolution
         @test SciMLBase.successful_retcode(sol.u[2])
-        @test sol.u[2].u≈3.0 atol=1e-10
+        @test sol.u[2].u ≈ 3.0 atol = 1.0e-10
 
         @testset "no real solutions" begin
             prob = NonlinearProblem(1.0, 0.5) do u, p
@@ -69,7 +69,8 @@ alg = HomotopyContinuationJL{true}(; threading = false)
             return [asin(u)]
         end
         fn = HomotopyNonlinearFunction(;
-            denominator, polynomialize, unpolynomialize) do u, p
+            denominator, polynomialize, unpolynomialize
+        ) do u, p
             return (u - p[1]) * (u - p[2])
         end
         prob = NonlinearProblem(fn, 0.0, [0.5, 0.7])
@@ -97,28 +98,30 @@ end
 
 f! = function (du, u, p)
     du[1] = u[1] * u[1] - p[1] * u[2] + u[2]^3 + 1
-    du[2] = u[2]^3 + 2 * p[2] * u[1] * u[2] + u[2]
+    return du[2] = u[2]^3 + 2 * p[2] * u[1] * u[2] + u[2]
 end
 
 f = function (u, p)
-    [u[1] * u[1] - p[1] * u[2] + u[2]^3 + 1, u[2]^3 + 2 * p[2] * u[1] * u[2] + u[2]]
+    return [u[1] * u[1] - p[1] * u[2] + u[2]^3 + 1, u[2]^3 + 2 * p[2] * u[1] * u[2] + u[2]]
 end
 
 fjac! = function (j, u, p)
     j[1, 1] = 2u[1]
     j[1, 2] = -p[1] + 3 * u[2]^2
     j[2, 1] = 2 * p[2] * u[2]
-    j[2, 2] = 3 * u[2]^2 + 2 * p[2] * u[1] + 1
+    return j[2, 2] = 3 * u[2]^2 + 2 * p[2] * u[1] + 1
 end
 fjac = function (u, p)
-    [2u[1] -p[1]+3 * u[2]^2;
-     2*p[2]*u[2] 3*u[2]^2+2*p[2]*u[1]+1]
+    return [
+        2u[1] -p[1] + 3 * u[2]^2;
+        2 * p[2] * u[2] 3 * u[2]^2 + 2 * p[2] * u[1] + 1
+    ]
 end
 
 # Filter test cases based on Julia version
 vector_test_cases = [
     (f, AutoForwardDiff(), "oop + forwarddiff"), (f, fjac, "oop + jac"),
-    (f!, AutoForwardDiff(), "iip + forwarddiff"), (f!, fjac!, "iip + jac")
+    (f!, AutoForwardDiff(), "iip + forwarddiff"), (f!, fjac!, "iip + jac"),
 ]
 if isempty(VERSION.prerelease) && VERSION < v"1.12"
     push!(vector_test_cases, (f, AutoEnzyme(), "oop + enzyme"))
@@ -143,7 +146,7 @@ end
         @test sol.converged
         for nlsol in sol.u
             @test SciMLBase.successful_retcode(nlsol)
-            @test f(nlsol.u, prob.p)≈[0.0, 0.0] atol=1e-10
+            @test f(nlsol.u, prob.p) ≈ [0.0, 0.0] atol = 1.0e-10
         end
 
         @testset "no real solutions" begin
@@ -174,8 +177,9 @@ end
         @test length(sol.u) == length(sol2.u)
         for nlsol2 in sol2.u
             @test any(
-                nlsol -> isapprox(polynomialize(nlsol2.u, prob.p), nlsol.u; rtol = 1e-8),
-                sol.u)
+                nlsol -> isapprox(polynomialize(nlsol2.u, prob.p), nlsol.u; rtol = 1.0e-8),
+                sol.u
+            )
         end
 
         @testset "some invalid solutions" begin
@@ -197,7 +201,8 @@ end
         return u^2 + u - 1
     end
     prob = NonlinearProblem(
-        HomotopyNonlinearFunction(rhs; polynomialize, unpolynomialize), 1.0)
+        HomotopyNonlinearFunction(rhs; polynomialize, unpolynomialize), 1.0
+    )
     sol = solve(prob, alg)
     @test sol isa EnsembleSolution
     for nlsol in sol.u

--- a/lib/NonlinearSolveHomotopyContinuation/test/single_root.jl
+++ b/lib/NonlinearSolveHomotopyContinuation/test/single_root.jl
@@ -32,7 +32,7 @@ alg = HomotopyContinuationJL{false}(; threading = false)
         sol = solve(prob, _alg)
 
         @test sol isa NonlinearSolution
-        @test sol.u≈2.0 atol=1e-10
+        @test sol.u ≈ 2.0 atol = 1.0e-10
 
         @testset "no real solutions" begin
             prob = NonlinearProblem(1.0, 1.0) do u, p
@@ -54,13 +54,14 @@ alg = HomotopyContinuationJL{false}(; threading = false)
             return [asin(u)]
         end
         fn = HomotopyNonlinearFunction(;
-            denominator, polynomialize, unpolynomialize) do u, p
+            denominator, polynomialize, unpolynomialize
+        ) do u, p
             return (u - p[1]) * (u - p[2])
         end
         prob = NonlinearProblem(fn, 0.0, [0.5, 0.7])
 
         sol = solve(prob, alg)
-        @test sin(sol.u[1])≈0.5 atol=1e-10
+        @test sin(sol.u[1]) ≈ 0.5 atol = 1.0e-10
 
         @testset "no valid solutions" begin
             prob2 = remake(prob; p = [0.7, 0.9])
@@ -71,39 +72,41 @@ alg = HomotopyContinuationJL{false}(; threading = false)
         @testset "closest root" begin
             prob3 = remake(prob; p = [0.5, 0.6], u0 = asin(0.4))
             sol3 = solve(prob3, alg)
-            @test sin(sol3.u)≈0.5 atol=1e-10
+            @test sin(sol3.u) ≈ 0.5 atol = 1.0e-10
             prob4 = remake(prob3; u0 = asin(0.7))
             sol4 = solve(prob4, alg)
-            @test sin(sol4.u)≈0.6 atol=1e-10
+            @test sin(sol4.u) ≈ 0.6 atol = 1.0e-10
         end
     end
 end
 
 f! = function (du, u, p)
     du[1] = u[1] * u[1] - p[1] * u[2] + u[2]^3 + 1
-    du[2] = u[2]^3 + 2 * p[2] * u[1] * u[2] + u[2]
+    return du[2] = u[2]^3 + 2 * p[2] * u[1] * u[2] + u[2]
 end
 
 f = function (u, p)
-    [u[1] * u[1] - p[1] * u[2] + u[2]^3 + 1, u[2]^3 + 2 * p[2] * u[1] * u[2] + u[2]]
+    return [u[1] * u[1] - p[1] * u[2] + u[2]^3 + 1, u[2]^3 + 2 * p[2] * u[1] * u[2] + u[2]]
 end
 
 jac! = function (j, u, p)
     j[1, 1] = 2u[1]
     j[1, 2] = -p[1] + 3 * u[2]^2
     j[2, 1] = 2 * p[2] * u[2]
-    j[2, 2] = 3 * u[2]^2 + 2 * p[2] * u[1] + 1
+    return j[2, 2] = 3 * u[2]^2 + 2 * p[2] * u[1] + 1
 end
 
 jac = function (u, p)
-    [2u[1] -p[1]+3 * u[2]^2;
-     2*p[2]*u[2] 3*u[2]^2+2*p[2]*u[1]+1]
+    return [
+        2u[1] -p[1] + 3 * u[2]^2;
+        2 * p[2] * u[2] 3 * u[2]^2 + 2 * p[2] * u[1] + 1
+    ]
 end
 
 # Filter test cases based on Julia version
 vector_test_cases = [
     (f, AutoForwardDiff(), "oop + forwarddiff"), (f, jac, "oop + jac"),
-    (f!, AutoForwardDiff(), "iip + forwarddiff"), (f!, jac!, "iip + jac")
+    (f!, AutoForwardDiff(), "iip + forwarddiff"), (f!, jac!, "iip + jac"),
 ]
 if isempty(VERSION.prerelease) && VERSION < v"1.12"
     push!(vector_test_cases, (f, AutoEnzyme(), "oop + enzyme"))
@@ -124,7 +127,7 @@ end
         prob = NonlinearProblem(fn, [1.0, 2.0], [2.0, 3.0])
         sol = solve(prob, _alg)
         @test SciMLBase.successful_retcode(sol)
-        @test f(sol.u, prob.p)≈[0.0, 0.0] atol=1e-10
+        @test f(sol.u, prob.p) ≈ [0.0, 0.0] atol = 1.0e-10
 
         @testset "no real solutions" begin
             prob2 = remake(prob; p = zeros(2))
@@ -148,7 +151,7 @@ end
         prob = NonlinearProblem(fn, [1.0, 1.0], [2.0, 3.0, 4.0, 5.0])
         sol = solve(prob, _alg)
         @test SciMLBase.successful_retcode(sol)
-        @test f(polynomialize(sol.u, prob.p), prob.p)≈zeros(2) atol=1e-10
+        @test f(polynomialize(sol.u, prob.p), prob.p) ≈ zeros(2) atol = 1.0e-10
 
         @testset "some invalid solutions" begin
             prob2 = remake(prob; p = [2.0, 3.0, polynomialize(sol.u, prob.p)...])
@@ -169,7 +172,8 @@ end
         return u^2 + u - 1
     end
     prob = NonlinearProblem(
-        HomotopyNonlinearFunction(rhs; polynomialize, unpolynomialize), 1.0)
+        HomotopyNonlinearFunction(rhs; polynomialize, unpolynomialize), 1.0
+    )
     sol = solve(prob, alg)
     @test !SciMLBase.successful_retcode(sol)
 end

--- a/lib/NonlinearSolveQuasiNewton/ext/NonlinearSolveQuasiNewtonForwardDiffExt.jl
+++ b/lib/NonlinearSolveQuasiNewton/ext/NonlinearSolveQuasiNewtonForwardDiffExt.jl
@@ -10,21 +10,21 @@ using NonlinearSolveQuasiNewton: QuasiNewtonAlgorithm
 
 const DualNonlinearProblem = NonlinearProblem{
     <:Union{Number, <:AbstractArray}, iip,
-    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}}
+    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}},
 } where {iip, T, V, P}
 const DualNonlinearLeastSquaresProblem = NonlinearLeastSquaresProblem{
     <:Union{Number, <:AbstractArray}, iip,
-    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}}
+    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}},
 } where {iip, T, V, P}
 const DualAbstractNonlinearProblem = Union{
-    DualNonlinearProblem, DualNonlinearLeastSquaresProblem
+    DualNonlinearProblem, DualNonlinearLeastSquaresProblem,
 }
 
 function SciMLBase.__solve(
         prob::DualAbstractNonlinearProblem, alg::QuasiNewtonAlgorithm, args...; kwargs...
-)
+    )
     sol,
-    partials = NonlinearSolveBase.nonlinearsolve_forwarddiff_solve(
+        partials = NonlinearSolveBase.nonlinearsolve_forwarddiff_solve(
         prob, alg, args...; kwargs...
     )
     dual_soln = NonlinearSolveBase.nonlinearsolve_dual_solution(sol.u, partials, prob.p)
@@ -35,7 +35,7 @@ end
 
 function SciMLBase.__init(
         prob::DualAbstractNonlinearProblem, alg::QuasiNewtonAlgorithm, args...; kwargs...
-)
+    )
     p = nodual_value(prob.p)
     newprob = SciMLBase.remake(prob; u0 = nodual_value(prob.u0), p)
     cache = init(newprob, alg, args...; kwargs...)

--- a/lib/NonlinearSolveQuasiNewton/src/NonlinearSolveQuasiNewton.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/NonlinearSolveQuasiNewton.jl
@@ -12,16 +12,16 @@ using LinearAlgebra: LinearAlgebra, Diagonal, dot, diag
 using LinearSolve: LinearSolve # Trigger Linear Solve extension in NonlinearSolveBase
 using MaybeInplace: @bb
 using NonlinearSolveBase: NonlinearSolveBase, AbstractNonlinearSolveAlgorithm,
-                          AbstractNonlinearSolveCache, AbstractResetCondition,
-                          AbstractResetConditionCache, AbstractApproximateJacobianStructure,
-                          AbstractJacobianCache, AbstractJacobianInitialization,
-                          AbstractApproximateJacobianUpdateRule, AbstractDescentDirection,
-                          AbstractApproximateJacobianUpdateRuleCache,
-                          Utils, InternalAPI, get_timer_output, @static_timeit,
-                          update_trace!, L2_NORM, NewtonDescent, NonlinearVerbosity,
-                          @SciMLMessage, None, AbstractVerbosityPreset, reused_jacobian
+    AbstractNonlinearSolveCache, AbstractResetCondition,
+    AbstractResetConditionCache, AbstractApproximateJacobianStructure,
+    AbstractJacobianCache, AbstractJacobianInitialization,
+    AbstractApproximateJacobianUpdateRule, AbstractDescentDirection,
+    AbstractApproximateJacobianUpdateRuleCache,
+    Utils, InternalAPI, get_timer_output, @static_timeit,
+    update_trace!, L2_NORM, NewtonDescent, NonlinearVerbosity,
+    @SciMLMessage, None, AbstractVerbosityPreset, reused_jacobian
 using SciMLBase: SciMLBase, AbstractNonlinearProblem, NLStats, ReturnCode,
-                 NonlinearProblem, NonlinearFunction, NoSpecialize
+    NonlinearProblem, NonlinearFunction, NoSpecialize
 using SciMLOperators: AbstractSciMLOperator
 
 include("reset_conditions.jl")
@@ -38,7 +38,7 @@ include("solve.jl")
     nonlinear_functions = (
         (NonlinearFunction{false, NoSpecialize}((u, p) -> u .* u .- p), 0.1),
         (NonlinearFunction{false, NoSpecialize}((u, p) -> u .* u .- p), [0.1]),
-        (NonlinearFunction{true, NoSpecialize}((du, u, p) -> du .= u .* u .- p), [0.1])
+        (NonlinearFunction{true, NoSpecialize}((du, u, p) -> du .= u .* u .- p), [0.1]),
     )
 
     nonlinear_problems = NonlinearProblem[]
@@ -51,7 +51,7 @@ include("solve.jl")
     @compile_workload begin
         @sync for prob in nonlinear_problems, alg in algs
 
-            Threads.@spawn CommonSolve.solve(prob, alg; abstol = 1e-2, verbose = false)
+            Threads.@spawn CommonSolve.solve(prob, alg; abstol = 1.0e-2, verbose = false)
         end
     end
 end

--- a/lib/NonlinearSolveQuasiNewton/src/lbroyden.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/lbroyden.jl
@@ -20,7 +20,7 @@ and line search.
 function LimitedMemoryBroyden(;
         max_resets::Int = 3, linesearch = nothing, threshold::Union{Val, Int} = Val(10),
         reset_tolerance = nothing, alpha = nothing
-)
+    )
     threshold isa Int && (threshold = Val(threshold))
     return QuasiNewtonAlgorithm(;
         linesearch,

--- a/lib/NonlinearSolveQuasiNewton/src/reset_conditions.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/reset_conditions.jl
@@ -24,7 +24,7 @@ end
 
 function InternalAPI.init(
         condition::NoChangeInStateReset, J, fu, u, du, args...; kwargs...
-)
+    )
     if condition.check_dfu
         @bb dfu = copy(fu)
     else
@@ -32,7 +32,7 @@ function InternalAPI.init(
     end
     T = real(eltype(u))
     tol = condition.reset_tolerance === nothing ? eps(T)^(3 // 4) :
-          T(condition.reset_tolerance)
+        T(condition.reset_tolerance)
     return NoChangeInStateResetCache(dfu, tol, condition, 0, 0)
 end
 
@@ -49,7 +49,7 @@ function InternalAPI.reinit!(cache::NoChangeInStateResetCache; u0 = nothing, kwa
         cache.reset_tolerance = eps(real(eltype(u0)))^(3 // 4)
     end
     cache.steps_since_change_dfu = 0
-    cache.steps_since_change_du = 0
+    return cache.steps_since_change_du = 0
 end
 
 function InternalAPI.solve!(cache::NoChangeInStateResetCache, J, fu, u, du; kwargs...)
@@ -96,9 +96,9 @@ struct IllConditionedJacobianReset <: AbstractResetCondition end
 
 function InternalAPI.init(
         condition::IllConditionedJacobianReset, J, fu, u, du, args...; kwargs...
-)
+    )
     condition_number_threshold = J isa AbstractMatrix ? inv(eps(real(eltype(J))))^(1 // 2) :
-                                 nothing
+        nothing
     return IllConditionedJacobianResetCache(condition_number_threshold)
 end
 
@@ -110,7 +110,7 @@ end
 
 function InternalAPI.solve!(
         cache::IllConditionedJacobianResetCache, J, fu, u, du; kwargs...
-)
+    )
     J isa Number && return iszero(J)
     J isa Diagonal && return any(iszero, diag(J))
     J isa AbstractVector && return any(iszero, J)

--- a/lib/NonlinearSolveQuasiNewton/src/structure.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/structure.jl
@@ -11,7 +11,7 @@ function NonlinearSolveBase.get_full_jacobian(cache, ::DiagonalStructure, J)
 end
 
 function (::DiagonalStructure)(J::AbstractMatrix; alias::Bool = false)
-    @assert size(J, 1)==size(J, 2) "Diagonal Jacobian Structure must be square!"
+    @assert size(J, 1) == size(J, 2) "Diagonal Jacobian Structure must be square!"
     return LinearAlgebra.diag(J)
 end
 (::DiagonalStructure)(J::AbstractVector; alias::Bool = false) = alias ? J : @bb(copy(J))

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests.jl
@@ -4,7 +4,7 @@ include("../../../common/common_rootfind_testing.jl")
 
 end
 
-@testitem "Broyden" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "Broyden" setup = [CoreRootfindTesting] tags = [:core] begin
     using ADTypes, LineSearch
     using LineSearches: LineSearches
     using BenchmarkTools: @ballocated
@@ -16,38 +16,38 @@ end
         using Enzyme
     end
 
-    u0s=([1.0, 1.0], @SVector[1.0, 1.0], 1.0)
+    u0s = ([1.0, 1.0], @SVector[1.0, 1.0], 1.0)
 
     # Filter autodiff backends based on Julia version
-    autodiff_backends=[AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()]
+    autodiff_backends = [AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()]
     if isempty(VERSION.prerelease) && VERSION < v"1.12"
         push!(autodiff_backends, AutoEnzyme())
     end
 
     @testset for ad in autodiff_backends
         @testset "$(nameof(typeof(linesearch)))" for linesearch in (
-            # LineSearchesJL(; method = LineSearches.Static(), autodiff = ad),
-            # LineSearchesJL(; method = LineSearches.BackTracking(), autodiff = ad),
-            # LineSearchesJL(; method = LineSearches.MoreThuente(), autodiff = ad),
-            # LineSearchesJL(; method = LineSearches.StrongWolfe(), autodiff = ad),
-            LineSearchesJL(; method = LineSearches.HagerZhang(), autodiff = ad),
-            BackTracking(; autodiff = ad),
-            LiFukushimaLineSearch()
-        )
+                # LineSearchesJL(; method = LineSearches.Static(), autodiff = ad),
+                # LineSearchesJL(; method = LineSearches.BackTracking(), autodiff = ad),
+                # LineSearchesJL(; method = LineSearches.MoreThuente(), autodiff = ad),
+                # LineSearchesJL(; method = LineSearches.StrongWolfe(), autodiff = ad),
+                LineSearchesJL(; method = LineSearches.HagerZhang(), autodiff = ad),
+                BackTracking(; autodiff = ad),
+                LiFukushimaLineSearch(),
+            )
             @testset for init_jacobian in (Val(:identity), Val(:true_jacobian)),
-                update_rule in (Val(:good_broyden), Val(:bad_broyden), Val(:diagonal))
+                    update_rule in (Val(:good_broyden), Val(:bad_broyden), Val(:diagonal))
 
                 @testset "[OOP] u0: $(typeof(u0))" for u0 in (
-                    [1.0, 1.0], @SVector[1.0, 1.0], 1.0
-                )
+                        [1.0, 1.0], @SVector[1.0, 1.0], 1.0,
+                    )
                     solver = Broyden(; linesearch, init_jacobian, update_rule)
                     sol = solve_oop(quadratic_f, u0; solver)
                     @test SciMLBase.successful_retcode(sol)
                     err = maximum(abs, quadratic_f(sol.u, 2.0))
-                    @test err < 1e-9
+                    @test err < 1.0e-9
 
                     cache = init(
-                        NonlinearProblem{false}(quadratic_f, u0, 2.0), solver, abstol = 1e-9
+                        NonlinearProblem{false}(quadratic_f, u0, 2.0), solver, abstol = 1.0e-9
                     )
                     @test (@ballocated solve!($cache)) < 200
                 end
@@ -59,10 +59,10 @@ end
                     sol = solve_iip(quadratic_f!, u0; solver)
                     @test SciMLBase.successful_retcode(sol)
                     err = maximum(abs, quadratic_f(sol.u, 2.0))
-                    @test err < 1e-9
+                    @test err < 1.0e-9
 
                     cache = init(
-                        NonlinearProblem{true}(quadratic_f!, u0, 2.0), solver, abstol = 1e-9
+                        NonlinearProblem{true}(quadratic_f!, u0, 2.0), solver, abstol = 1.0e-9
                     )
                     @test (@ballocated solve!($cache)) ≤ 64
                 end
@@ -71,28 +71,28 @@ end
     end
 end
 
-@testitem "Broyden: Iterator Interface" setup=[CoreRootfindTesting] tags=[:core] begin
-    p=range(0.01, 2, length = 200)
+@testitem "Broyden: Iterator Interface" setup = [CoreRootfindTesting] tags = [:core] begin
+    p = range(0.01, 2, length = 200)
     @test nlprob_iterator_interface(quadratic_f, p, false, Broyden()) ≈ sqrt.(p)
     @test nlprob_iterator_interface(quadratic_f!, p, true, Broyden()) ≈ sqrt.(p)
 end
 
-@testitem "Broyden Termination Conditions" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "Broyden Termination Conditions" setup = [CoreRootfindTesting] tags = [:core] begin
     using StaticArrays: @SVector
 
     @testset "TC: $(nameof(typeof(termination_condition)))" for termination_condition in
-                                                                TERMINATION_CONDITIONS
+        TERMINATION_CONDITIONS
 
         @testset "u0: $(typeof(u0))" for u0 in ([1.0, 1.0], 1.0, @SVector([1.0, 1.0]))
             probN = NonlinearProblem(quadratic_f, u0, 2.0)
             sol = solve(probN, Broyden(); termination_condition)
             err = maximum(abs, quadratic_f(sol.u, 2.0))
-            @test err < 1e-9
+            @test err < 1.0e-9
         end
     end
 end
 
-@testitem "Klement" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "Klement" setup = [CoreRootfindTesting] tags = [:core] begin
     using ADTypes, LineSearch
     using LineSearches: LineSearches
     using BenchmarkTools: @ballocated
@@ -105,35 +105,36 @@ end
     end
 
     # Filter autodiff backends based on Julia version
-    autodiff_backends=[AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()]
+    autodiff_backends = [AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()]
     if isempty(VERSION.prerelease) && VERSION < v"1.12"
         push!(autodiff_backends, AutoEnzyme())
     end
 
     @testset for ad in autodiff_backends
         @testset "$(nameof(typeof(linesearch)))" for linesearch in (
-            # LineSearchesJL(; method = LineSearches.Static(), autodiff = ad),
-            # LineSearchesJL(; method = LineSearches.BackTracking(), autodiff = ad),
-            # LineSearchesJL(; method = LineSearches.MoreThuente(), autodiff = ad),
-            # LineSearchesJL(; method = LineSearches.StrongWolfe(), autodiff = ad),
-            LineSearchesJL(; method = LineSearches.HagerZhang(), autodiff = ad),
-            BackTracking(; autodiff = ad),
-            LiFukushimaLineSearch()
-        )
+                # LineSearchesJL(; method = LineSearches.Static(), autodiff = ad),
+                # LineSearchesJL(; method = LineSearches.BackTracking(), autodiff = ad),
+                # LineSearchesJL(; method = LineSearches.MoreThuente(), autodiff = ad),
+                # LineSearchesJL(; method = LineSearches.StrongWolfe(), autodiff = ad),
+                LineSearchesJL(; method = LineSearches.HagerZhang(), autodiff = ad),
+                BackTracking(; autodiff = ad),
+                LiFukushimaLineSearch(),
+            )
             @testset for init_jacobian in (
-                Val(:identity), Val(:true_jacobian), Val(:true_jacobian_diagonal))
-                @testset "[OOP] u0: $(typeof(u0))" for u0 in (
-                    [1.0, 1.0], @SVector[1.0, 1.0], 1.0
+                    Val(:identity), Val(:true_jacobian), Val(:true_jacobian_diagonal),
                 )
+                @testset "[OOP] u0: $(typeof(u0))" for u0 in (
+                        [1.0, 1.0], @SVector[1.0, 1.0], 1.0,
+                    )
                     solver = Klement(; linesearch, init_jacobian)
                     sol = solve_oop(quadratic_f, u0; solver)
                     # XXX: some tests are failing by a margin
                     # @test SciMLBase.successful_retcode(sol)
                     err = maximum(abs, quadratic_f(sol.u, 2.0))
-                    @test err < 1e-9
+                    @test err < 1.0e-9
 
                     cache = init(
-                        NonlinearProblem{false}(quadratic_f, u0, 2.0), solver, abstol = 1e-9
+                        NonlinearProblem{false}(quadratic_f, u0, 2.0), solver, abstol = 1.0e-9
                     )
                     @test (@ballocated solve!($cache)) < 200
                 end
@@ -145,10 +146,10 @@ end
                     sol = solve_iip(quadratic_f!, u0; solver)
                     @test SciMLBase.successful_retcode(sol)
                     err = maximum(abs, quadratic_f(sol.u, 2.0))
-                    @test err < 1e-9
+                    @test err < 1.0e-9
 
                     cache = init(
-                        NonlinearProblem{true}(quadratic_f!, u0, 2.0), solver, abstol = 1e-9
+                        NonlinearProblem{true}(quadratic_f!, u0, 2.0), solver, abstol = 1.0e-9
                     )
                     @test (@ballocated solve!($cache)) ≤ 64
                 end
@@ -157,28 +158,28 @@ end
     end
 end
 
-@testitem "Klement: Iterator Interface" setup=[CoreRootfindTesting] tags=[:core] begin
-    p=range(0.01, 2, length = 200)
+@testitem "Klement: Iterator Interface" setup = [CoreRootfindTesting] tags = [:core] begin
+    p = range(0.01, 2, length = 200)
     @test nlprob_iterator_interface(quadratic_f, p, false, Klement()) ≈ sqrt.(p)
     @test nlprob_iterator_interface(quadratic_f!, p, true, Klement()) ≈ sqrt.(p)
 end
 
-@testitem "Klement Termination Conditions" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "Klement Termination Conditions" setup = [CoreRootfindTesting] tags = [:core] begin
     using StaticArrays: @SVector
 
     @testset "TC: $(nameof(typeof(termination_condition)))" for termination_condition in
-                                                                TERMINATION_CONDITIONS
+        TERMINATION_CONDITIONS
 
         @testset "u0: $(typeof(u0))" for u0 in ([1.0, 1.0], 1.0, @SVector([1.0, 1.0]))
             probN = NonlinearProblem(quadratic_f, u0, 2.0)
             sol = solve(probN, Klement(); termination_condition)
             err = maximum(abs, quadratic_f(sol.u, 2.0))
-            @test err < 1e-9
+            @test err < 1.0e-9
         end
     end
 end
 
-@testitem "LimitedMemoryBroyden" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "LimitedMemoryBroyden" setup = [CoreRootfindTesting] tags = [:core] begin
     using ADTypes, LineSearch
     using LineSearches: LineSearches
     using BenchmarkTools: @ballocated
@@ -191,33 +192,33 @@ end
     end
 
     # Filter autodiff backends based on Julia version
-    autodiff_backends=[AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()]
+    autodiff_backends = [AutoForwardDiff(), AutoZygote(), AutoFiniteDiff()]
     if isempty(VERSION.prerelease) && VERSION < v"1.12"
         push!(autodiff_backends, AutoEnzyme())
     end
 
     @testset for ad in autodiff_backends
         @testset "$(nameof(typeof(linesearch)))" for linesearch in (
-            # LineSearchesJL(; method = LineSearches.Static(), autodiff = ad),
-            # LineSearchesJL(; method = LineSearches.BackTracking(), autodiff = ad),
-            # LineSearchesJL(; method = LineSearches.MoreThuente(), autodiff = ad),
-            # LineSearchesJL(; method = LineSearches.StrongWolfe(), autodiff = ad),
-            LineSearchesJL(; method = LineSearches.HagerZhang(), autodiff = ad),
-            BackTracking(; autodiff = ad),
-            LiFukushimaLineSearch()
-        )
+                # LineSearchesJL(; method = LineSearches.Static(), autodiff = ad),
+                # LineSearchesJL(; method = LineSearches.BackTracking(), autodiff = ad),
+                # LineSearchesJL(; method = LineSearches.MoreThuente(), autodiff = ad),
+                # LineSearchesJL(; method = LineSearches.StrongWolfe(), autodiff = ad),
+                LineSearchesJL(; method = LineSearches.HagerZhang(), autodiff = ad),
+                BackTracking(; autodiff = ad),
+                LiFukushimaLineSearch(),
+            )
             @testset "[OOP] u0: $(typeof(u0))" for u0 in (ones(32), @SVector(ones(2)), 1.0)
                 broken = Sys.iswindows() && u0 isa Vector{Float64} &&
-                         linesearch isa BackTracking && ad isa AutoFiniteDiff
+                    linesearch isa BackTracking && ad isa AutoFiniteDiff
 
                 solver = LimitedMemoryBroyden(; linesearch)
                 sol = solve_oop(quadratic_f, u0; solver)
-                @test SciMLBase.successful_retcode(sol) broken=broken
+                @test SciMLBase.successful_retcode(sol) broken = broken
                 err = maximum(abs, quadratic_f(sol.u, 2.0))
-                @test err<1e-9 broken=broken
+                @test err < 1.0e-9 broken = broken
 
                 cache = init(
-                    NonlinearProblem{false}(quadratic_f, u0, 2.0), solver, abstol = 1e-9
+                    NonlinearProblem{false}(quadratic_f, u0, 2.0), solver, abstol = 1.0e-9
                 )
                 @test (@ballocated solve!($cache)) ≤ 400
             end
@@ -226,16 +227,16 @@ end
                 ad isa AutoZygote && continue
 
                 broken = Sys.iswindows() && u0 isa Vector{Float64} &&
-                         linesearch isa BackTracking && ad isa AutoFiniteDiff
+                    linesearch isa BackTracking && ad isa AutoFiniteDiff
 
                 solver = LimitedMemoryBroyden(; linesearch)
                 sol = solve_iip(quadratic_f!, u0; solver)
-                @test SciMLBase.successful_retcode(sol) broken=broken
+                @test SciMLBase.successful_retcode(sol) broken = broken
                 err = maximum(abs, quadratic_f(sol.u, 2.0))
-                @test err<1e-9 broken=broken
+                @test err < 1.0e-9 broken = broken
 
                 cache = init(
-                    NonlinearProblem{true}(quadratic_f!, u0, 2.0), solver, abstol = 1e-9
+                    NonlinearProblem{true}(quadratic_f!, u0, 2.0), solver, abstol = 1.0e-9
                 )
                 @test (@ballocated solve!($cache)) ≤ 64
             end
@@ -243,25 +244,25 @@ end
     end
 end
 
-@testitem "LimitedMemoryBroyden: Iterator Interface" setup=[CoreRootfindTesting] tags=[:core] begin
-    p=range(0.01, 2, length = 200)
+@testitem "LimitedMemoryBroyden: Iterator Interface" setup = [CoreRootfindTesting] tags = [:core] begin
+    p = range(0.01, 2, length = 200)
     @test nlprob_iterator_interface(quadratic_f, p, false, LimitedMemoryBroyden()) ≈
-          sqrt.(p)
+        sqrt.(p)
     @test nlprob_iterator_interface(quadratic_f!, p, true, LimitedMemoryBroyden()) ≈
-          sqrt.(p)
+        sqrt.(p)
 end
 
-@testitem "LimitedMemoryBroyden Termination Conditions" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "LimitedMemoryBroyden Termination Conditions" setup = [CoreRootfindTesting] tags = [:core] begin
     using StaticArrays: @SVector
 
     @testset "TC: $(nameof(typeof(termination_condition)))" for termination_condition in
-                                                                TERMINATION_CONDITIONS
+        TERMINATION_CONDITIONS
 
         @testset "u0: $(typeof(u0))" for u0 in ([1.0, 1.0], 1.0, @SVector([1.0, 1.0]))
             probN = NonlinearProblem(quadratic_f, u0, 2.0)
             sol = solve(probN, LimitedMemoryBroyden(); termination_condition)
             err = maximum(abs, quadratic_f(sol.u, 2.0))
-            @test err < 1e-9
+            @test err < 1.0e-9
         end
     end
 end

--- a/lib/NonlinearSolveQuasiNewton/test/qa_tests.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/qa_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Aqua" tags=[:core] begin
+@testitem "Aqua" tags = [:core] begin
     using Aqua, NonlinearSolveQuasiNewton
 
     Aqua.test_all(
@@ -11,7 +11,7 @@
     Aqua.test_ambiguities(NonlinearSolveQuasiNewton; recursive = false)
 end
 
-@testitem "Explicit Imports" tags=[:core] begin
+@testitem "Explicit Imports" tags = [:core] begin
     using ExplicitImports, NonlinearSolveQuasiNewton
 
     @test check_no_implicit_imports(

--- a/lib/NonlinearSolveQuasiNewton/test/runtests.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/runtests.jl
@@ -5,11 +5,13 @@ using ReTestItems, NonlinearSolveQuasiNewton, Hwloc, InteractiveUtils, Pkg
 const GROUP = lowercase(get(ENV, "GROUP", "All"))
 
 const RETESTITEMS_NWORKERS = parse(
-    Int, get(ENV, "RETESTITEMS_NWORKERS",
+    Int, get(
+        ENV, "RETESTITEMS_NWORKERS",
         string(min(ifelse(Sys.iswindows(), 0, Hwloc.num_physical_cores()), 4))
     )
 )
-const RETESTITEMS_NWORKER_THREADS = parse(Int,
+const RETESTITEMS_NWORKER_THREADS = parse(
+    Int,
     get(
         ENV, "RETESTITEMS_NWORKER_THREADS",
         string(max(Hwloc.num_virtual_cores() ÷ max(RETESTITEMS_NWORKERS, 1), 1))

--- a/lib/NonlinearSolveSciPy/test/wrappers_tests.jl
+++ b/lib/NonlinearSolveSciPy/test/wrappers_tests.jl
@@ -1,4 +1,4 @@
-@testitem "SciPyLeastSquares" tags=[:wrappers] begin
+@testitem "SciPyLeastSquares" tags = [:wrappers] begin
     using SciMLBase, NonlinearSolveSciPy
     success = false
     try
@@ -18,8 +18,11 @@
         prob = NonlinearLeastSquaresProblem(residuals, x0_ls)
         sol = solve(prob, SciPyLeastSquaresTRF())
         @test SciMLBase.successful_retcode(sol)
-        prob_bounded = NonlinearLeastSquaresProblem(residuals, x0_ls; lb = [0.0, -2.0], ub = [
-            5.0, 3.0])
+        prob_bounded = NonlinearLeastSquaresProblem(
+            residuals, x0_ls; lb = [0.0, -2.0], ub = [
+                5.0, 3.0,
+            ]
+        )
         sol2 = solve(prob_bounded, SciPyLeastSquares(method = "trf"))
         @test SciMLBase.successful_retcode(sol2)
     else
@@ -27,7 +30,7 @@
     end
 end
 
-@testitem "SciPyRoot + SciPyRootScalar" tags=[:wrappers] begin
+@testitem "SciPyRoot + SciPyRootScalar" tags = [:wrappers] begin
     using SciMLBase, NonlinearSolveSciPy
     success = false
     try
@@ -43,13 +46,13 @@ end
         prob_vec = NonlinearProblem(fvec, zeros(2))
         sol_vec = solve(prob_vec, SciPyRoot())
         @test SciMLBase.successful_retcode(sol_vec)
-        @test maximum(abs, sol_vec.resid) < 1e-6
+        @test maximum(abs, sol_vec.resid) < 1.0e-6
 
         fscalar(x, p) = x^2 - 2
         prob_interval = IntervalNonlinearProblem(fscalar, (1.0, 2.0))
         sol_scalar = solve(prob_interval, SciPyRootScalar())
         @test SciMLBase.successful_retcode(sol_scalar)
-        @test abs(sol_scalar.u - sqrt(2)) < 1e-6
+        @test abs(sol_scalar.u - sqrt(2)) < 1.0e-6
     else
         @test true
     end

--- a/lib/NonlinearSolveSpectralMethods/ext/NonlinearSolveSpectralMethodsForwardDiffExt.jl
+++ b/lib/NonlinearSolveSpectralMethods/ext/NonlinearSolveSpectralMethodsForwardDiffExt.jl
@@ -10,21 +10,21 @@ using NonlinearSolveSpectralMethods: GeneralizedDFSane
 
 const DualNonlinearProblem = NonlinearProblem{
     <:Union{Number, <:AbstractArray}, iip,
-    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}}
+    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}},
 } where {iip, T, V, P}
 const DualNonlinearLeastSquaresProblem = NonlinearLeastSquaresProblem{
     <:Union{Number, <:AbstractArray}, iip,
-    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}}
+    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}},
 } where {iip, T, V, P}
 const DualAbstractNonlinearProblem = Union{
-    DualNonlinearProblem, DualNonlinearLeastSquaresProblem
+    DualNonlinearProblem, DualNonlinearLeastSquaresProblem,
 }
 
 function SciMLBase.__solve(
         prob::DualAbstractNonlinearProblem, alg::GeneralizedDFSane, args...; kwargs...
-)
+    )
     sol,
-    partials = NonlinearSolveBase.nonlinearsolve_forwarddiff_solve(
+        partials = NonlinearSolveBase.nonlinearsolve_forwarddiff_solve(
         prob, alg, args...; kwargs...
     )
     dual_soln = NonlinearSolveBase.nonlinearsolve_dual_solution(sol.u, partials, prob.p)
@@ -35,7 +35,7 @@ end
 
 function SciMLBase.__init(
         prob::DualAbstractNonlinearProblem, alg::GeneralizedDFSane, args...; kwargs...
-)
+    )
     p = nodual_value(prob.p)
     newprob = SciMLBase.remake(prob; u0 = nodual_value(prob.u0), p)
     cache = init(newprob, alg, args...; kwargs...)

--- a/lib/NonlinearSolveSpectralMethods/src/NonlinearSolveSpectralMethods.jl
+++ b/lib/NonlinearSolveSpectralMethods/src/NonlinearSolveSpectralMethods.jl
@@ -8,11 +8,11 @@ using CommonSolve: CommonSolve
 using LineSearch: RobustNonMonotoneLineSearch
 using MaybeInplace: @bb
 using NonlinearSolveBase: NonlinearSolveBase, AbstractNonlinearSolveAlgorithm,
-                          AbstractNonlinearSolveCache, Utils, InternalAPI, get_timer_output,
-                          @static_timeit, update_trace!, NonlinearVerbosity, @SciMLMessage, None,
-                          AbstractVerbosityPreset
+    AbstractNonlinearSolveCache, Utils, InternalAPI, get_timer_output,
+    @static_timeit, update_trace!, NonlinearVerbosity, @SciMLMessage, None,
+    AbstractVerbosityPreset
 using SciMLBase: SciMLBase, AbstractNonlinearProblem, NLStats, ReturnCode,
-                 NonlinearProblem, NonlinearFunction, NoSpecialize
+    NonlinearProblem, NonlinearFunction, NoSpecialize
 
 include("dfsane.jl")
 
@@ -22,7 +22,7 @@ include("solve.jl")
     nonlinear_functions = (
         (NonlinearFunction{false, NoSpecialize}((u, p) -> u .* u .- p), 0.1),
         (NonlinearFunction{false, NoSpecialize}((u, p) -> u .* u .- p), [0.1]),
-        (NonlinearFunction{true, NoSpecialize}((du, u, p) -> du .= u .* u .- p), [0.1])
+        (NonlinearFunction{true, NoSpecialize}((du, u, p) -> du .= u .* u .- p), [0.1]),
     )
 
     nonlinear_problems = NonlinearProblem[]
@@ -35,7 +35,7 @@ include("solve.jl")
     @compile_workload begin
         @sync for prob in nonlinear_problems, alg in algs
 
-            Threads.@spawn CommonSolve.solve(prob, alg; abstol = 1e-2, verbose = false)
+            Threads.@spawn CommonSolve.solve(prob, alg; abstol = 1.0e-2, verbose = false)
         end
     end
 end

--- a/lib/NonlinearSolveSpectralMethods/src/dfsane.jl
+++ b/lib/NonlinearSolveSpectralMethods/src/dfsane.jl
@@ -19,11 +19,12 @@ parameters and the algorithm, see [la2006spectral](@citet).
 For other keyword arguments, see RobustNonMonotoneLineSearch in LineSearch.jl.
 """
 function DFSane(;
-        sigma_min = 1 // 10^10, sigma_max = 1e10, sigma_1 = 1, M::Int = 10,
+        sigma_min = 1 // 10^10, sigma_max = 1.0e10, sigma_1 = 1, M::Int = 10,
         gamma = 1 // 10^4, tau_min = 1 // 10, tau_max = 1 // 2, n_exp::Int = 2,
         max_inner_iterations::Int = 100, eta_strategy::F = (
-            fn_1, n, x_n, f_n) -> fn_1 / n^2
-) where {F}
+            fn_1, n, x_n, f_n,
+        ) -> fn_1 / n^2
+    ) where {F}
     linesearch = RobustNonMonotoneLineSearch(;
         gamma = gamma, sigma_1 = sigma_1, M, tau_min = tau_min, tau_max = tau_max,
         n_exp, η_strategy = eta_strategy, maxiters = max_inner_iterations

--- a/lib/NonlinearSolveSpectralMethods/src/solve.jl
+++ b/lib/NonlinearSolveSpectralMethods/src/solve.jl
@@ -29,7 +29,7 @@ end
 
 function GeneralizedDFSane(;
         linesearch, sigma_min, sigma_max, sigma_1, name::Symbol = :unknown
-)
+    )
     return GeneralizedDFSane(linesearch, sigma_min, sigma_max, sigma_1, name)
 end
 
@@ -75,10 +75,10 @@ end
 end
 
 function SciMLBase.get_du(cache::GeneralizedDFSaneCache)
-    cache.du
+    return cache.du
 end
 function NonlinearSolveBase.set_du!(cache::GeneralizedDFSaneCache, δu)
-    cache.du = δu
+    return cache.du = δu
 end
 
 function InternalAPI.reinit_self!(
@@ -86,7 +86,7 @@ function InternalAPI.reinit_self!(
         alias_u0::Bool = hasproperty(cache, :alias_u0) ? cache.alias_u0 : false,
         maxiters = hasproperty(cache, :maxiters) ? cache.maxiters : 1000,
         maxtime = hasproperty(cache, :maxtime) ? cache.maxtime : nothing, kwargs...
-)
+    )
     Utils.reinit_common!(cache, u0, p, alias_u0)
     T = eltype(u0)
 
@@ -95,7 +95,7 @@ function InternalAPI.reinit_self!(
         # Spectral parameter bounds check
         if !(cache.alg.σ_min ≤ abs(σ_n) ≤ cache.alg.σ_max)
             test_norm = NonlinearSolveBase.L2_NORM(cache.fu)
-            σ_n = clamp(inv(test_norm), T(1), T(1e5))
+            σ_n = clamp(inv(test_norm), T(1), T(1.0e5))
         end
     else
         σ_n = T(cache.alg.σ_1)
@@ -126,9 +126,9 @@ function SciMLBase.__init(
         prob::AbstractNonlinearProblem, alg::GeneralizedDFSane, args...;
         stats = NLStats(0, 0, 0, 0, 0), alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = false), maxiters = 1000,
         abstol = nothing, reltol = nothing, termination_condition = nothing,
-        maxtime = nothing, verbose = NonlinearVerbosity(), 
+        maxtime = nothing, verbose = NonlinearVerbosity(),
         initializealg = NonlinearSolveBase.NonlinearSolveDefaultInit(), kwargs...
-)
+    )
     if haskey(kwargs, :alias_u0)
         alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = kwargs[:alias_u0])
     end
@@ -147,7 +147,7 @@ function SciMLBase.__init(
         linesearch_cache = CommonSolve.init(prob, alg.linesearch, fu, u; stats, kwargs...)
 
         abstol, reltol,
-        tc_cache = NonlinearSolveBase.init_termination_cache(
+            tc_cache = NonlinearSolveBase.init_termination_cache(
             prob, abstol, reltol, fu, u_cache, termination_condition, Val(:regular)
         )
         trace = NonlinearSolveBase.init_nonlinearsolve_trace(
@@ -159,7 +159,7 @@ function SciMLBase.__init(
             # Spectral parameter bounds check
             if !(alg.σ_min ≤ abs(σ_n) ≤ alg.σ_max)
                 test_norm = NonlinearSolveBase.L2_NORM(fu)
-                σ_n = clamp(inv(test_norm), T(1), T(1e5))
+                σ_n = clamp(inv(test_norm), T(1), T(1.0e5))
             end
         else
             σ_n = T(alg.σ_1)
@@ -190,7 +190,7 @@ end
 function InternalAPI.step!(
         cache::GeneralizedDFSaneCache; recompute_jacobian::Union{Nothing, Bool} = nothing,
         kwargs...
-)
+    )
     if recompute_jacobian !== nothing
         @warn "GeneralizedDFSane is a Jacobian-Free Algorithm. Ignoring \
               `recompute_jacobian`"
@@ -227,13 +227,13 @@ function InternalAPI.step!(
         @bb @. cache.fu_cache = cache.fu - cache.fu_cache
 
         cache.σ_n = Utils.safe_dot(cache.u_cache, cache.u_cache) /
-                    Utils.safe_dot(cache.u_cache, cache.fu_cache)
+            Utils.safe_dot(cache.u_cache, cache.fu_cache)
 
         # Spectral parameter bounds check
         if !(cache.σ_min ≤ abs(cache.σ_n) ≤ cache.σ_max)
             test_norm = NonlinearSolveBase.L2_NORM(cache.fu)
             T = eltype(cache.σ_n)
-            cache.σ_n = clamp(inv(test_norm), T(1), T(1e5))
+            cache.σ_n = clamp(inv(test_norm), T(1), T(1.0e5))
         end
     end
 

--- a/lib/NonlinearSolveSpectralMethods/test/core_tests.jl
+++ b/lib/NonlinearSolveSpectralMethods/test/core_tests.jl
@@ -4,19 +4,19 @@ include("../../../common/common_rootfind_testing.jl")
 
 end
 
-@testitem "DFSane" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "DFSane" setup = [CoreRootfindTesting] tags = [:core] begin
     using BenchmarkTools: @ballocated
     using StaticArrays: @SVector
 
-    u0s=([1.0, 1.0], @SVector[1.0, 1.0], 1.0)
+    u0s = ([1.0, 1.0], @SVector[1.0, 1.0], 1.0)
 
     @testset "[OOP] u0: $(typeof(u0))" for u0 in u0s
         sol = solve_oop(quadratic_f, u0; solver = DFSane())
         @test SciMLBase.successful_retcode(sol)
         err = maximum(abs, quadratic_f(sol.u, 2.0))
-        @test err < 1e-9
+        @test err < 1.0e-9
 
-        cache = init(NonlinearProblem{false}(quadratic_f, u0, 2.0), DFSane(), abstol = 1e-9)
+        cache = init(NonlinearProblem{false}(quadratic_f, u0, 2.0), DFSane(), abstol = 1.0e-9)
         @test (@ballocated solve!($cache)) < 200
     end
 
@@ -24,66 +24,66 @@ end
         sol = solve_iip(quadratic_f!, u0; solver = DFSane())
         @test SciMLBase.successful_retcode(sol)
         err = maximum(abs, quadratic_f(sol.u, 2.0))
-        @test err < 1e-9
+        @test err < 1.0e-9
 
-        cache = init(NonlinearProblem{true}(quadratic_f!, u0, 2.0), DFSane(), abstol = 1e-9)
+        cache = init(NonlinearProblem{true}(quadratic_f!, u0, 2.0), DFSane(), abstol = 1.0e-9)
         @test (@ballocated solve!($cache)) ≤ 64
     end
 end
 
-@testitem "DFSane Iterator Interface" setup=[CoreRootfindTesting] tags=[:core] begin
-    p=range(0.01, 2, length = 200)
+@testitem "DFSane Iterator Interface" setup = [CoreRootfindTesting] tags = [:core] begin
+    p = range(0.01, 2, length = 200)
     @test nlprob_iterator_interface(quadratic_f, p, false, DFSane()) ≈ sqrt.(p)
     @test nlprob_iterator_interface(quadratic_f!, p, true, DFSane()) ≈ sqrt.(p)
 end
 
-@testitem "DFSane NewtonRaphson Fails" setup=[CoreRootfindTesting] tags=[:core] begin
-    u0=[-10.0, -1.0, 1.0, 2.0, 3.0, 4.0, 10.0]
-    p=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-    sol=solve_oop(newton_fails, u0, p; solver = DFSane())
+@testitem "DFSane NewtonRaphson Fails" setup = [CoreRootfindTesting] tags = [:core] begin
+    u0 = [-10.0, -1.0, 1.0, 2.0, 3.0, 4.0, 10.0]
+    p = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    sol = solve_oop(newton_fails, u0, p; solver = DFSane())
     @test SciMLBase.successful_retcode(sol)
-    @test all(abs.(newton_fails(sol.u, p)) .< 1e-9)
+    @test all(abs.(newton_fails(sol.u, p)) .< 1.0e-9)
 end
 
-@testitem "DFSane: Kwargs" setup=[CoreRootfindTesting] tags=[:core] begin
-    σ_min=[1e-10, 1e-5, 1e-4]
-    σ_max=[1e10, 1e5, 1e4]
-    σ_1=[1.0, 0.5, 2.0]
-    M=[10, 1, 100]
-    γ=[1e-4, 1e-3, 1e-5]
-    τ_min=[0.1, 0.2, 0.3]
-    τ_max=[0.5, 0.8, 0.9]
-    nexp=[2, 1, 2]
-    η_strategy=[
-        (f_1, k, x, F)->f_1/k^2, (f_1, k, x, F)->f_1/k^3,
-        (f_1, k, x, F)->f_1/k^4
+@testitem "DFSane: Kwargs" setup = [CoreRootfindTesting] tags = [:core] begin
+    σ_min = [1.0e-10, 1.0e-5, 1.0e-4]
+    σ_max = [1.0e10, 1.0e5, 1.0e4]
+    σ_1 = [1.0, 0.5, 2.0]
+    M = [10, 1, 100]
+    γ = [1.0e-4, 1.0e-3, 1.0e-5]
+    τ_min = [0.1, 0.2, 0.3]
+    τ_max = [0.5, 0.8, 0.9]
+    nexp = [2, 1, 2]
+    η_strategy = [
+        (f_1, k, x, F) -> f_1 / k^2, (f_1, k, x, F) -> f_1 / k^3,
+        (f_1, k, x, F) -> f_1 / k^4,
     ]
 
-    list_of_options=zip(σ_min, σ_max, σ_1, M, γ, τ_min, τ_max, nexp, η_strategy)
+    list_of_options = zip(σ_min, σ_max, σ_1, M, γ, τ_min, τ_max, nexp, η_strategy)
     for options in list_of_options
         local probN, sol, alg
-        alg=DFSane(;
+        alg = DFSane(;
             sigma_min = options[1], sigma_max = options[2], sigma_1 = options[3],
             M = options[4], gamma = options[5], tau_min = options[6],
             tau_max = options[7], n_exp = options[8], eta_strategy = options[9]
         )
 
-        probN=NonlinearProblem{false}(quadratic_f, [1.0, 1.0], 2.0)
-        sol=solve(probN, alg, abstol = 1e-11)
-        @test all(abs.(quadratic_f(sol.u, 2.0)) .< 1e-6)
+        probN = NonlinearProblem{false}(quadratic_f, [1.0, 1.0], 2.0)
+        sol = solve(probN, alg, abstol = 1.0e-11)
+        @test all(abs.(quadratic_f(sol.u, 2.0)) .< 1.0e-6)
     end
 end
 
-@testitem "DFSane Termination Conditions" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "DFSane Termination Conditions" setup = [CoreRootfindTesting] tags = [:core] begin
     using StaticArrays: @SVector
 
     @testset "TC: $(nameof(typeof(termination_condition)))" for termination_condition in
-                                                                TERMINATION_CONDITIONS
+        TERMINATION_CONDITIONS
 
         @testset "u0: $(typeof(u0))" for u0 in ([1.0, 1.0], 1.0, @SVector([1.0, 1.0]))
             probN = NonlinearProblem(quadratic_f, u0, 2.0)
             sol = solve(probN, DFSane(); termination_condition)
-            @test all(abs.(quadratic_f(sol.u, 2.0)) .< 1e-10)
+            @test all(abs.(quadratic_f(sol.u, 2.0)) .< 1.0e-10)
         end
     end
 end

--- a/lib/NonlinearSolveSpectralMethods/test/qa_tests.jl
+++ b/lib/NonlinearSolveSpectralMethods/test/qa_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Aqua" tags=[:core] begin
+@testitem "Aqua" tags = [:core] begin
     using Aqua, NonlinearSolveSpectralMethods
 
     Aqua.test_all(
@@ -11,7 +11,7 @@
     Aqua.test_ambiguities(NonlinearSolveSpectralMethods; recursive = false)
 end
 
-@testitem "Explicit Imports" tags=[:core] begin
+@testitem "Explicit Imports" tags = [:core] begin
     using ExplicitImports, NonlinearSolveSpectralMethods
 
     @test check_no_implicit_imports(

--- a/lib/NonlinearSolveSpectralMethods/test/runtests.jl
+++ b/lib/NonlinearSolveSpectralMethods/test/runtests.jl
@@ -5,11 +5,13 @@ using ReTestItems, NonlinearSolveSpectralMethods, Hwloc, InteractiveUtils, Pkg
 const GROUP = lowercase(get(ENV, "GROUP", "All"))
 
 const RETESTITEMS_NWORKERS = parse(
-    Int, get(ENV, "RETESTITEMS_NWORKERS",
+    Int, get(
+        ENV, "RETESTITEMS_NWORKERS",
         string(min(ifelse(Sys.iswindows(), 0, Hwloc.num_physical_cores()), 4))
     )
 )
-const RETESTITEMS_NWORKER_THREADS = parse(Int,
+const RETESTITEMS_NWORKER_THREADS = parse(
+    Int,
     get(
         ENV, "RETESTITEMS_NWORKER_THREADS",
         string(max(Hwloc.num_virtual_cores() ÷ max(RETESTITEMS_NWORKERS, 1), 1))

--- a/lib/SCCNonlinearSolve/ext/SCCNonlinearSolveChainRulesCoreExt.jl
+++ b/lib/SCCNonlinearSolve/ext/SCCNonlinearSolveChainRulesCoreExt.jl
@@ -2,15 +2,16 @@ module SCCNonlinearSolveChainRulesCoreExt
 
 import SCCNonlinearSolve: SCCAlg, scc_solve_up
 using SciMLBase: SCCNonlinearProblem, AbstractSensitivityAlgorithm, ChainRulesOriginator,
-                 _concrete_solve_adjoint
+    _concrete_solve_adjoint
 
 import ChainRulesCore
 
 function ChainRulesCore.rrule(
         ::typeof(scc_solve_up), prob::SCCNonlinearProblem,
         sensealg::Union{Nothing, AbstractSensitivityAlgorithm},
-        u0, p, alg::SCCAlg; kwargs...)
-    _concrete_solve_adjoint(prob, alg, sensealg, u0, p, ChainRulesOriginator(); kwargs...)
+        u0, p, alg::SCCAlg; kwargs...
+    )
+    return _concrete_solve_adjoint(prob, alg, sensealg, u0, p, ChainRulesOriginator(); kwargs...)
 end
 
 end

--- a/lib/SCCNonlinearSolve/test/core_tests.jl
+++ b/lib/SCCNonlinearSolve/test/core_tests.jl
@@ -4,79 +4,85 @@ include("../../../common/common_rootfind_testing.jl")
 
 end
 
-@testitem "Manual SCC" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "Manual SCC" setup = [CoreRootfindTesting] tags = [:core] begin
     using NonlinearSolveFirstOrder
     function f(du, u, p)
-        du[1]=cos(u[2])-u[1]
-        du[2]=sin(u[1]+u[2])+u[2]
-        du[3]=2u[4]+u[3]+1.0
-        du[4]=u[5]^2+u[4]
-        du[5]=u[3]^2+u[5]
-        du[6]=u[1]+u[2]+u[3]+u[4]+u[5]+2.0u[6]+2.5u[7]+1.5u[8]
-        du[7]=u[1]+u[2]+u[3]+2.0u[4]+u[5]+4.0u[6]-1.5u[7]+1.5u[8]
-        du[8]=u[1]+2.0u[2]+3.0u[3]+5.0u[4]+6.0u[5]+u[6]-u[7]-u[8]
+        du[1] = cos(u[2]) - u[1]
+        du[2] = sin(u[1] + u[2]) + u[2]
+        du[3] = 2u[4] + u[3] + 1.0
+        du[4] = u[5]^2 + u[4]
+        du[5] = u[3]^2 + u[5]
+        du[6] = u[1] + u[2] + u[3] + u[4] + u[5] + 2.0u[6] + 2.5u[7] + 1.5u[8]
+        du[7] = u[1] + u[2] + u[3] + 2.0u[4] + u[5] + 4.0u[6] - 1.5u[7] + 1.5u[8]
+        du[8] = u[1] + 2.0u[2] + 3.0u[3] + 5.0u[4] + 6.0u[5] + u[6] - u[7] - u[8]
     end
-    prob=NonlinearProblem(f, zeros(8))
-    sol=solve(prob, NewtonRaphson())
+    prob = NonlinearProblem(f, zeros(8))
+    sol = solve(prob, NewtonRaphson())
 
-    u0=zeros(2)
-    p=zeros(3)
+    u0 = zeros(2)
+    p = zeros(3)
 
     function f1(du, u, p)
-        du[1]=cos(u[2])-u[1]
-        du[2]=sin(u[1]+u[2])+u[2]
+        du[1] = cos(u[2]) - u[1]
+        du[2] = sin(u[1] + u[2]) + u[2]
     end
-    explicitfun1(p, sols)=nothing
-    prob1=NonlinearProblem(
-        NonlinearFunction{true, SciMLBase.NoSpecialize}(f1), zeros(2), p)
-    sol1=solve(prob1, NewtonRaphson())
+    explicitfun1(p, sols) = nothing
+    prob1 = NonlinearProblem(
+        NonlinearFunction{true, SciMLBase.NoSpecialize}(f1), zeros(2), p
+    )
+    sol1 = solve(prob1, NewtonRaphson())
 
     function f2(du, u, p)
-        du[1]=2u[2]+u[1]+1.0
-        du[2]=u[3]^2+u[2]
-        du[3]=u[1]^2+u[3]
+        du[1] = 2u[2] + u[1] + 1.0
+        du[2] = u[3]^2 + u[2]
+        du[3] = u[1]^2 + u[3]
     end
-    explicitfun2(p, sols)=nothing
-    prob2=NonlinearProblem(
-        NonlinearFunction{true, SciMLBase.NoSpecialize}(f2), zeros(3), p)
-    sol2=solve(prob2, NewtonRaphson())
+    explicitfun2(p, sols) = nothing
+    prob2 = NonlinearProblem(
+        NonlinearFunction{true, SciMLBase.NoSpecialize}(f2), zeros(3), p
+    )
+    sol2 = solve(prob2, NewtonRaphson())
 
     # Convert f3 to a LinearProblem since it's linear in u
     # du = Au + b where A is the coefficient matrix and b is from parameters
-    A3=[2.0 2.5 1.5; 4.0 -1.5 1.5; 1.0 -1.0 -1.0]
-    b3=p  # b will be updated by explicitfun3
-    prob3=LinearProblem(A3, b3, zeros(3))
+    A3 = [2.0 2.5 1.5; 4.0 -1.5 1.5; 1.0 -1.0 -1.0]
+    b3 = p  # b will be updated by explicitfun3
+    prob3 = LinearProblem(A3, b3, zeros(3))
     function explicitfun3(p, sols)
-        p[1]=-(sols[1][1]+sols[1][2]+sols[2][1]+sols[2][2]+sols[2][3])
-        p[2]=-(sols[1][1]+sols[1][2]+sols[2][1]+2.0sols[2][2]+sols[2][3])
-        p[3]=-(sols[1][1]+2.0sols[1][2]+3.0sols[2][1]+5.0sols[2][2]+
-               6.0sols[2][3])
+        p[1] = -(sols[1][1] + sols[1][2] + sols[2][1] + sols[2][2] + sols[2][3])
+        p[2] = -(sols[1][1] + sols[1][2] + sols[2][1] + 2.0sols[2][2] + sols[2][3])
+        p[3] = -(
+            sols[1][1] + 2.0sols[1][2] + 3.0sols[2][1] + 5.0sols[2][2] +
+                6.0sols[2][3]
+        )
     end
     explicitfun3(p, [sol1, sol2])
-    sol3=solve(prob3)  # LinearProblem uses default linear solver
-    manualscc=reduce(vcat, (sol1, sol2, sol3))
+    sol3 = solve(prob3)  # LinearProblem uses default linear solver
+    manualscc = reduce(vcat, (sol1, sol2, sol3))
 
-    sccprob=SciMLBase.SCCNonlinearProblem((prob1, prob2, prob3),
-        SciMLBase.Void{Any}.([explicitfun1, explicitfun2, explicitfun3]))
+    sccprob = SciMLBase.SCCNonlinearProblem(
+        (prob1, prob2, prob3),
+        SciMLBase.Void{Any}.([explicitfun1, explicitfun2, explicitfun3])
+    )
 
     # Test with SCCAlg that handles both nonlinear and linear problems
     using SCCNonlinearSolve
-    scc_alg=SCCNonlinearSolve.SCCAlg(nlalg = NewtonRaphson(), linalg = nothing)
-    scc_sol=solve(sccprob, scc_alg)
+    scc_alg = SCCNonlinearSolve.SCCAlg(nlalg = NewtonRaphson(), linalg = nothing)
+    scc_sol = solve(sccprob, scc_alg)
     @test sol ≈ manualscc ≈ scc_sol
 
     # Backwards compat of alg choice
-    scc_sol=solve(sccprob, NewtonRaphson())
+    scc_sol = solve(sccprob, NewtonRaphson())
     @test sol ≈ manualscc ≈ scc_sol
 
     import NonlinearSolve # Required for Default
 
     # Test default interface
-    scc_sol_default=solve(sccprob)
+    scc_sol_default = solve(sccprob)
     @test sol ≈ manualscc ≈ scc_sol_default
 end
 
-@testitem "SCCNonlinearProblem solve without explicit u0 (issue #758)" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "SCCNonlinearProblem solve without explicit u0 (issue #758)" setup = [CoreRootfindTesting] tags = [:core] begin
     # Regression test for https://github.com/SciML/NonlinearSolve.jl/issues/758
     # SCCNonlinearProblem does not have a u0 field, so calling solve() without
     # explicit u0 should not try to access prob.u0
@@ -111,7 +117,7 @@ end
     @test sol.u[2] ≈ 1.0
 end
 
-@testitem "SCC Residuals Transfer" setup=[CoreRootfindTesting] tags=[:core] begin
+@testitem "SCC Residuals Transfer" setup = [CoreRootfindTesting] tags = [:core] begin
     using NonlinearSolveFirstOrder
     using LinearAlgebra
 
@@ -125,7 +131,8 @@ end
     end
     explicitfun1(p, sols) = nothing
     prob1 = NonlinearProblem(
-        NonlinearFunction{true, SciMLBase.NoSpecialize}(f1), [1.0, 1.0], nothing)
+        NonlinearFunction{true, SciMLBase.NoSpecialize}(f1), [1.0, 1.0], nothing
+    )
 
     # Linear problem
     A2 = [1.0 0.5; 0.5 1.0]
@@ -140,11 +147,14 @@ end
     end
     explicitfun3(p, sols) = nothing
     prob3 = NonlinearProblem(
-        NonlinearFunction{true, SciMLBase.NoSpecialize}(f3), [1.0, 2.0], nothing)
+        NonlinearFunction{true, SciMLBase.NoSpecialize}(f3), [1.0, 2.0], nothing
+    )
 
     # Create SCC problem
-    sccprob = SciMLBase.SCCNonlinearProblem((prob1, prob2, prob3),
-        SciMLBase.Void{Any}.([explicitfun1, explicitfun2, explicitfun3]))
+    sccprob = SciMLBase.SCCNonlinearProblem(
+        (prob1, prob2, prob3),
+        SciMLBase.Void{Any}.([explicitfun1, explicitfun2, explicitfun3])
+    )
 
     # Solve with SCCAlg
     using SCCNonlinearSolve
@@ -163,7 +173,7 @@ end
     @test length(scc_sol.resid) == expected_length
 
     # Test that residuals are small (near zero for converged solution)
-    @test norm(scc_sol.resid) < 1e-10
+    @test norm(scc_sol.resid) < 1.0e-10
 
     # Manually compute residuals to verify correctness
     u1 = scc_sol.u[1:2]
@@ -180,5 +190,5 @@ end
     f3(resid3, u3, nothing)
 
     expected_resid = vcat(resid1, resid2, resid3)
-    @test scc_sol.resid ≈ expected_resid atol=1e-10
+    @test scc_sol.resid ≈ expected_resid atol = 1.0e-10
 end

--- a/lib/SCCNonlinearSolve/test/qa_tests.jl
+++ b/lib/SCCNonlinearSolve/test/qa_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Aqua" tags=[:core] begin
+@testitem "Aqua" tags = [:core] begin
     using Aqua, SCCNonlinearSolve
 
     Aqua.test_all(
@@ -6,15 +6,18 @@
         piracies = false, ambiguities = false, stale_deps = false, deps_compat = false
     )
     Aqua.test_stale_deps(
-        SCCNonlinearSolve; ignore = [:SciMLJacobianOperators, :NonlinearSolveBase])
+        SCCNonlinearSolve; ignore = [:SciMLJacobianOperators, :NonlinearSolveBase]
+    )
     Aqua.test_deps_compat(
-        SCCNonlinearSolve; ignore = [:SciMLJacobianOperators, :NonlinearSolveBase])
+        SCCNonlinearSolve; ignore = [:SciMLJacobianOperators, :NonlinearSolveBase]
+    )
     Aqua.test_piracies(
-        SCCNonlinearSolve; treat_as_own = [SCCNonlinearSolve.SciMLBase.solve])
+        SCCNonlinearSolve; treat_as_own = [SCCNonlinearSolve.SciMLBase.solve]
+    )
     Aqua.test_ambiguities(SCCNonlinearSolve; recursive = false)
 end
 
-@testitem "Explicit Imports" tags=[:core] begin
+@testitem "Explicit Imports" tags = [:core] begin
     using ExplicitImports, SciMLBase, SCCNonlinearSolve
 
     @test check_no_implicit_imports(

--- a/lib/SCCNonlinearSolve/test/runtests.jl
+++ b/lib/SCCNonlinearSolve/test/runtests.jl
@@ -5,11 +5,13 @@ using ReTestItems, SCCNonlinearSolve, Hwloc, InteractiveUtils, Pkg
 const GROUP = lowercase(get(ENV, "GROUP", "All"))
 
 const RETESTITEMS_NWORKERS = parse(
-    Int, get(ENV, "RETESTITEMS_NWORKERS",
+    Int, get(
+        ENV, "RETESTITEMS_NWORKERS",
         string(min(ifelse(Sys.iswindows(), 0, Hwloc.num_physical_cores()), 4))
     )
 )
-const RETESTITEMS_NWORKER_THREADS = parse(Int,
+const RETESTITEMS_NWORKER_THREADS = parse(
+    Int,
     get(
         ENV, "RETESTITEMS_NWORKER_THREADS",
         string(max(Hwloc.num_virtual_cores() ÷ max(RETESTITEMS_NWORKERS, 1), 1))

--- a/lib/SciMLJacobianOperators/test/core_tests.jl
+++ b/lib/SciMLJacobianOperators/test/core_tests.jl
@@ -12,7 +12,7 @@
         AutoZygote(),
         AutoReverseDiff(),
         AutoTracker(),
-        AutoFiniteDiff()
+        AutoFiniteDiff(),
     ]
     if isempty(VERSION.prerelease) && VERSION < v"1.12"
         push!(reverse_ADs, AutoEnzyme())
@@ -21,7 +21,7 @@
 
     forward_ADs = [
         AutoForwardDiff(),
-        AutoFiniteDiff()
+        AutoFiniteDiff(),
     ]
     if isempty(VERSION.prerelease) && VERSION < v"1.12"
         push!(forward_ADs, AutoEnzyme())
@@ -42,21 +42,22 @@
             @testset for u in rand(4), v in rand(4)
 
                 sop = StatefulJacobianOperator(jac_op, u, prob.p)
-                @test (sop * v)≈analytic_jvp(v, u, prob.p) atol=1e-5
-                @test (sop' * v)≈analytic_vjp(v, u, prob.p) atol=1e-5
+                @test (sop * v) ≈ analytic_jvp(v, u, prob.p) atol = 1.0e-5
+                @test (sop' * v) ≈ analytic_vjp(v, u, prob.p) atol = 1.0e-5
 
                 normal_form_sop = sop' * sop
                 JᵀJv = normal_form_sop * v
                 J_analytic = analytic_jac(u, prob.p)
                 JᵀJv_analytic = J_analytic' * J_analytic * v
-                @test JᵀJv≈JᵀJv_analytic atol=1e-5
+                @test JᵀJv ≈ JᵀJv_analytic atol = 1.0e-5
             end
         end
     end
 
     prob = NonlinearProblem(
         NonlinearFunction{false}((u, p) -> u^2 - p; jvp = analytic_jvp, vjp = analytic_vjp),
-        1.0, 2.0)
+        1.0, 2.0
+    )
 
     @testset "Analytic JVP/VJP" begin
         jac_op = JacobianOperator(prob, -1.0, 1.0)
@@ -64,19 +65,20 @@
         @testset for u in rand(4), v in rand(4)
 
             sop = StatefulJacobianOperator(jac_op, u, prob.p)
-            @test (sop * v)≈analytic_jvp(v, u, prob.p) atol=1e-5
-            @test (sop' * v)≈analytic_vjp(v, u, prob.p) atol=1e-5
+            @test (sop * v) ≈ analytic_jvp(v, u, prob.p) atol = 1.0e-5
+            @test (sop' * v) ≈ analytic_vjp(v, u, prob.p) atol = 1.0e-5
 
             normal_form_sop = sop' * sop
             JᵀJv = normal_form_sop * v
             J_analytic = analytic_jac(u, prob.p)
             JᵀJv_analytic = J_analytic' * J_analytic * v
-            @test JᵀJv≈JᵀJv_analytic atol=1e-5
+            @test JᵀJv ≈ JᵀJv_analytic atol = 1.0e-5
         end
     end
 
     prob = NonlinearProblem(
-        NonlinearFunction{false}((u, p) -> u^2 - p; jac = (u, p) -> 2 * u), 1.0, 2.0)
+        NonlinearFunction{false}((u, p) -> u^2 - p; jac = (u, p) -> 2 * u), 1.0, 2.0
+    )
 
     @testset "Analytic Jacobian" begin
         jac_op = JacobianOperator(prob, -1.0, 1.0)
@@ -84,14 +86,14 @@
         @testset for u in rand(4), v in rand(4)
 
             sop = StatefulJacobianOperator(jac_op, u, prob.p)
-            @test (sop * v)≈2 * u * v atol=1e-5
-            @test (sop' * v)≈2 * u * v atol=1e-5
+            @test (sop * v) ≈ 2 * u * v atol = 1.0e-5
+            @test (sop' * v) ≈ 2 * u * v atol = 1.0e-5
 
             normal_form_sop = sop' * sop
             JᵀJv = normal_form_sop * v
             J_analytic = analytic_jac(u, prob.p)
             JᵀJv_analytic = J_analytic' * J_analytic * v
-            @test JᵀJv≈JᵀJv_analytic atol=1e-5
+            @test JᵀJv ≈ JᵀJv_analytic atol = 1.0e-5
         end
     end
 end
@@ -108,7 +110,7 @@ end
 
     reverse_ADs = [
         AutoReverseDiff(),
-        AutoFiniteDiff()
+        AutoFiniteDiff(),
     ]
     if isempty(VERSION.prerelease) && VERSION < v"1.12"
         push!(reverse_ADs, AutoEnzyme())
@@ -117,7 +119,7 @@ end
 
     forward_ADs = [
         AutoForwardDiff(),
-        AutoFiniteDiff()
+        AutoFiniteDiff(),
     ]
     if isempty(VERSION.prerelease) && VERSION < v"1.12"
         push!(forward_ADs, AutoEnzyme())
@@ -125,9 +127,10 @@ end
     end
 
     prob = NonlinearProblem(
-        NonlinearFunction{true}((du, u, p) -> du .= u .^ 2 .- p .+ u[2] * u[1]), [1.0, 3.0], 2.0)
+        NonlinearFunction{true}((du, u, p) -> du .= u .^ 2 .- p .+ u[2] * u[1]), [1.0, 3.0], 2.0
+    )
 
-    analytic_jac(u, p) = [2 * u[1]+u[2] u[1]; u[2] 2 * u[2]+u[1]]
+    analytic_jac(u, p) = [2 * u[1] + u[2] u[1]; u[2] 2 * u[2] + u[1]]
     analytic_jvp(v, u, p) = analytic_jac(u, p) * v
     analytic_vjp(v, u, p) = analytic_jac(u, p)' * v
 
@@ -143,21 +146,24 @@ end
             @testset for u in [rand(2) for _ in 1:4], v in [rand(2) for _ in 1:4]
 
                 sop = StatefulJacobianOperator(jac_op, u, prob.p)
-                @test (sop * v)≈analytic_jvp(v, u, prob.p) atol=1e-5
-                @test (sop' * v)≈analytic_vjp(v, u, prob.p) atol=1e-5
+                @test (sop * v) ≈ analytic_jvp(v, u, prob.p) atol = 1.0e-5
+                @test (sop' * v) ≈ analytic_vjp(v, u, prob.p) atol = 1.0e-5
 
                 normal_form_sop = sop' * sop
                 JᵀJv = normal_form_sop * v
                 J_analytic = analytic_jac(u, prob.p)
                 JᵀJv_analytic = J_analytic' * J_analytic * v
-                @test JᵀJv≈JᵀJv_analytic atol=1e-5
+                @test JᵀJv ≈ JᵀJv_analytic atol = 1.0e-5
             end
         end
     end
 
     prob = NonlinearProblem(
-        NonlinearFunction{true}((du, u, p) -> du .= u .^ 2 .- p .+ u[2] * u[1];
-            jvp = analytic_jvp!, vjp = analytic_vjp!), [1.0, 3.0], 2.0)
+        NonlinearFunction{true}(
+            (du, u, p) -> du .= u .^ 2 .- p .+ u[2] * u[1];
+            jvp = analytic_jvp!, vjp = analytic_vjp!
+        ), [1.0, 3.0], 2.0
+    )
 
     @testset "Analytic JVP/VJP" begin
         jac_op = JacobianOperator(prob, [2.0, 3.0], prob.u0)
@@ -165,20 +171,23 @@ end
         @testset for u in [rand(2) for _ in 1:4], v in [rand(2) for _ in 1:4]
 
             sop = StatefulJacobianOperator(jac_op, u, prob.p)
-            @test (sop * v)≈analytic_jvp(v, u, prob.p) atol=1e-5
-            @test (sop' * v)≈analytic_vjp(v, u, prob.p) atol=1e-5
+            @test (sop * v) ≈ analytic_jvp(v, u, prob.p) atol = 1.0e-5
+            @test (sop' * v) ≈ analytic_vjp(v, u, prob.p) atol = 1.0e-5
 
             normal_form_sop = sop' * sop
             JᵀJv = normal_form_sop * v
             J_analytic = analytic_jac(u, prob.p)
             JᵀJv_analytic = J_analytic' * J_analytic * v
-            @test JᵀJv≈JᵀJv_analytic atol=1e-5
+            @test JᵀJv ≈ JᵀJv_analytic atol = 1.0e-5
         end
     end
 
     prob = NonlinearProblem(
-        NonlinearFunction{true}((du, u, p) -> du .= u .^ 2 .- p .+ u[2] * u[1];
-            jac = analytic_jac!), [1.0, 3.0], 2.0)
+        NonlinearFunction{true}(
+            (du, u, p) -> du .= u .^ 2 .- p .+ u[2] * u[1];
+            jac = analytic_jac!
+        ), [1.0, 3.0], 2.0
+    )
 
     @testset "Analytic Jacobian" begin
         jac_op = JacobianOperator(prob, [2.0, 3.0], prob.u0)
@@ -186,14 +195,14 @@ end
         @testset for u in [rand(2) for _ in 1:4], v in [rand(2) for _ in 1:4]
 
             sop = StatefulJacobianOperator(jac_op, u, prob.p)
-            @test (sop * v)≈analytic_jvp(v, u, prob.p) atol=1e-5
-            @test (sop' * v)≈analytic_vjp(v, u, prob.p) atol=1e-5
+            @test (sop * v) ≈ analytic_jvp(v, u, prob.p) atol = 1.0e-5
+            @test (sop' * v) ≈ analytic_vjp(v, u, prob.p) atol = 1.0e-5
 
             normal_form_sop = sop' * sop
             JᵀJv = normal_form_sop * v
             J_analytic = analytic_jac(u, prob.p)
             JᵀJv_analytic = J_analytic' * J_analytic * v
-            @test JᵀJv≈JᵀJv_analytic atol=1e-5
+            @test JᵀJv ≈ JᵀJv_analytic atol = 1.0e-5
         end
     end
 end
@@ -212,7 +221,7 @@ end
         AutoZygote(),
         AutoTracker(),
         AutoReverseDiff(),
-        AutoFiniteDiff()
+        AutoFiniteDiff(),
     ]
     if isempty(VERSION.prerelease) && VERSION < v"1.12"
         push!(reverse_ADs, AutoEnzyme())
@@ -221,7 +230,7 @@ end
 
     forward_ADs = [
         AutoForwardDiff(),
-        AutoFiniteDiff()
+        AutoFiniteDiff(),
     ]
     if isempty(VERSION.prerelease) && VERSION < v"1.12"
         push!(forward_ADs, AutoEnzyme())
@@ -229,9 +238,10 @@ end
     end
 
     prob = NonlinearProblem(
-        NonlinearFunction{false}((u, p) -> u .^ 2 .- p .+ u[2] * u[1]), [1.0, 3.0], 2.0)
+        NonlinearFunction{false}((u, p) -> u .^ 2 .- p .+ u[2] * u[1]), [1.0, 3.0], 2.0
+    )
 
-    analytic_jac(u, p) = [2 * u[1]+u[2] u[1]; u[2] 2 * u[2]+u[1]]
+    analytic_jac(u, p) = [2 * u[1] + u[2] u[1]; u[2] 2 * u[2] + u[1]]
     analytic_jvp(v, u, p) = analytic_jac(u, p) * v
     analytic_vjp(v, u, p) = analytic_jac(u, p)' * v
 
@@ -243,21 +253,24 @@ end
             @testset for u in [rand(2) for _ in 1:4], v in [rand(2) for _ in 1:4]
 
                 sop = StatefulJacobianOperator(jac_op, u, prob.p)
-                @test (sop * v)≈analytic_jvp(v, u, prob.p) atol=1e-5
-                @test (sop' * v)≈analytic_vjp(v, u, prob.p) atol=1e-5
+                @test (sop * v) ≈ analytic_jvp(v, u, prob.p) atol = 1.0e-5
+                @test (sop' * v) ≈ analytic_vjp(v, u, prob.p) atol = 1.0e-5
 
                 normal_form_sop = sop' * sop
                 JᵀJv = normal_form_sop * v
                 J_analytic = analytic_jac(u, prob.p)
                 JᵀJv_analytic = J_analytic' * J_analytic * v
-                @test JᵀJv≈JᵀJv_analytic atol=1e-5
+                @test JᵀJv ≈ JᵀJv_analytic atol = 1.0e-5
             end
         end
     end
 
     prob = NonlinearProblem(
-        NonlinearFunction{false}((u, p) -> u .^ 2 .- p .+ u[2] * u[1];
-            vjp = analytic_vjp, jvp = analytic_jvp), [1.0, 3.0], 2.0)
+        NonlinearFunction{false}(
+            (u, p) -> u .^ 2 .- p .+ u[2] * u[1];
+            vjp = analytic_vjp, jvp = analytic_jvp
+        ), [1.0, 3.0], 2.0
+    )
 
     @testset "Analytic JVP/VJP" begin
         jac_op = JacobianOperator(prob, [2.0, 3.0], prob.u0)
@@ -265,20 +278,23 @@ end
         @testset for u in [rand(2) for _ in 1:4], v in [rand(2) for _ in 1:4]
 
             sop = StatefulJacobianOperator(jac_op, u, prob.p)
-            @test (sop * v)≈analytic_jvp(v, u, prob.p) atol=1e-5
-            @test (sop' * v)≈analytic_vjp(v, u, prob.p) atol=1e-5
+            @test (sop * v) ≈ analytic_jvp(v, u, prob.p) atol = 1.0e-5
+            @test (sop' * v) ≈ analytic_vjp(v, u, prob.p) atol = 1.0e-5
 
             normal_form_sop = sop' * sop
             JᵀJv = normal_form_sop * v
             J_analytic = analytic_jac(u, prob.p)
             JᵀJv_analytic = J_analytic' * J_analytic * v
-            @test JᵀJv≈JᵀJv_analytic atol=1e-5
+            @test JᵀJv ≈ JᵀJv_analytic atol = 1.0e-5
         end
     end
 
     prob = NonlinearProblem(
-        NonlinearFunction{false}((u, p) -> u .^ 2 .- p .+ u[2] * u[1];
-            jac = analytic_jac), [1.0, 3.0], 2.0)
+        NonlinearFunction{false}(
+            (u, p) -> u .^ 2 .- p .+ u[2] * u[1];
+            jac = analytic_jac
+        ), [1.0, 3.0], 2.0
+    )
 
     @testset "Analytic Jacobian" begin
         jac_op = JacobianOperator(prob, [2.0, 3.0], prob.u0)
@@ -286,14 +302,14 @@ end
         @testset for u in [rand(2) for _ in 1:4], v in [rand(2) for _ in 1:4]
 
             sop = StatefulJacobianOperator(jac_op, u, prob.p)
-            @test (sop * v)≈analytic_jvp(v, u, prob.p) atol=1e-5
-            @test (sop' * v)≈analytic_vjp(v, u, prob.p) atol=1e-5
+            @test (sop * v) ≈ analytic_jvp(v, u, prob.p) atol = 1.0e-5
+            @test (sop' * v) ≈ analytic_vjp(v, u, prob.p) atol = 1.0e-5
 
             normal_form_sop = sop' * sop
             JᵀJv = normal_form_sop * v
             J_analytic = analytic_jac(u, prob.p)
             JᵀJv_analytic = J_analytic' * J_analytic * v
-            @test JᵀJv≈JᵀJv_analytic atol=1e-5
+            @test JᵀJv ≈ JᵀJv_analytic atol = 1.0e-5
         end
     end
 end
@@ -357,10 +373,12 @@ end
         brusselator_f(fu0, u0, p_tuple)
 
         prob = NonlinearProblem(
-            NonlinearFunction{true}(brusselator_f), u0, p_tuple)
+            NonlinearFunction{true}(brusselator_f), u0, p_tuple
+        )
 
         jac_op = JacobianOperator(
-            prob, fu0, u0; jvp_autodiff = AutoForwardDiff(), vjp_autodiff = AutoFiniteDiff())
+            prob, fu0, u0; jvp_autodiff = AutoForwardDiff(), vjp_autodiff = AutoFiniteDiff()
+        )
         sop = StatefulJacobianOperator(jac_op, u0, p_tuple)
 
         # This should not throw MethodError: no method matching copy(::NTuple{4, Float64})
@@ -391,10 +409,12 @@ end
         simple_f(fu0, u0, p_namedtuple)
 
         prob = NonlinearProblem(
-            NonlinearFunction{true}(simple_f), u0, p_namedtuple)
+            NonlinearFunction{true}(simple_f), u0, p_namedtuple
+        )
 
         jac_op = JacobianOperator(
-            prob, fu0, u0; jvp_autodiff = AutoForwardDiff(), vjp_autodiff = AutoFiniteDiff())
+            prob, fu0, u0; jvp_autodiff = AutoForwardDiff(), vjp_autodiff = AutoFiniteDiff()
+        )
         sop = StatefulJacobianOperator(jac_op, u0, p_namedtuple)
 
         # This should not throw

--- a/lib/SimpleNonlinearSolve/ext/SimpleNonlinearSolveChainRulesCoreExt.jl
+++ b/lib/SimpleNonlinearSolve/ext/SimpleNonlinearSolveChainRulesCoreExt.jl
@@ -11,15 +11,15 @@ function ChainRulesCore.rrule(
         ::typeof(simplenonlinearsolve_solve_up),
         prob::Union{ImmutableNonlinearProblem, NonlinearLeastSquaresProblem},
         sensealg, u0, u0_changed, p, p_changed, alg, args...; kwargs...
-)
+    )
     out,
-    ∇internal = _solve_adjoint(
+        ∇internal = _solve_adjoint(
         prob, sensealg, u0, p, ChainRulesOriginator(), alg, args...; kwargs...
     )
     function ∇simplenonlinearsolve_solve_up(Δ)
         ∂f, ∂prob, ∂sensealg, ∂u0, ∂p, _, ∂args... = ∇internal(Δ)
         return (
-            ∂f, ∂prob, ∂sensealg, ∂u0, NoTangent(), ∂p, NoTangent(), NoTangent(), ∂args...
+            ∂f, ∂prob, ∂sensealg, ∂u0, NoTangent(), ∂p, NoTangent(), NoTangent(), ∂args...,
         )
     end
     return out, ∇simplenonlinearsolve_solve_up

--- a/lib/SimpleNonlinearSolve/ext/SimpleNonlinearSolveReverseDiffExt.jl
+++ b/lib/SimpleNonlinearSolve/ext/SimpleNonlinearSolveReverseDiffExt.jl
@@ -14,21 +14,26 @@ for pType in (ImmutableNonlinearProblem, NonlinearLeastSquaresProblem)
     for (uT, pT) in collect(Iterators.product(aTypes, aTypes))[1:(end - 1)]
         @eval function simplenonlinearsolve_solve_up(
                 prob::$(pType), sensealg, u0::$(uT), u0_changed,
-                p::$(pT), p_changed, alg, args...; kwargs...)
-            return ReverseDiff.track(SimpleNonlinearSolve.simplenonlinearsolve_solve_up,
+                p::$(pT), p_changed, alg, args...; kwargs...
+            )
+            return ReverseDiff.track(
+                SimpleNonlinearSolve.simplenonlinearsolve_solve_up,
                 prob, sensealg, ArrayInterface.aos_to_soa(u0), true,
-                ArrayInterface.aos_to_soa(p), true, alg, args...; kwargs...)
+                ArrayInterface.aos_to_soa(p), true, alg, args...; kwargs...
+            )
         end
     end
 
     @eval ReverseDiff.@grad function simplenonlinearsolve_solve_up(
             tprob::$(pType), sensealg, tu0, u0_changed,
-            tp, p_changed, alg, args...; kwargs...)
+            tp, p_changed, alg, args...; kwargs...
+        )
         u0, p = ReverseDiff.value(tu0), ReverseDiff.value(tp)
         prob = remake(tprob; u0, p)
         out,
-        ∇internal = _solve_adjoint(
-            prob, sensealg, u0, p, ReverseDiffOriginator(), alg, args...; kwargs...)
+            ∇internal = _solve_adjoint(
+            prob, sensealg, u0, p, ReverseDiffOriginator(), alg, args...; kwargs...
+        )
 
         function ∇simplenonlinearsolve_solve_up(Δ...)
             ∂prob, ∂sensealg, ∂u0, ∂p, _, ∂args... = ∇internal(Δ...)

--- a/lib/SimpleNonlinearSolve/ext/SimpleNonlinearSolveTrackerExt.jl
+++ b/lib/SimpleNonlinearSolve/ext/SimpleNonlinearSolveTrackerExt.jl
@@ -13,21 +13,26 @@ for pType in (ImmutableNonlinearProblem, NonlinearLeastSquaresProblem)
     for (uT, pT) in collect(Iterators.product(aTypes, aTypes))[1:(end - 1)]
         @eval function SimpleNonlinearSolve.simplenonlinearsolve_solve_up(
                 prob::$(pType), sensealg, u0::$(uT), u0_changed,
-                p::$(pT), p_changed, alg, args...; kwargs...)
-            return Tracker.track(SimpleNonlinearSolve.simplenonlinearsolve_solve_up,
+                p::$(pT), p_changed, alg, args...; kwargs...
+            )
+            return Tracker.track(
+                SimpleNonlinearSolve.simplenonlinearsolve_solve_up,
                 prob, sensealg, ArrayInterface.aos_to_soa(u0), true,
-                ArrayInterface.aos_to_soa(p), true, alg, args...; kwargs...)
+                ArrayInterface.aos_to_soa(p), true, alg, args...; kwargs...
+            )
         end
     end
 
     @eval Tracker.@grad function SimpleNonlinearSolve.simplenonlinearsolve_solve_up(
             tprob::$(pType), sensealg, tu0, u0_changed,
-            tp, p_changed, alg, args...; kwargs...)
+            tp, p_changed, alg, args...; kwargs...
+        )
         u0, p = Tracker.data(tu0), Tracker.data(tp)
         prob = remake(tprob; u0, p)
         out,
-        ∇internal = _solve_adjoint(
-            prob, sensealg, u0, p, TrackerOriginator(), alg, args...; kwargs...)
+            ∇internal = _solve_adjoint(
+            prob, sensealg, u0, p, TrackerOriginator(), alg, args...; kwargs...
+        )
 
         function ∇simplenonlinearsolve_solve_up(Δ)
             ∂prob, ∂sensealg, ∂u0, ∂p, _, ∂args... = ∇internal(Tracker.data(Δ))

--- a/lib/SimpleNonlinearSolve/src/SimpleNonlinearSolve.jl
+++ b/lib/SimpleNonlinearSolve/src/SimpleNonlinearSolve.jl
@@ -11,11 +11,11 @@ using CommonSolve: CommonSolve, solve, init, solve!
 using LineSearch: LiFukushimaLineSearch
 using MaybeInplace: @bb
 using NonlinearSolveBase: NonlinearSolveBase, ImmutableNonlinearProblem, L2_NORM,
-                          nonlinearsolve_forwarddiff_solve, nonlinearsolve_dual_solution,
-                          AbstractNonlinearSolveAlgorithm, NonlinearVerbosity, @SciMLMessage,
-                          AbstractVerbosityPreset
+    nonlinearsolve_forwarddiff_solve, nonlinearsolve_dual_solution,
+    AbstractNonlinearSolveAlgorithm, NonlinearVerbosity, @SciMLMessage,
+    AbstractVerbosityPreset
 using SciMLBase: SciMLBase, NonlinearFunction, NonlinearProblem,
-                 NonlinearLeastSquaresProblem, ReturnCode, remake
+    NonlinearLeastSquaresProblem, ReturnCode, remake
 using LinearAlgebra: LinearAlgebra, dot
 
 using StaticArraysCore: StaticArray, SArray, SVector, MArray
@@ -30,12 +30,12 @@ const DI = DifferentiationInterface
 
 const DualNonlinearProblem = NonlinearProblem{
     <:Union{Number, <:AbstractArray}, iip,
-    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}}
+    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}},
 } where {iip, T, V, P}
 
 const DualNonlinearLeastSquaresProblem = NonlinearLeastSquaresProblem{
     <:Union{Number, <:AbstractArray}, iip,
-    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}}
+    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}},
 } where {iip, T, V, P}
 
 abstract type AbstractSimpleNonlinearSolveAlgorithm <: AbstractNonlinearSolveAlgorithm end
@@ -59,7 +59,7 @@ include("trust_region.jl")
 function CommonSolve.solve(
         prob::NonlinearProblem, alg::AbstractSimpleNonlinearSolveAlgorithm, args...;
         kwargs...
-)
+    )
     prob = convert(ImmutableNonlinearProblem, prob)
     return solve(prob, alg, args...; kwargs...)
 end
@@ -67,7 +67,7 @@ end
 function CommonSolve.solve(
         prob::DualNonlinearProblem, alg::AbstractSimpleNonlinearSolveAlgorithm,
         args...; kwargs...
-)
+    )
     alg = configure_autodiff(prob, alg)
     prob = convert(ImmutableNonlinearProblem, prob)
     sol, partials = nonlinearsolve_forwarddiff_solve(prob, alg, args...; kwargs...)
@@ -80,7 +80,7 @@ end
 function CommonSolve.solve(
         prob::DualNonlinearLeastSquaresProblem, alg::AbstractSimpleNonlinearSolveAlgorithm,
         args...; kwargs...
-)
+    )
     alg = configure_autodiff(prob, alg)
     sol, partials = nonlinearsolve_forwarddiff_solve(prob, alg, args...; kwargs...)
     dual_soln = nonlinearsolve_dual_solution(sol.u, partials, prob.p)
@@ -94,13 +94,15 @@ function CommonSolve.solve(
         alg::AbstractSimpleNonlinearSolveAlgorithm,
         args...; sensealg = nothing, u0 = nothing, p = nothing,
         initializealg = SciMLBase.NoInit(), kwargs...
-)
+    )
     alg = configure_autodiff(prob, alg)
     cache = SciMLBase.__init(prob, alg, args...; initializealg, kwargs...)
     prob = cache.prob
     if cache.retcode == ReturnCode.InitialFailure
-        return SciMLBase.build_solution(prob, alg, prob.u0,
-            NonlinearSolveBase.Utils.evaluate_f(prob, prob.u0); cache.retcode)
+        return SciMLBase.build_solution(
+            prob, alg, prob.u0,
+            NonlinearSolveBase.Utils.evaluate_f(prob, prob.u0); cache.retcode
+        )
     end
     if sensealg === nothing && haskey(prob.kwargs, :sensealg)
         sensealg = prob.kwargs[:sensealg]
@@ -119,7 +121,7 @@ end
 function simplenonlinearsolve_solve_up(
         prob::Union{ImmutableNonlinearProblem, NonlinearLeastSquaresProblem}, sensealg, u0,
         u0_changed, p, p_changed, alg, args...; kwargs...
-)
+    )
     (u0_changed || p_changed) && (prob = remake(prob; u0, p))
     return SciMLBase.__solve(prob, alg, args...; kwargs...)
 end
@@ -146,7 +148,7 @@ end
         @compile_workload begin
             @sync for prob in (prob_scalar, prob_iip, prob_oop), alg in algs
 
-                Threads.@spawn CommonSolve.solve(prob, alg; abstol = 1e-2, verbose = false)
+                Threads.@spawn CommonSolve.solve(prob, alg; abstol = 1.0e-2, verbose = false)
             end
         end
     end

--- a/lib/SimpleNonlinearSolve/src/broyden.jl
+++ b/lib/SimpleNonlinearSolve/src/broyden.jl
@@ -19,7 +19,7 @@ end
 
 function SimpleBroyden(;
         linesearch::Union{Bool, Val{true}, Val{false}} = Val(false), alpha = nothing
-)
+    )
     linesearch = linesearch isa Bool ? Val(linesearch) : linesearch
     return SimpleBroyden(linesearch, alpha)
 end
@@ -28,7 +28,7 @@ function SciMLBase.__solve(
         prob::ImmutableNonlinearProblem, alg::SimpleBroyden, args...;
         abstol = nothing, reltol = nothing, maxiters = 1000,
         alias_u0 = false, termination_condition = nothing, kwargs...
-)
+    )
     x = NLBUtils.maybe_unaliased(prob.u0, alias_u0)
     fx = NLBUtils.evaluate_f(prob, x)
     T = promote_type(eltype(fx), eltype(x))
@@ -44,7 +44,7 @@ function SciMLBase.__solve(
     if alg.alpha === nothing
         fx_norm = L2_NORM(fx)
         x_norm = L2_NORM(x)
-        init_α = ifelse(fx_norm ≥ 1e-5, max(x_norm, T(true)) / (2 * fx_norm), T(true))
+        init_α = ifelse(fx_norm ≥ 1.0e-5, max(x_norm, T(true)) / (2 * fx_norm), T(true))
     else
         init_α = inv(alg.alpha)
     end
@@ -56,7 +56,7 @@ function SciMLBase.__solve(
     @bb δJ⁻¹ = copy(J⁻¹)
 
     abstol, reltol,
-    tc_cache = NonlinearSolveBase.init_termination_cache(
+        tc_cache = NonlinearSolveBase.init_termination_cache(
         prob, abstol, reltol, fx, x, termination_condition, Val(:simple)
     )
 

--- a/lib/SimpleNonlinearSolve/src/dfsane.jl
+++ b/lib/SimpleNonlinearSolve/src/dfsane.jl
@@ -51,11 +51,11 @@ see [la2006spectral](@citet).
 end
 
 function SimpleDFSane(;
-        sigma_min::Real = 1e-10, sigma_max::Real = 1e10, sigma_1::Real = 1.0,
-        M::Union{Int, Val} = Val(10), gamma::Real = 1e-4, tau_min::Real = 0.1,
+        sigma_min::Real = 1.0e-10, sigma_max::Real = 1.0e10, sigma_1::Real = 1.0,
+        M::Union{Int, Val} = Val(10), gamma::Real = 1.0e-4, tau_min::Real = 0.1,
         tau_max::Real = 0.5, n_exp::Int = 2,
         eta_strategy::F = (fn_1, n, x_n, f_n) -> fn_1 / n^2
-) where {F}
+    ) where {F}
     M = M isa Int ? Val(M) : M
     return SimpleDFSane(
         sigma_min, sigma_max, sigma_1, gamma, tau_min, tau_max, n_exp,
@@ -67,7 +67,7 @@ function SciMLBase.__solve(
         prob::ImmutableNonlinearProblem, alg::SimpleDFSane, args...;
         abstol = nothing, reltol = nothing, maxiters = 1000, alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = false),
         termination_condition = nothing, kwargs...
-)
+    )
     if haskey(kwargs, :alias_u0)
         alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = kwargs[:alias_u0])
     end
@@ -86,7 +86,7 @@ function SciMLBase.__solve(
     τ_max = T(alg.τ_max)
 
     abstol, reltol,
-    tc_cache = NonlinearSolveBase.init_termination_cache(
+        tc_cache = NonlinearSolveBase.init_termination_cache(
         prob, abstol, reltol, fx, x, termination_condition, Val(:simple)
     )
 

--- a/lib/SimpleNonlinearSolve/src/klement.jl
+++ b/lib/SimpleNonlinearSolve/src/klement.jl
@@ -10,13 +10,13 @@ function SciMLBase.__solve(
         prob::ImmutableNonlinearProblem, alg::SimpleKlement, args...;
         abstol = nothing, reltol = nothing, maxiters = 1000,
         alias_u0 = false, termination_condition = nothing, kwargs...
-)
+    )
     x = NLBUtils.maybe_unaliased(prob.u0, alias_u0)
     T = eltype(x)
     fx = NLBUtils.evaluate_f(prob, x)
 
     abstol, reltol,
-    tc_cache = NonlinearSolveBase.init_termination_cache(
+        tc_cache = NonlinearSolveBase.init_termination_cache(
         prob, abstol, reltol, fx, x, termination_condition, Val(:simple)
     )
 
@@ -42,7 +42,7 @@ function SciMLBase.__solve(
 
         @bb δx .*= -1
         @bb @. δx² = δx^2 * J^2
-        @bb @. J += (fx - fprev - J * δx) / ifelse(iszero(δx²), T(1e-5), δx²) * δx * (J^2)
+        @bb @. J += (fx - fprev - J * δx) / ifelse(iszero(δx²), T(1.0e-5), δx²) * δx * (J^2)
 
         @bb copyto!(fprev, fx)
         @bb copyto!(xo, x)

--- a/lib/SimpleNonlinearSolve/src/raphson.jl
+++ b/lib/SimpleNonlinearSolve/src/raphson.jl
@@ -26,9 +26,9 @@ const SimpleGaussNewton = SimpleNewtonRaphson
 function configure_autodiff(prob, alg::SimpleNewtonRaphson)
     autodiff = something(alg.autodiff, AutoForwardDiff())
     autodiff = SciMLBase.has_jac(prob.f) ? autodiff :
-               NonlinearSolveBase.select_jacobian_autodiff(prob, autodiff)
+        NonlinearSolveBase.select_jacobian_autodiff(prob, autodiff)
     @set! alg.autodiff = autodiff
-    alg
+    return alg
 end
 
 function SciMLBase.__solve(
@@ -36,7 +36,7 @@ function SciMLBase.__solve(
         alg::SimpleNewtonRaphson, args...;
         abstol = nothing, reltol = nothing, maxiters = 1000,
         alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = false), termination_condition = nothing, kwargs...
-)
+    )
     if haskey(kwargs, :alias_u0)
         alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = kwargs[:alias_u0])
     end
@@ -49,13 +49,13 @@ function SciMLBase.__solve(
         return SciMLBase.build_solution(prob, alg, x, fx; retcode = ReturnCode.Success)
 
     abstol, reltol,
-    tc_cache = NonlinearSolveBase.init_termination_cache(
+        tc_cache = NonlinearSolveBase.init_termination_cache(
         prob, abstol, reltol, fx, x, termination_condition, Val(:simple)
     )
 
     @bb xo = similar(x)
     fx_cache = (SciMLBase.isinplace(prob) && !SciMLBase.has_jac(prob.f)) ?
-               NLBUtils.safe_similar(fx) : fx
+        NLBUtils.safe_similar(fx) : fx
     jac_cache = Utils.prepare_jacobian(prob, autodiff, fx_cache, x)
     J = Utils.compute_jacobian!!(nothing, prob, autodiff, fx_cache, x, jac_cache)
 

--- a/lib/SimpleNonlinearSolve/src/trust_region.jl
+++ b/lib/SimpleNonlinearSolve/src/trust_region.jl
@@ -62,7 +62,7 @@ function SciMLBase.__solve(
         alg::SimpleTrustRegion, args...;
         abstol = nothing, reltol = nothing, maxiters = 1000,
         alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = false), termination_condition = nothing, kwargs...
-)
+    )
     if haskey(kwargs, :alias_u0)
         alias = SciMLBase.NonlinearAliasSpecifier(alias_u0 = kwargs[:alias_u0])
     end
@@ -95,19 +95,19 @@ function SciMLBase.__solve(
     max_shrink_times = alg.max_shrink_times
 
     autodiff = SciMLBase.has_jac(prob.f) ? alg.autodiff :
-               NonlinearSolveBase.select_jacobian_autodiff(prob, alg.autodiff)
+        NonlinearSolveBase.select_jacobian_autodiff(prob, alg.autodiff)
 
     fx = NLBUtils.evaluate_f(prob, x)
     norm_fx = L2_NORM(fx)
 
     @bb xo = copy(x)
     fx_cache = (SciMLBase.isinplace(prob) && !SciMLBase.has_jac(prob.f)) ?
-               NLBUtils.safe_similar(fx) : fx
+        NLBUtils.safe_similar(fx) : fx
     jac_cache = Utils.prepare_jacobian(prob, autodiff, fx_cache, x)
     J = Utils.compute_jacobian!!(nothing, prob, autodiff, fx_cache, x, jac_cache)
 
     abstol, reltol,
-    tc_cache = NonlinearSolveBase.init_termination_cache(
+        tc_cache = NonlinearSolveBase.init_termination_cache(
         prob, abstol, reltol, fx, x, termination_condition, Val(:simple)
     )
 
@@ -158,13 +158,14 @@ function SciMLBase.__solve(
             Δ = t₁ * Δ
             shrink_counter += 1
             shrink_counter > max_shrink_times && return SciMLBase.build_solution(
-                prob, alg, x, fx; retcode = ReturnCode.ShrinkThresholdExceeded)
+                prob, alg, x, fx; retcode = ReturnCode.ShrinkThresholdExceeded
+            )
         end
 
         if r ≥ η₁
             # Termination Checks
             solved, retcode, fx_sol,
-            x_sol = Utils.check_termination(
+                x_sol = Utils.check_termination(
                 tc_cache, fx, x, xo, prob
             )
             solved && return SciMLBase.build_solution(prob, alg, x_sol, fx_sol; retcode)
@@ -197,7 +198,7 @@ function SciMLBase.__solve(
     return SciMLBase.build_solution(prob, alg, x, fx; retcode = ReturnCode.MaxIters)
 end
 
-function dogleg_method!!(cache, J, f::F, g, Δ) where F
+function dogleg_method!!(cache, J, f::F, g, Δ) where {F}
     (; δsd, δN_δsd, δN) = cache
 
     # Compute the Newton step

--- a/lib/SimpleNonlinearSolve/src/utils.jl
+++ b/lib/SimpleNonlinearSolve/src/utils.jl
@@ -5,8 +5,8 @@ using DifferentiationInterface: DifferentiationInterface, Constant
 using FastClosures: @closure
 using LinearAlgebra: LinearAlgebra, I, diagind
 using NonlinearSolveBase: NonlinearSolveBase, AbstractNonlinearTerminationMode,
-                          AbstractSafeNonlinearTerminationMode,
-                          AbstractSafeBestNonlinearTerminationMode
+    AbstractSafeNonlinearTerminationMode,
+    AbstractSafeBestNonlinearTerminationMode
 using SciMLBase: SciMLBase, ReturnCode
 using StaticArraysCore: StaticArray, SArray, SMatrix, SVector
 
@@ -59,7 +59,7 @@ function check_termination(cache, fx, x, xo, _, ::AbstractSafeNonlinearTerminati
 end
 function check_termination(
         cache, fx, x, xo, prob, ::AbstractSafeBestNonlinearTerminationMode
-)
+    )
     if cache(fx, x, xo)
         x = cache.u
         fx = NLBUtils.evaluate_f!!(prob, fx, x)
@@ -87,12 +87,18 @@ end
 function prepare_jacobian(prob, autodiff, fx, x)
     SciMLBase.has_jac(prob.f) && return AnalyticJacobian()
     if SciMLBase.isinplace(prob.f)
-        return DIExtras(DI.prepare_jacobian(
-            prob.f, fx, autodiff, x, Constant(prob.p), strict = Val(false)))
+        return DIExtras(
+            DI.prepare_jacobian(
+                prob.f, fx, autodiff, x, Constant(prob.p), strict = Val(false)
+            )
+        )
     else
         x isa SArray && return DINoPreparation()
-        return DIExtras(DI.prepare_jacobian(
-            prob.f, autodiff, x, Constant(prob.p), strict = Val(false)))
+        return DIExtras(
+            DI.prepare_jacobian(
+                prob.f, autodiff, x, Constant(prob.p), strict = Val(false)
+            )
+        )
     end
 end
 
@@ -166,8 +172,10 @@ function compute_hvvp(prob, autodiff, _, x::Number, dir::Number)
 end
 function compute_hvvp(prob, autodiff, fx, x, dir)
     jvp_fn = if SciMLBase.isinplace(prob)
-        @closure (u,
-            p) -> begin
+        @closure (
+            u,
+            p,
+        ) -> begin
             du = NLBUtils.safe_similar(fx, promote_type(eltype(fx), eltype(u)))
             return only(DI.pushforward(prob.f, du, autodiff, u, (dir,), Constant(p)))
         end
@@ -179,7 +187,7 @@ end
 
 function nonlinear_solution_new_alg(
         sol::SciMLBase.NonlinearSolution{T, N, uType, R, P, A, O, uType2, S, Tr}, alg
-) where {T, N, uType, R, P, A, O, uType2, S, Tr}
+    ) where {T, N, uType, R, P, A, O, uType2, S, Tr}
     return SciMLBase.NonlinearSolution{T, N, uType, R, P, typeof(alg), O, uType2, S, Tr}(
         sol.u, sol.resid, sol.prob, alg, sol.retcode, sol.original, sol.left, sol.right,
         sol.stats, sol.trace

--- a/lib/SimpleNonlinearSolve/test/core/adjoint_tests.jl
+++ b/lib/SimpleNonlinearSolve/test/core/adjoint_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Simple Adjoint Test" tags=[:adjoint] begin
+@testitem "Simple Adjoint Test" tags = [:adjoint] begin
     using ForwardDiff, ReverseDiff, SciMLSensitivity, Tracker, Zygote
 
     ff(u, p) = u .^ 2 .- p

--- a/lib/SimpleNonlinearSolve/test/core/allocation_tests.jl
+++ b/lib/SimpleNonlinearSolve/test/core/allocation_tests.jl
@@ -1,21 +1,21 @@
-@itesitem "Allocation Tests" tags=[:alloc_check] begin
+@itesitem "Allocation Tests" tags = [:alloc_check] begin
     using SimpleNonlinearSolve, StaticArrays, AllocCheck
 
     quadratic_f(u, p) = u .* u .- p
     quadratic_f!(du, u, p) = (du .= u .* u .- p)
 
     @testset "$(nameof(typeof(alg)))" for alg in (
-        SimpleNewtonRaphson(),
-        SimpleTrustRegion(),
-        SimpleTrustRegion(; nlsolve_update_rule = Val(true)),
-        SimpleBroyden(),
-        SimpleLimitedMemoryBroyden(),
-        SimpleKlement(),
-        SimpleHalley(),
-        SimpleBroyden(; linesearch = Val(true)),
-        SimpleLimitedMemoryBroyden(; linesearch = Val(true))
-    )
-        @check_allocs nlsolve(prob, alg) = SciMLBase.solve(prob, alg; abstol = 1e-9)
+            SimpleNewtonRaphson(),
+            SimpleTrustRegion(),
+            SimpleTrustRegion(; nlsolve_update_rule = Val(true)),
+            SimpleBroyden(),
+            SimpleLimitedMemoryBroyden(),
+            SimpleKlement(),
+            SimpleHalley(),
+            SimpleBroyden(; linesearch = Val(true)),
+            SimpleLimitedMemoryBroyden(; linesearch = Val(true)),
+        )
+        @check_allocs nlsolve(prob, alg) = SciMLBase.solve(prob, alg; abstol = 1.0e-9)
 
         nlprob_scalar = NonlinearProblem{false}(quadratic_f, 1.0, 2.0)
         nlprob_sa = NonlinearProblem{false}(quadratic_f, @SVector[1.0, 1.0], 2.0)
@@ -34,7 +34,7 @@
             @test true
         catch e
             @error e
-            @test false broken=(alg isa SimpleHalley)
+            @test false broken = (alg isa SimpleHalley)
         end
     end
 end

--- a/lib/SimpleNonlinearSolve/test/core/exotic_type_tests.jl
+++ b/lib/SimpleNonlinearSolve/test/core/exotic_type_tests.jl
@@ -1,4 +1,4 @@
-@testitem "BigFloat Support" tags=[:core] begin
+@testitem "BigFloat Support" tags = [:core] begin
     using SimpleNonlinearSolve, LinearAlgebra, ADTypes, SciMLBase
 
     fn_iip = NonlinearFunction{true}((du, u, p) -> du .= u .* u .- p)
@@ -9,22 +9,22 @@
     prob_oop_bf = NonlinearProblem{false}(fn_oop, u0, BigFloat(2))
 
     @testset "$(nameof(typeof(alg)))" for alg in (
-        SimpleNewtonRaphson(; autodiff = AutoForwardDiff()),
-        SimpleBroyden(),
-        SimpleKlement(),
-        SimpleDFSane(),
-        SimpleTrustRegion(; autodiff = AutoForwardDiff()),
-        SimpleLimitedMemoryBroyden(),
-        SimpleHalley(; autodiff = AutoForwardDiff())
-    )
+            SimpleNewtonRaphson(; autodiff = AutoForwardDiff()),
+            SimpleBroyden(),
+            SimpleKlement(),
+            SimpleDFSane(),
+            SimpleTrustRegion(; autodiff = AutoForwardDiff()),
+            SimpleLimitedMemoryBroyden(),
+            SimpleHalley(; autodiff = AutoForwardDiff()),
+        )
         sol = solve(prob_oop_bf, alg)
-        @test maximum(abs, sol.resid) < 1e-6
+        @test maximum(abs, sol.resid) < 1.0e-6
         @test SciMLBase.successful_retcode(sol.retcode)
 
         alg isa SimpleHalley && continue
 
         sol = solve(prob_iip_bf, alg)
-        @test maximum(abs, sol.resid) < 1e-6
+        @test maximum(abs, sol.resid) < 1.0e-6
         @test SciMLBase.successful_retcode(sol.retcode)
     end
 end

--- a/lib/SimpleNonlinearSolve/test/core/forward_diff_tests.jl
+++ b/lib/SimpleNonlinearSolve/test/core/forward_diff_tests.jl
@@ -1,7 +1,7 @@
-@testitem "ForwardDiff.jl Integration: NonlinearProblem" tags=[:core] begin
+@testitem "ForwardDiff.jl Integration: NonlinearProblem" tags = [:core] begin
     using ArrayInterface
     using ForwardDiff, FiniteDiff, SimpleNonlinearSolve, StaticArrays, LinearAlgebra,
-          Zygote, ReverseDiff, SciMLBase
+        Zygote, ReverseDiff, SciMLBase
     using DifferentiationInterface
 
     const DI = DifferentiationInterface
@@ -15,20 +15,20 @@
     jacobian_f(u, p::AbstractArray) = diagm(vec(@. 1 / (2 * √p)))
 
     @testset "$(nameof(typeof(alg)))" for alg in (
-        SimpleNewtonRaphson(),
-        SimpleTrustRegion(),
-        SimpleTrustRegion(; nlsolve_update_rule = Val(true)),
-        SimpleHalley(),
-        SimpleBroyden(),
-        SimpleKlement(),
-        SimpleDFSane()
-    )
+            SimpleNewtonRaphson(),
+            SimpleTrustRegion(),
+            SimpleTrustRegion(; nlsolve_update_rule = Val(true)),
+            SimpleHalley(),
+            SimpleBroyden(),
+            SimpleKlement(),
+            SimpleDFSane(),
+        )
         us = (
             2.0,
             @SVector([1.0, 1.0]),
             [1.0, 1.0],
             ones(2, 2),
-            @SArray(ones(2, 2))
+            @SArray(ones(2, 2)),
         )
 
         @testset "Scalar AD" begin
@@ -36,16 +36,18 @@
 
                 sol = solve(NonlinearProblem{false}(test_f, u0, p), alg)
                 if SciMLBase.successful_retcode(sol)
-                    gs = abs.(ForwardDiff.derivative(p) do pᵢ
-                        solve(NonlinearProblem{false}(test_f, u0, pᵢ), alg).u
-                    end)
+                    gs = abs.(
+                        ForwardDiff.derivative(p) do pᵢ
+                            solve(NonlinearProblem{false}(test_f, u0, pᵢ), alg).u
+                        end
+                    )
                     gs_true = abs.(jacobian_f(u0, p))
 
-                    if !(isapprox(gs, gs_true, atol = 1e-5))
+                    if !(isapprox(gs, gs_true, atol = 1.0e-5))
                         @show sol.retcode, sol.u
-                        @error "ForwardDiff Failed for u0=$(u0) and p=$(p) with $(alg)" forwardiff_gradient=gs true_gradient=gs_true
+                        @error "ForwardDiff Failed for u0=$(u0) and p=$(p) with $(alg)" forwardiff_gradient = gs true_gradient = gs_true
                     else
-                        @test abs.(gs)≈abs.(gs_true) atol=1e-5
+                        @test abs.(gs) ≈ abs.(gs_true) atol = 1.0e-5
                     end
                 end
             end
@@ -53,7 +55,7 @@
 
         @testset "Jacobian" begin
             @testset "$(typeof(u0))" for u0 in us[2:end],
-                p in ([2.0, 1.0], [2.0 1.0; 3.0 4.0])
+                    p in ([2.0, 1.0], [2.0 1.0; 3.0 4.0])
 
                 if u0 isa AbstractArray && p isa AbstractArray
                     size(u0) != size(p) && continue
@@ -64,16 +66,18 @@
 
                     sol = solve(NonlinearProblem{iip}(fn, u0, p), alg)
                     if SciMLBase.successful_retcode(sol)
-                        gs = abs.(ForwardDiff.jacobian(p) do pᵢ
-                            solve(NonlinearProblem{iip}(fn, u0, pᵢ), alg).u
-                        end)
+                        gs = abs.(
+                            ForwardDiff.jacobian(p) do pᵢ
+                                solve(NonlinearProblem{iip}(fn, u0, pᵢ), alg).u
+                            end
+                        )
                         gs_true = abs.(jacobian_f(u0, p))
 
-                        if !(isapprox(gs, gs_true, atol = 1e-5))
+                        if !(isapprox(gs, gs_true, atol = 1.0e-5))
                             @show sol.retcode, sol.u
-                            @error "ForwardDiff Failed for u0=$(u0) and p=$(p) with $(alg)" forwardiff_jacobian=gs true_jacobian=gs_true
+                            @error "ForwardDiff Failed for u0=$(u0) and p=$(p) with $(alg)" forwardiff_jacobian = gs true_jacobian = gs_true
                         else
-                            @test abs.(gs)≈abs.(gs_true) atol=1e-5
+                            @test abs.(gs) ≈ abs.(gs_true) atol = 1.0e-5
                         end
                     end
                 end
@@ -82,9 +86,9 @@
     end
 end
 
-@testitem "ForwardDiff.jl Integration NonlinearLeastSquaresProblem" tags=[:core] begin
+@testitem "ForwardDiff.jl Integration NonlinearLeastSquaresProblem" tags = [:core] begin
     using ForwardDiff, FiniteDiff, SimpleNonlinearSolve, StaticArrays, LinearAlgebra,
-          Zygote, ReverseDiff
+        Zygote, ReverseDiff
     using DifferentiationInterface
 
     const DI = DifferentiationInterface
@@ -120,11 +124,11 @@ end
     θ_init = θ_true .+ 0.1
 
     for alg in (
-        SimpleGaussNewton(),
-        SimpleGaussNewton(; autodiff = AutoForwardDiff()),
-        SimpleGaussNewton(; autodiff = AutoFiniteDiff()),
-        SimpleGaussNewton(; autodiff = AutoReverseDiff())
-    )
+            SimpleGaussNewton(),
+            SimpleGaussNewton(; autodiff = AutoForwardDiff()),
+            SimpleGaussNewton(; autodiff = AutoFiniteDiff()),
+            SimpleGaussNewton(; autodiff = AutoReverseDiff()),
+        )
         function obj_1(p)
             prob_oop = NonlinearLeastSquaresProblem{false}(loss_function, θ_init, p)
             sol = solve(prob_oop, alg)
@@ -133,7 +137,8 @@ end
 
         function obj_2(p)
             ff = NonlinearFunction{false}(
-                loss_function; resid_prototype = zeros(length(y_target)))
+                loss_function; resid_prototype = zeros(length(y_target))
+            )
             prob_oop = NonlinearLeastSquaresProblem{false}(ff, θ_init, p)
             sol = solve(prob_oop, alg)
             return sum(abs2, sol.u)
@@ -152,17 +157,19 @@ end
         fdiff2 = DI.gradient(obj_2, AutoForwardDiff(), x)
         fdiff3 = DI.gradient(obj_3, AutoForwardDiff(), x)
 
-        @test finitediff≈fdiff1 atol=1e-5
-        @test finitediff≈fdiff2 atol=1e-5
-        @test finitediff≈fdiff3 atol=1e-5
+        @test finitediff ≈ fdiff1 atol = 1.0e-5
+        @test finitediff ≈ fdiff2 atol = 1.0e-5
+        @test finitediff ≈ fdiff3 atol = 1.0e-5
         @test fdiff1 ≈ fdiff2 ≈ fdiff3
 
         function obj_4(p)
             prob_iip = NonlinearLeastSquaresProblem(
                 NonlinearFunction{true}(
-                    loss_function!; resid_prototype = zeros(length(y_target))),
+                    loss_function!; resid_prototype = zeros(length(y_target))
+                ),
                 θ_init,
-                p)
+                p
+            )
             sol = solve(prob_iip, alg)
             return sum(abs2, sol.u)
         end
@@ -170,7 +177,8 @@ end
         function obj_5(p)
             ff = NonlinearFunction{true}(
                 loss_function!; resid_prototype = zeros(length(y_target)),
-                jac = loss_function_jac!)
+                jac = loss_function_jac!
+            )
             prob_iip = NonlinearLeastSquaresProblem(ff, θ_init, p)
             sol = solve(prob_iip, alg)
             return sum(abs2, sol.u)
@@ -179,7 +187,8 @@ end
         function obj_6(p)
             ff = NonlinearFunction{true}(
                 loss_function!; resid_prototype = zeros(length(y_target)),
-                vjp = loss_function_vjp!)
+                vjp = loss_function_vjp!
+            )
             prob_iip = NonlinearLeastSquaresProblem(ff, θ_init, p)
             sol = solve(prob_iip, alg)
             return sum(abs2, sol.u)
@@ -191,9 +200,9 @@ end
         fdiff5 = DI.gradient(obj_5, AutoForwardDiff(), x)
         fdiff6 = DI.gradient(obj_6, AutoForwardDiff(), x)
 
-        @test finitediff≈fdiff4 atol=1e-5
-        @test finitediff≈fdiff5 atol=1e-5
-        @test finitediff≈fdiff6 atol=1e-5
+        @test finitediff ≈ fdiff4 atol = 1.0e-5
+        @test finitediff ≈ fdiff5 atol = 1.0e-5
+        @test finitediff ≈ fdiff6 atol = 1.0e-5
         @test fdiff4 ≈ fdiff5 ≈ fdiff6
     end
 end

--- a/lib/SimpleNonlinearSolve/test/core/least_squares_tests.jl
+++ b/lib/SimpleNonlinearSolve/test/core/least_squares_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Nonlinear Least Squares" tags=[:core] begin
+@testitem "Nonlinear Least Squares" tags = [:core] begin
     using LinearAlgebra
 
     true_function(x, θ) = @. θ[1] * exp(θ[2] * x) * cos(θ[3] * x + θ[4])
@@ -22,20 +22,23 @@
     prob_oop = NonlinearLeastSquaresProblem{false}(loss_function, θ_init, x)
 
     @testset "Solver: $(nameof(typeof(solver)))" for solver in [
-        SimpleNewtonRaphson(AutoForwardDiff()), SimpleGaussNewton(AutoForwardDiff()),
-        SimpleNewtonRaphson(AutoFiniteDiff()), SimpleGaussNewton(AutoFiniteDiff())]
+            SimpleNewtonRaphson(AutoForwardDiff()), SimpleGaussNewton(AutoForwardDiff()),
+            SimpleNewtonRaphson(AutoFiniteDiff()), SimpleGaussNewton(AutoFiniteDiff()),
+        ]
         sol = solve(prob_oop, solver)
-        @test norm(sol.resid, Inf) < 1e-12
+        @test norm(sol.resid, Inf) < 1.0e-12
     end
 
     prob_iip = NonlinearLeastSquaresProblem(
         NonlinearFunction{true}(loss_function!, resid_prototype = zeros(length(y_target))),
-        θ_init, x)
+        θ_init, x
+    )
 
     @testset "Solver: $(nameof(typeof(solver)))" for solver in [
-        SimpleNewtonRaphson(AutoForwardDiff()), SimpleGaussNewton(AutoForwardDiff()),
-        SimpleNewtonRaphson(AutoFiniteDiff()), SimpleGaussNewton(AutoFiniteDiff())]
+            SimpleNewtonRaphson(AutoForwardDiff()), SimpleGaussNewton(AutoForwardDiff()),
+            SimpleNewtonRaphson(AutoFiniteDiff()), SimpleGaussNewton(AutoFiniteDiff()),
+        ]
         sol = solve(prob_iip, solver)
-        @test norm(sol.resid, Inf) < 1e-12
+        @test norm(sol.resid, Inf) < 1.0e-12
     end
 end

--- a/lib/SimpleNonlinearSolve/test/core/matrix_resizing_tests.jl
+++ b/lib/SimpleNonlinearSolve/test/core/matrix_resizing_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Matrix Resizing" tags=[:core] begin
+@testitem "Matrix Resizing" tags = [:core] begin
     ff(u, p) = u .* u .- p
     u0 = ones(2, 3)
     p = 2.0
@@ -6,14 +6,14 @@
     prob = NonlinearProblem(ff, u0, p)
 
     @testset "$(nameof(typeof(alg)))" for alg in (
-        SimpleKlement(),
-        SimpleBroyden(),
-        SimpleNewtonRaphson(),
-        SimpleDFSane(),
-        SimpleLimitedMemoryBroyden(; threshold = Val(2)),
-        SimpleTrustRegion(),
-        SimpleTrustRegion(; nlsolve_update_rule = Val(true))
-    )
+            SimpleKlement(),
+            SimpleBroyden(),
+            SimpleNewtonRaphson(),
+            SimpleDFSane(),
+            SimpleLimitedMemoryBroyden(; threshold = Val(2)),
+            SimpleTrustRegion(),
+            SimpleTrustRegion(; nlsolve_update_rule = Val(true)),
+        )
         @test vec(solve(prob, alg).u) ≈ solve(vecprob, alg).u
     end
 end

--- a/lib/SimpleNonlinearSolve/test/core/qa_tests.jl
+++ b/lib/SimpleNonlinearSolve/test/core/qa_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Aqua" tags=[:core] begin
+@testitem "Aqua" tags = [:core] begin
     using Aqua, SimpleNonlinearSolve
 
     Aqua.test_all(
@@ -7,15 +7,16 @@
     )
     Aqua.test_stale_deps(SimpleNonlinearSolve; ignore = [:SciMLJacobianOperators])
     Aqua.test_deps_compat(SimpleNonlinearSolve; ignore = [:SciMLJacobianOperators])
-    Aqua.test_piracies(SimpleNonlinearSolve;
+    Aqua.test_piracies(
+        SimpleNonlinearSolve;
         treat_as_own = [
-            NonlinearProblem, NonlinearLeastSquaresProblem, IntervalNonlinearProblem
+            NonlinearProblem, NonlinearLeastSquaresProblem, IntervalNonlinearProblem,
         ]
     )
     Aqua.test_ambiguities(SimpleNonlinearSolve; recursive = false)
 end
 
-@testitem "Explicit Imports" tags=[:core] begin
+@testitem "Explicit Imports" tags = [:core] begin
     import ReverseDiff, Tracker, StaticArrays, Zygote
     using ExplicitImports, SimpleNonlinearSolve
 

--- a/lib/SimpleNonlinearSolve/test/core/rootfind_tests.jl
+++ b/lib/SimpleNonlinearSolve/test/core/rootfind_tests.jl
@@ -12,12 +12,20 @@
 
     function newton_fails(u, p)
         return 0.010000000000000002 .+
-               10.000000000000002 ./ (1 .+
-                (0.21640425613334457 .+
-                 216.40425613334457 ./ (1 .+
-                  (0.21640425613334457 .+
-                   216.40425613334457 ./ (1 .+ 0.0006250000000000001(u .^ 2.0))) .^ 2.0)) .^
-                2.0) .- 0.0011552453009332421u .- p
+            10.000000000000002 ./ (
+            1 .+
+                (
+                0.21640425613334457 .+
+                    216.40425613334457 ./ (
+                    1 .+
+                        (
+                        0.21640425613334457 .+
+                            216.40425613334457 ./ (1 .+ 0.0006250000000000001(u .^ 2.0))
+                    ) .^ 2.0
+                )
+            ) .^
+                2.0
+        ) .- 0.0011552453009332421u .- p
     end
 
     const TERMINATION_CONDITIONS = [
@@ -29,35 +37,35 @@
         AbsTerminationMode(),
         AbsNormTerminationMode(Base.Fix1(maximum, abs)),
         AbsNormSafeTerminationMode(Base.Fix1(maximum, abs)),
-        AbsNormSafeBestTerminationMode(Base.Fix1(maximum, abs))
+        AbsNormSafeBestTerminationMode(Base.Fix1(maximum, abs)),
     ]
 
     function run_nlsolve_oop(f::F, u0, p = 2.0; solver, broken_inferred = false) where {F}
         prob = NonlinearProblem{false}(f, u0, p)
-        @test @inferred(solve(prob, solver; abstol = 1e-9)) isa
-              SciMLBase.AbstractNonlinearSolution broken=broken_inferred
-        return solve(prob, solver; abstol = 1e-9)
+        @test @inferred(solve(prob, solver; abstol = 1.0e-9)) isa
+            SciMLBase.AbstractNonlinearSolution broken = broken_inferred
+        return solve(prob, solver; abstol = 1.0e-9)
     end
     function run_nlsolve_iip(f!::F, u0, p = 2.0; solver, broken_inferred = false) where {F}
         prob = NonlinearProblem{true}(f!, u0, p)
-        @test @inferred(solve(prob, solver; abstol = 1e-9)) isa
-              SciMLBase.AbstractNonlinearSolution broken=broken_inferred
-        return solve(prob, solver; abstol = 1e-9)
+        @test @inferred(solve(prob, solver; abstol = 1.0e-9)) isa
+            SciMLBase.AbstractNonlinearSolution broken = broken_inferred
+        return solve(prob, solver; abstol = 1.0e-9)
     end
 end
 
-@testitem "First Order Methods" setup=[RootfindTestSnippet] tags=[:core] begin
+@testitem "First Order Methods" setup = [RootfindTestSnippet] tags = [:core] begin
     @testset for alg in (
-        SimpleNewtonRaphson,
-        SimpleTrustRegion,
-        (; kwargs...) -> SimpleTrustRegion(; kwargs..., nlsolve_update_rule = Val(true))
-    )
+            SimpleNewtonRaphson,
+            SimpleTrustRegion,
+            (; kwargs...) -> SimpleTrustRegion(; kwargs..., nlsolve_update_rule = Val(true)),
+        )
         # Filter autodiff backends based on Julia version
         autodiff_backends = [
             AutoForwardDiff(),
             AutoFiniteDiff(),
             AutoReverseDiff(),
-            nothing
+            nothing,
         ]
         if isempty(VERSION.prerelease) && VERSION < v"1.12"
             push!(autodiff_backends, AutoEnzyme())
@@ -65,91 +73,107 @@ end
 
         @testset for autodiff in autodiff_backends
             @testset "[OOP] u0: $(typeof(u0))" for u0 in (
-                [1.0, 1.0], @SVector[1.0, 1.0], 1.0)
-                broken_inferred = u0 isa StaticArray && (autodiff isa AutoFiniteDiff ||
-                                   (autodiff isa AutoReverseDiff && VERSION < v"1.11"))
-                sol = run_nlsolve_oop(quadratic_f, u0; solver = alg(; autodiff),
-                    broken_inferred)
+                    [1.0, 1.0], @SVector[1.0, 1.0], 1.0,
+                )
+                broken_inferred = u0 isa StaticArray && (
+                    autodiff isa AutoFiniteDiff ||
+                        (autodiff isa AutoReverseDiff && VERSION < v"1.11")
+                )
+                sol = run_nlsolve_oop(
+                    quadratic_f, u0; solver = alg(; autodiff),
+                    broken_inferred
+                )
                 @test SciMLBase.successful_retcode(sol)
-                @test maximum(abs, quadratic_f(sol.u, 2.0)) < 1e-9
+                @test maximum(abs, quadratic_f(sol.u, 2.0)) < 1.0e-9
             end
 
             @testset "[IIP] u0: $(typeof(u0))" for u0 in ([1.0, 1.0],)
                 sol = run_nlsolve_iip(quadratic_f!, u0; solver = alg(; autodiff))
                 @test SciMLBase.successful_retcode(sol)
-                @test maximum(abs, quadratic_f(sol.u, 2.0)) < 1e-9
+                @test maximum(abs, quadratic_f(sol.u, 2.0)) < 1.0e-9
             end
 
             @testset "Termination Condition: $(nameof(typeof(termination_condition))) u0: $(nameof(typeof(u0)))" for termination_condition in
-                                                                                                                     TERMINATION_CONDITIONS,
-                u0 in (1.0, [1.0, 1.0], @SVector[1.0, 1.0])
+                    TERMINATION_CONDITIONS,
+                    u0 in (1.0, [1.0, 1.0], @SVector[1.0, 1.0])
 
                 probN = NonlinearProblem(quadratic_f, u0, 2.0)
-                @test all(solve(
-                    probN, alg(; autodiff = AutoForwardDiff()); termination_condition).u .≈
-                          sqrt(2.0))
+                @test all(
+                    solve(
+                        probN, alg(; autodiff = AutoForwardDiff()); termination_condition
+                    ).u .≈
+                        sqrt(2.0)
+                )
             end
         end
     end
 end
 
-@testitem "Second Order Methods" setup=[RootfindTestSnippet] tags=[:core] begin
+@testitem "Second Order Methods" setup = [RootfindTestSnippet] tags = [:core] begin
     @testset for alg in (
-        SimpleHalley,
-    )
-        @testset for autodiff in (
-            AutoForwardDiff(),
-            AutoFiniteDiff(),
-            AutoReverseDiff(),
-            nothing
+            SimpleHalley,
         )
+        @testset for autodiff in (
+                AutoForwardDiff(),
+                AutoFiniteDiff(),
+                AutoReverseDiff(),
+                nothing,
+            )
             @testset "[OOP] u0: $(typeof(u0))" for u0 in (
-                [1.0, 1.0], @SVector[1.0, 1.0], 1.0)
-                broken_inferred = u0 isa StaticArray && (autodiff isa AutoFiniteDiff ||
-                                   (autodiff isa AutoReverseDiff && VERSION < v"1.11"))
-                sol = run_nlsolve_oop(quadratic_f, u0; solver = alg(; autodiff),
-                    broken_inferred)
+                    [1.0, 1.0], @SVector[1.0, 1.0], 1.0,
+                )
+                broken_inferred = u0 isa StaticArray && (
+                    autodiff isa AutoFiniteDiff ||
+                        (autodiff isa AutoReverseDiff && VERSION < v"1.11")
+                )
+                sol = run_nlsolve_oop(
+                    quadratic_f, u0; solver = alg(; autodiff),
+                    broken_inferred
+                )
                 @test SciMLBase.successful_retcode(sol)
-                @test maximum(abs, quadratic_f(sol.u, 2.0)) < 1e-9
+                @test maximum(abs, quadratic_f(sol.u, 2.0)) < 1.0e-9
             end
         end
 
         @testset "Termination Condition: $(nameof(typeof(termination_condition))) u0: $(nameof(typeof(u0)))" for termination_condition in
-                                                                                                                 TERMINATION_CONDITIONS,
-            u0 in (1.0, [1.0, 1.0], @SVector[1.0, 1.0])
+                TERMINATION_CONDITIONS,
+                u0 in (1.0, [1.0, 1.0], @SVector[1.0, 1.0])
 
             probN = NonlinearProblem(quadratic_f, u0, 2.0)
-            @test all(solve(
-                probN, alg(; autodiff = AutoForwardDiff()); termination_condition).u .≈
-                      sqrt(2.0))
+            @test all(
+                solve(
+                    probN, alg(; autodiff = AutoForwardDiff()); termination_condition
+                ).u .≈
+                    sqrt(2.0)
+            )
         end
     end
 end
 
-@testitem "Derivative Free Methods" setup=[RootfindTestSnippet] tags=[:core] begin
+@testitem "Derivative Free Methods" setup = [RootfindTestSnippet] tags = [:core] begin
     @testset "$(nameof(typeof(alg)))" for alg in (
-        SimpleBroyden(),
-        SimpleKlement(),
-        SimpleDFSane(),
-        SimpleLimitedMemoryBroyden(),
-        SimpleBroyden(; linesearch = Val(true)),
-        SimpleLimitedMemoryBroyden(; linesearch = Val(true))
-    )
+            SimpleBroyden(),
+            SimpleKlement(),
+            SimpleDFSane(),
+            SimpleLimitedMemoryBroyden(),
+            SimpleBroyden(; linesearch = Val(true)),
+            SimpleLimitedMemoryBroyden(; linesearch = Val(true)),
+        )
         @testset "[OOP] u0: $(typeof(u0))" for u0 in ([1.0, 1.0], @SVector[1.0, 1.0], 1.0)
             sol = run_nlsolve_oop(quadratic_f, u0; solver = alg)
             @test SciMLBase.successful_retcode(sol)
-            @test maximum(abs, quadratic_f(sol.u, 2.0)) < 1e-9
+            @test maximum(abs, quadratic_f(sol.u, 2.0)) < 1.0e-9
         end
 
         @testset "[IIP] u0: $(typeof(u0))" for u0 in ([1.0, 1.0],)
             sol = run_nlsolve_iip(quadratic_f!, u0; solver = alg)
             @test SciMLBase.successful_retcode(sol)
-            @test maximum(abs, quadratic_f(sol.u, 2.0)) < 1e-9
+            @test maximum(abs, quadratic_f(sol.u, 2.0)) < 1.0e-9
         end
 
         @testset "Termination Condition: $(nameof(typeof(termination_condition))) u0: $(nameof(typeof(u0)))" for termination_condition in
-                                                                                                                 TERMINATION_CONDITIONS,
-            u0 in (1.0, [1.0, 1.0], @SVector[1.0, 1.0])
+                TERMINATION_CONDITIONS,
+                u0 in (1.0, [1.0, 1.0], @SVector[1.0, 1.0])
 
             probN = NonlinearProblem(quadratic_f, u0, 2.0)
             @test all(solve(probN, alg; termination_condition).u .≈ sqrt(2.0))
@@ -157,24 +181,24 @@ end
     end
 end
 
-@testitem "Newton Fails" setup=[RootfindTestSnippet] tags=[:core] begin
-    u0=[-10.0, -1.0, 1.0, 2.0, 3.0, 4.0, 10.0]
-    p=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+@testitem "Newton Fails" setup = [RootfindTestSnippet] tags = [:core] begin
+    u0 = [-10.0, -1.0, 1.0, 2.0, 3.0, 4.0, 10.0]
+    p = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
 
     @testset "$(nameof(typeof(alg)))" for alg in (
-        SimpleDFSane(),
-        SimpleTrustRegion(),
-        SimpleHalley(),
-        SimpleTrustRegion(; nlsolve_update_rule = Val(true))
-    )
+            SimpleDFSane(),
+            SimpleTrustRegion(),
+            SimpleHalley(),
+            SimpleTrustRegion(; nlsolve_update_rule = Val(true)),
+        )
         sol = run_nlsolve_oop(newton_fails, u0, p; solver = alg)
         @test SciMLBase.successful_retcode(sol)
-        @test maximum(abs, newton_fails(sol.u, p)) < 1e-9
+        @test maximum(abs, newton_fails(sol.u, p)) < 1.0e-9
     end
 end
 
-@testitem "Kwargs Propagation" setup=[RootfindTestSnippet] tags=[:core] begin
-    prob=NonlinearProblem(quadratic_f, ones(4), 2.0; maxiters = 2)
-    sol=solve(prob, SimpleNewtonRaphson())
+@testitem "Kwargs Propagation" setup = [RootfindTestSnippet] tags = [:core] begin
+    prob = NonlinearProblem(quadratic_f, ones(4), 2.0; maxiters = 2)
+    sol = solve(prob, SimpleNewtonRaphson())
     @test sol.retcode === ReturnCode.MaxIters
 end

--- a/lib/SimpleNonlinearSolve/test/gpu/cuda_tests.jl
+++ b/lib/SimpleNonlinearSolve/test/gpu/cuda_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Solving on CUDA" tags=[:cuda] begin
+@testitem "Solving on CUDA" tags = [:cuda] begin
     using StaticArrays, CUDA, SimpleNonlinearSolve, ADTypes
 
     if CUDA.functional()
@@ -8,18 +8,19 @@
         f!(du, u, p) = (du .= u .* u .- 2)
 
         @testset "$(nameof(typeof(alg)))" for alg in (
-            SimpleNewtonRaphson(; autodiff = AutoForwardDiff()),
-            SimpleDFSane(),
-            SimpleTrustRegion(; autodiff = AutoForwardDiff()),
-            SimpleTrustRegion(;
-                nlsolve_update_rule = Val(true), autodiff = AutoForwardDiff()),
-            SimpleBroyden(),
-            SimpleLimitedMemoryBroyden(),
-            SimpleKlement(),
-            SimpleHalley(; autodiff = AutoForwardDiff()),
-            SimpleBroyden(; linesearch = Val(true)),
-            SimpleLimitedMemoryBroyden(; linesearch = Val(true))
-        )
+                SimpleNewtonRaphson(; autodiff = AutoForwardDiff()),
+                SimpleDFSane(),
+                SimpleTrustRegion(; autodiff = AutoForwardDiff()),
+                SimpleTrustRegion(;
+                    nlsolve_update_rule = Val(true), autodiff = AutoForwardDiff()
+                ),
+                SimpleBroyden(),
+                SimpleLimitedMemoryBroyden(),
+                SimpleKlement(),
+                SimpleHalley(; autodiff = AutoForwardDiff()),
+                SimpleBroyden(; linesearch = Val(true)),
+                SimpleLimitedMemoryBroyden(; linesearch = Val(true)),
+            )
             # Static Arrays
             u0 = @SVector[1.0f0, 1.0f0]
             probN = NonlinearProblem{false}(f, u0)
@@ -46,7 +47,7 @@
     end
 end
 
-@testitem "CUDA Kernel Launch Test" tags=[:cuda] begin
+@testitem "CUDA Kernel Launch Test" tags = [:cuda] begin
     using StaticArrays, CUDA, SimpleNonlinearSolve, ADTypes
     using NonlinearSolveBase: ImmutableNonlinearProblem
 
@@ -64,18 +65,19 @@ end
             prob = convert(ImmutableNonlinearProblem, NonlinearProblem{false}(f, u0, 2.0f0))
 
             @testset "$(nameof(typeof(alg)))" for alg in (
-                SimpleNewtonRaphson(; autodiff = AutoForwardDiff()),
-                SimpleDFSane(),
-                SimpleTrustRegion(; autodiff = AutoForwardDiff()),
-                SimpleTrustRegion(;
-                    nlsolve_update_rule = Val(true), autodiff = AutoForwardDiff()),
-                SimpleBroyden(),
-                SimpleLimitedMemoryBroyden(),
-                SimpleKlement(),
-                SimpleHalley(; autodiff = AutoForwardDiff()),
-                SimpleBroyden(; linesearch = Val(true)),
-                SimpleLimitedMemoryBroyden(; linesearch = Val(true))
-            )
+                    SimpleNewtonRaphson(; autodiff = AutoForwardDiff()),
+                    SimpleDFSane(),
+                    SimpleTrustRegion(; autodiff = AutoForwardDiff()),
+                    SimpleTrustRegion(;
+                        nlsolve_update_rule = Val(true), autodiff = AutoForwardDiff()
+                    ),
+                    SimpleBroyden(),
+                    SimpleLimitedMemoryBroyden(),
+                    SimpleKlement(),
+                    SimpleHalley(; autodiff = AutoForwardDiff()),
+                    SimpleBroyden(; linesearch = Val(true)),
+                    SimpleLimitedMemoryBroyden(; linesearch = Val(true)),
+                )
                 @test begin
                     @cuda kernel_function(prob, alg)
                     @info "Successfully launched kernel for $(alg)."

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -11,17 +11,17 @@ using CommonSolve: CommonSolve, init, solve, solve!
 using LinearAlgebra: LinearAlgebra
 using LineSearch: BackTracking
 using NonlinearSolveBase: NonlinearSolveBase, AbstractNonlinearSolveAlgorithm,
-                          NonlinearSolvePolyAlgorithm, pickchunksize, NonlinearVerbosity
+    NonlinearSolvePolyAlgorithm, pickchunksize, NonlinearVerbosity
 
 using SciMLBase: SciMLBase, ReturnCode, AbstractNonlinearProblem,
-                 NonlinearFunction,
-                 NonlinearProblem, NonlinearLeastSquaresProblem, NoSpecialize
+    NonlinearFunction,
+    NonlinearProblem, NonlinearLeastSquaresProblem, NoSpecialize
 using SymbolicIndexingInterface: SymbolicIndexingInterface
 using StaticArraysCore: StaticArray
 
 # Default Algorithm
 using NonlinearSolveFirstOrder: NewtonRaphson, TrustRegion, LevenbergMarquardt, GaussNewton,
-                                RUS, RobustMultiNewton
+    RUS, RobustMultiNewton
 using NonlinearSolveQuasiNewton: Broyden, Klement
 using SimpleNonlinearSolve: SimpleBroyden, SimpleKlement
 
@@ -51,7 +51,7 @@ include("forward_diff.jl")
     nonlinear_functions = (
         (NonlinearFunction{false, NoSpecialize}((u, p) -> u .* u .- p), 0.1),
         (NonlinearFunction{false, NoSpecialize}((u, p) -> u .* u .- p), [0.1]),
-        (NonlinearFunction{true, NoSpecialize}((du, u, p) -> du .= u .* u .- p), [0.1])
+        (NonlinearFunction{true, NoSpecialize}((du, u, p) -> du .= u .* u .- p), [0.1]),
     )
 
     nonlinear_problems = NonlinearProblem[]
@@ -62,22 +62,25 @@ include("forward_diff.jl")
     nonlinear_functions = (
         (NonlinearFunction{false, NoSpecialize}((u, p) -> (u .^ 2 .- p)[1:1]), [0.1, 0.0]),
         (
-            NonlinearFunction{false, NoSpecialize}((
-                u, p) -> vcat(u .* u .- p, u .* u .- p)),
-            [0.1, 0.1]
+            NonlinearFunction{false, NoSpecialize}(
+                (
+                    u, p,
+                ) -> vcat(u .* u .- p, u .* u .- p)
+            ),
+            [0.1, 0.1],
         ),
         (
             NonlinearFunction{true, NoSpecialize}(
                 (du, u, p) -> du[1] = u[1] * u[1] - p, resid_prototype = zeros(1)
             ),
-            [0.1, 0.0]
+            [0.1, 0.0],
         ),
         (
             NonlinearFunction{true, NoSpecialize}(
                 (du, u, p) -> du .= vcat(u .* u .- p, u .* u .- p), resid_prototype = zeros(4)
             ),
-            [0.1, 0.1]
-        )
+            [0.1, 0.1],
+        ),
     )
 
     nlls_problems = NonlinearLeastSquaresProblem[]
@@ -91,11 +94,11 @@ include("forward_diff.jl")
     @compile_workload begin
         @sync begin
             for prob in nonlinear_problems, alg in nlp_algs
-                Threads.@spawn CommonSolve.solve(prob, alg; abstol = 1e-2, verbose = NonlinearVerbosity())
+                Threads.@spawn CommonSolve.solve(prob, alg; abstol = 1.0e-2, verbose = NonlinearVerbosity())
             end
 
             for prob in nlls_problems, alg in nlls_algs
-                Threads.@spawn CommonSolve.solve(prob, alg; abstol = 1e-2, verbose = NonlinearVerbosity())
+                Threads.@spawn CommonSolve.solve(prob, alg; abstol = 1.0e-2, verbose = NonlinearVerbosity())
             end
         end
     end
@@ -104,7 +107,7 @@ end
 # Rexexports
 @reexport using SciMLBase, NonlinearSolveBase, LineSearch, ADTypes
 @reexport using NonlinearSolveFirstOrder, NonlinearSolveSpectralMethods,
-                NonlinearSolveQuasiNewton, SimpleNonlinearSolve, BracketingNonlinearSolve
+    NonlinearSolveQuasiNewton, SimpleNonlinearSolve, BracketingNonlinearSolve
 @reexport using LinearSolve
 
 # Poly Algorithms
@@ -112,7 +115,7 @@ export NonlinearSolvePolyAlgorithm, FastShortcutNonlinearPolyalg, FastShortcutNL
 
 # Extension Algorithms
 export LeastSquaresOptimJL, FastLevenbergMarquardtJL, NLsolveJL, NLSolversJL,
-       FixedPointAccelerationJL, SpeedMappingJL, SIAMFANLEquationsJL
+    FixedPointAccelerationJL, SpeedMappingJL, SIAMFANLEquationsJL
 export PETScSNES, CMINPACK
 
 end

--- a/src/default.jl
+++ b/src/default.jl
@@ -57,15 +57,15 @@ end
 
 function SciMLBase.__solve(
         prob::NonlinearLeastSquaresProblem, ::Nothing, args...; kwargs...
-)
+    )
     return SciMLBase.__solve(
         prob, FastShortcutNLLSPolyalg(eltype(prob.u0)), args...; kwargs...
     )
 end
 
 function NonlinearSolveBase.initialization_alg(::AbstractNonlinearProblem, autodiff)
-    FastShortcutNonlinearPolyalg(; autodiff)
+    return FastShortcutNonlinearPolyalg(; autodiff)
 end
 function NonlinearSolveBase.initialization_alg(::NonlinearLeastSquaresProblem, autodiff)
-    FastShortcutNLLSPolyalg(; autodiff)
+    return FastShortcutNLLSPolyalg(; autodiff)
 end

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -82,10 +82,10 @@ see the documentation for `FastLevenbergMarquardt.jl`.
 end
 
 function FastLevenbergMarquardtJL(
-        linsolve::Symbol = :cholesky; factor = 1e-6, factoraccept = 13.0,
-        factorreject = 3.0, factorupdate = :marquardt, minscale = 1e-12,
-        maxscale = 1e16, minfactor = 1e-28, maxfactor = 1e32, autodiff = nothing
-)
+        linsolve::Symbol = :cholesky; factor = 1.0e-6, factoraccept = 13.0,
+        factorreject = 3.0, factorupdate = :marquardt, minscale = 1.0e-12,
+        maxscale = 1.0e16, minfactor = 1.0e-28, maxfactor = 1.0e32, autodiff = nothing
+    )
     @assert linsolve in (:qr, :cholesky)
     @assert factorupdate in (:marquardt, :nielson)
 
@@ -223,7 +223,7 @@ end
 function NLsolveJL(;
         method = :trust_region, autodiff = :central, linesearch = missing, beta = 1.0,
         linsolve = (x, A, b) -> copyto!(x, A \ b), factor = 1.0, autoscale = true, m = 10
-)
+    )
     if Base.get_extension(@__MODULE__, :NonlinearSolveNLsolveExt) === nothing
         error("`NLsolveJL` requires `NLsolve.jl` to be loaded")
     end
@@ -307,7 +307,7 @@ end
 function SpeedMappingJL(;
         σ_min = 0.0, stabilize::Bool = false, check_obj::Bool = false,
         orders::Vector{Int} = [3, 3, 2]
-)
+    )
     if Base.get_extension(@__MODULE__, :NonlinearSolveSpeedMappingExt) === nothing
         error("`SpeedMappingJL` requires `SpeedMapping.jl` to be loaded")
     end
@@ -356,7 +356,7 @@ end
 function FixedPointAccelerationJL(;
         algorithm = :Anderson, m = missing, condition_number_threshold = missing,
         extrapolation_period = missing, replace_invalids = :NoAction, dampening = 1.0
-)
+    )
     if Base.get_extension(@__MODULE__, :NonlinearSolveFixedPointAccelerationExt) === nothing
         error("`FixedPointAccelerationJL` requires `FixedPointAcceleration.jl` to be loaded")
     end
@@ -365,14 +365,14 @@ function FixedPointAccelerationJL(;
     @assert replace_invalids in (:ReplaceInvalids, :ReplaceVector, :NoAction)
 
     if algorithm !== :Anderson
-        @assert condition_number_threshold===missing "`condition_number_threshold` is only valid for Anderson acceleration"
-        @assert m===missing "`m` is only valid for Anderson acceleration"
+        @assert condition_number_threshold === missing "`condition_number_threshold` is only valid for Anderson acceleration"
+        @assert m === missing "`m` is only valid for Anderson acceleration"
     end
-    condition_number_threshold === missing && (condition_number_threshold = 1e3)
+    condition_number_threshold === missing && (condition_number_threshold = 1.0e3)
     m === missing && (m = 10)
 
     if algorithm !== :MPE && algorithm !== :RRE && algorithm !== :VEA && algorithm !== :SEA
-        @assert extrapolation_period===missing "`extrapolation_period` is only valid for MPE, RRE, VEA and SEA"
+        @assert extrapolation_period === missing "`extrapolation_period` is only valid for MPE, RRE, VEA and SEA"
     end
     if extrapolation_period === missing
         extrapolation_period = algorithm === :SEA || algorithm === :VEA ? 6 : 7
@@ -427,9 +427,9 @@ end
 end
 
 function SIAMFANLEquationsJL(;
-        method = :newton, delta = 1e-3, linsolve = nothing, m = 0, beta = 1.0,
+        method = :newton, delta = 1.0e-3, linsolve = nothing, m = 0, beta = 1.0,
         autodiff = missing
-)
+    )
     if Base.get_extension(@__MODULE__, :NonlinearSolveSIAMFANLEquationsExt) === nothing
         error("`SIAMFANLEquationsJL` requires `SIAMFANLEquations.jl` to be loaded")
     end

--- a/src/forward_diff.jl
+++ b/src/forward_diff.jl
@@ -1,25 +1,25 @@
 const EXTENSION_SOLVER_TYPES = [
     LeastSquaresOptimJL, FastLevenbergMarquardtJL, NLsolveJL, NLSolversJL,
     SpeedMappingJL, FixedPointAccelerationJL, SIAMFANLEquationsJL,
-    CMINPACK, PETScSNES
+    CMINPACK, PETScSNES,
 ]
 
 const DualNonlinearProblem = NonlinearProblem{
     <:Union{Number, <:AbstractArray}, iip,
-    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}}
+    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}},
 } where {iip, T, V, P}
 const DualNonlinearLeastSquaresProblem = NonlinearLeastSquaresProblem{
     <:Union{Number, <:AbstractArray}, iip,
-    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}}
+    <:Union{<:Dual{T, V, P}, <:AbstractArray{<:Dual{T, V, P}}},
 } where {iip, T, V, P}
 const DualAbstractNonlinearProblem = Union{
-    DualNonlinearProblem, DualNonlinearLeastSquaresProblem
+    DualNonlinearProblem, DualNonlinearLeastSquaresProblem,
 }
 
 for algType in EXTENSION_SOLVER_TYPES
     @eval function SciMLBase.__init(
             prob::DualAbstractNonlinearProblem, alg::$(algType), args...; kwargs...
-    )
+        )
         p = NonlinearSolveBase.nodual_value(prob.p)
         newprob = SciMLBase.remake(prob; u0 = NonlinearSolveBase.nodual_value(prob.u0), p)
         cache = init(newprob, alg, args...; kwargs...)
@@ -32,9 +32,9 @@ end
 for algType in EXTENSION_SOLVER_TYPES
     @eval function SciMLBase.__solve(
             prob::DualAbstractNonlinearProblem, alg::$(algType), args...; kwargs...
-    )
+        )
         sol,
-        partials = NonlinearSolveBase.nonlinearsolve_forwarddiff_solve(
+            partials = NonlinearSolveBase.nonlinearsolve_forwarddiff_solve(
             prob, alg, args...; kwargs...
         )
         dual_soln = NonlinearSolveBase.nonlinearsolve_dual_solution(sol.u, partials, prob.p)

--- a/src/poly_algs.jl
+++ b/src/poly_algs.jl
@@ -31,7 +31,7 @@ function FastShortcutNonlinearPolyalg(
         prefer_simplenonlinearsolve::Val = Val(false),
         autodiff = nothing, vjp_autodiff = nothing, jvp_autodiff = nothing,
         u0_len::Union{Int, Nothing} = nothing
-) where {T}
+    ) where {T}
     start_index = 1
     common_kwargs = (; concrete_jac, linsolve, autodiff, vjp_autodiff, jvp_autodiff)
     common_kwargs_nocj = (; linsolve, autodiff, vjp_autodiff, jvp_autodiff)
@@ -43,7 +43,7 @@ function FastShortcutNonlinearPolyalg(
                 NewtonRaphson(; common_kwargs...),
                 TrustRegion(; common_kwargs...),
                 TrustRegion(; common_kwargs..., radius_update_scheme = RUS.Bastin),
-                LevenbergMarquardt(; common_kwargs_nocj...)
+                LevenbergMarquardt(; common_kwargs_nocj...),
             )
         end
     else
@@ -54,7 +54,7 @@ function FastShortcutNonlinearPolyalg(
                 algs = (
                     SimpleBroyden(),
                     SimpleKlement(),
-                    NewtonRaphson(; common_kwargs...)
+                    NewtonRaphson(; common_kwargs...),
                 )
             else
                 start_index = u0_len !== nothing ? (u0_len ≤ 25 ? 3 : 1) : 1
@@ -64,7 +64,7 @@ function FastShortcutNonlinearPolyalg(
                     NewtonRaphson(; common_kwargs...),
                     TrustRegion(; common_kwargs...),
                     TrustRegion(; common_kwargs..., radius_update_scheme = RUS.Bastin),
-                    LevenbergMarquardt(; common_kwargs_nocj...)
+                    LevenbergMarquardt(; common_kwargs_nocj...),
                 )
             end
         else
@@ -72,7 +72,7 @@ function FastShortcutNonlinearPolyalg(
                 algs = (
                     Broyden(; autodiff),
                     Klement(; linsolve, autodiff),
-                    NewtonRaphson(; common_kwargs...)
+                    NewtonRaphson(; common_kwargs...),
                 )
             else
                 # TODO: This number requires a bit rigorous testing
@@ -83,7 +83,7 @@ function FastShortcutNonlinearPolyalg(
                     NewtonRaphson(; common_kwargs...),
                     TrustRegion(; common_kwargs...),
                     TrustRegion(; common_kwargs..., radius_update_scheme = RUS.Bastin),
-                    LevenbergMarquardt(; common_kwargs_nocj...)
+                    LevenbergMarquardt(; common_kwargs_nocj...),
                 )
             end
         end
@@ -112,13 +112,13 @@ function FastShortcutNLLSPolyalg(
         concrete_jac = nothing,
         linsolve = nothing,
         autodiff = nothing, vjp_autodiff = nothing, jvp_autodiff = nothing
-) where {T}
+    ) where {T}
     common_kwargs = (; linsolve, autodiff, vjp_autodiff, jvp_autodiff)
     if T <: Complex
         algs = (
             GaussNewton(; common_kwargs..., concrete_jac),
             LevenbergMarquardt(; common_kwargs..., disable_geodesic = Val(true)),
-            LevenbergMarquardt(; common_kwargs...)
+            LevenbergMarquardt(; common_kwargs...),
         )
     else
         algs = (
@@ -129,7 +129,7 @@ function FastShortcutNLLSPolyalg(
             TrustRegion(;
                 common_kwargs..., radius_update_scheme = RUS.Bastin, concrete_jac
             ),
-            LevenbergMarquardt(; common_kwargs...)
+            LevenbergMarquardt(; common_kwargs...),
         )
     end
     return NonlinearSolvePolyAlgorithm(algs)

--- a/test/23_test_problems_tests.jl
+++ b/test/23_test_problems_tests.jl
@@ -5,13 +5,14 @@ problems = NonlinearProblemLibrary.problems
 dicts = NonlinearProblemLibrary.dicts
 
 function test_on_library(
-        problems, dicts, alg_ops, broken_tests, ϵ = 1e-4; skip_tests = nothing)
+        problems, dicts, alg_ops, broken_tests, ϵ = 1.0e-4; skip_tests = nothing
+    )
     for (idx, (problem, dict)) in enumerate(zip(problems, dicts))
         x = dict["start"]
         res = similar(x)
         nlprob = NonlinearProblem(problem, copy(x))
         @testset "$idx: $(dict["title"]) | alg #$(alg_id)" for (alg_id, alg) in
-                                                               enumerate(alg_ops)
+            enumerate(alg_ops)
             try
                 sol = solve(nlprob, alg; maxiters = 10000)
                 problem(res, sol.u, nothing)
@@ -22,12 +23,12 @@ function test_on_library(
                     continue
                 end
                 broken = idx in broken_tests[alg] ? true : false
-                @test norm(res, Inf)≤ϵ broken=broken
+                @test norm(res, Inf) ≤ ϵ broken = broken
             catch err
                 @error err
                 broken = idx in broken_tests[alg] ? true : false
                 if broken
-                    @test false broken=true
+                    @test false broken = true
                 else
                     @test 1 == 2
                 end
@@ -39,39 +40,39 @@ end
 export test_on_library, problems, dicts
 end
 
-@testitem "23 Test Problems: PolyAlgorithms" setup=[RobustnessTesting] tags=[:nopre] begin
-    alg_ops=(RobustMultiNewton(), FastShortcutNonlinearPolyalg())
+@testitem "23 Test Problems: PolyAlgorithms" setup = [RobustnessTesting] tags = [:nopre] begin
+    alg_ops = (RobustMultiNewton(), FastShortcutNonlinearPolyalg())
 
-    broken_tests=Dict(alg=>Int[] for alg in alg_ops)
-    broken_tests[alg_ops[1]]=[]
-    broken_tests[alg_ops[2]]=[]
+    broken_tests = Dict(alg => Int[] for alg in alg_ops)
+    broken_tests[alg_ops[1]] = []
+    broken_tests[alg_ops[2]] = []
 
     test_on_library(problems, dicts, alg_ops, broken_tests)
 end
 
-@testitem "23 Test Problems: NewtonRaphson" setup=[RobustnessTesting] tags=[:core] begin
-    alg_ops=(
+@testitem "23 Test Problems: NewtonRaphson" setup = [RobustnessTesting] tags = [:core] begin
+    alg_ops = (
         NewtonRaphson(),
-        SimpleNewtonRaphson()
+        SimpleNewtonRaphson(),
     )
 
-    broken_tests=Dict(alg=>Int[] for alg in alg_ops)
-    broken_tests[alg_ops[1]]=[1]
+    broken_tests = Dict(alg => Int[] for alg in alg_ops)
+    broken_tests[alg_ops[1]] = [1]
 
     test_on_library(problems, dicts, alg_ops, broken_tests)
 end
 
-@testitem "23 Test Problems: Halley" setup=[RobustnessTesting] tags=[:core] begin
-    alg_ops=(SimpleHalley(; autodiff = AutoForwardDiff()),)
+@testitem "23 Test Problems: Halley" setup = [RobustnessTesting] tags = [:core] begin
+    alg_ops = (SimpleHalley(; autodiff = AutoForwardDiff()),)
 
-    broken_tests=Dict(alg=>Int[] for alg in alg_ops)
-    broken_tests[alg_ops[1]]=[1, 5, 15, 16, 18]
+    broken_tests = Dict(alg => Int[] for alg in alg_ops)
+    broken_tests[alg_ops[1]] = [1, 5, 15, 16, 18]
 
     test_on_library(problems, dicts, alg_ops, broken_tests)
 end
 
-@testitem "23 Test Problems: TrustRegion" setup=[RobustnessTesting] tags=[:core] begin
-    alg_ops=(
+@testitem "23 Test Problems: TrustRegion" setup = [RobustnessTesting] tags = [:core] begin
+    alg_ops = (
         TrustRegion(; radius_update_scheme = RadiusUpdateSchemes.Simple),
         TrustRegion(; radius_update_scheme = RadiusUpdateSchemes.Fan),
         TrustRegion(; radius_update_scheme = RadiusUpdateSchemes.Hei),
@@ -79,114 +80,114 @@ end
         TrustRegion(; radius_update_scheme = RadiusUpdateSchemes.Bastin),
         TrustRegion(; radius_update_scheme = RadiusUpdateSchemes.NLsolve),
         SimpleTrustRegion(),
-        SimpleTrustRegion(; nlsolve_update_rule = Val(true))
+        SimpleTrustRegion(; nlsolve_update_rule = Val(true)),
     )
 
-    broken_tests=Dict(alg=>Int[] for alg in alg_ops)
-    broken_tests[alg_ops[1]]=[11, 21]
-    broken_tests[alg_ops[2]]=[11, 21]
-    broken_tests[alg_ops[3]]=[11, 21]
-    broken_tests[alg_ops[4]]=[8, 11, 21]
-    broken_tests[alg_ops[5]]=[21]
-    broken_tests[alg_ops[6]]=[11, 21]
-    broken_tests[alg_ops[7]]=[3, 15, 16, 21]
-    broken_tests[alg_ops[8]]=[15, 16]
+    broken_tests = Dict(alg => Int[] for alg in alg_ops)
+    broken_tests[alg_ops[1]] = [11, 21]
+    broken_tests[alg_ops[2]] = [11, 21]
+    broken_tests[alg_ops[3]] = [11, 21]
+    broken_tests[alg_ops[4]] = [8, 11, 21]
+    broken_tests[alg_ops[5]] = [21]
+    broken_tests[alg_ops[6]] = [11, 21]
+    broken_tests[alg_ops[7]] = [3, 15, 16, 21]
+    broken_tests[alg_ops[8]] = [15, 16]
 
     test_on_library(problems, dicts, alg_ops, broken_tests)
 end
 
-@testitem "23 Test Problems: LevenbergMarquardt" setup=[RobustnessTesting] tags=[:core] begin
+@testitem "23 Test Problems: LevenbergMarquardt" setup = [RobustnessTesting] tags = [:core] begin
     using LinearSolve
 
-    alg_ops=(
+    alg_ops = (
         LevenbergMarquardt(),
         LevenbergMarquardt(; α_geodesic = 0.1),
-        LevenbergMarquardt(; linsolve = CholeskyFactorization())
+        LevenbergMarquardt(; linsolve = CholeskyFactorization()),
     )
 
-    broken_tests=Dict(alg=>Int[] for alg in alg_ops)
-    broken_tests[alg_ops[1]]=[11, 21]
-    broken_tests[alg_ops[2]]=[11, 21]
-    broken_tests[alg_ops[3]]=[11, 21]
+    broken_tests = Dict(alg => Int[] for alg in alg_ops)
+    broken_tests[alg_ops[1]] = [11, 21]
+    broken_tests[alg_ops[2]] = [11, 21]
+    broken_tests[alg_ops[3]] = [11, 21]
 
     test_on_library(problems, dicts, alg_ops, broken_tests)
 end
 
-@testitem "23 Test Problems: DFSane" setup=[RobustnessTesting] tags=[:core] begin
-    alg_ops=(
+@testitem "23 Test Problems: DFSane" setup = [RobustnessTesting] tags = [:core] begin
+    alg_ops = (
         DFSane(),
-        SimpleDFSane()
+        SimpleDFSane(),
     )
 
-    broken_tests=Dict(alg=>Int[] for alg in alg_ops)
-    broken_tests[alg_ops[1]]=[1, 2, 3, 5, 21]
+    broken_tests = Dict(alg => Int[] for alg in alg_ops)
+    broken_tests[alg_ops[1]] = [1, 2, 3, 5, 21]
     if Sys.isapple()
-        if VERSION≥v"1.11-"
-            broken_tests[alg_ops[2]]=[1, 2, 3, 5, 6, 11, 21]
+        if VERSION ≥ v"1.11-"
+            broken_tests[alg_ops[2]] = [1, 2, 3, 5, 6, 11, 21]
         else
-            broken_tests[alg_ops[2]]=[1, 2, 3, 5, 6, 21]
+            broken_tests[alg_ops[2]] = [1, 2, 3, 5, 6, 21]
         end
     else
-        broken_tests[alg_ops[2]]=[1, 2, 3, 5, 6, 11, 21]
+        broken_tests[alg_ops[2]] = [1, 2, 3, 5, 6, 11, 21]
     end
 
     test_on_library(problems, dicts, alg_ops, broken_tests)
 end
 
-@testitem "23 Test Problems: Broyden" setup=[RobustnessTesting] tags=[:core] retries=3 begin
-    alg_ops=(
+@testitem "23 Test Problems: Broyden" setup = [RobustnessTesting] tags = [:core] retries = 3 begin
+    alg_ops = (
         Broyden(),
         Broyden(; init_jacobian = Val(:true_jacobian)),
         Broyden(; update_rule = Val(:bad_broyden)),
         Broyden(; init_jacobian = Val(:true_jacobian), update_rule = Val(:bad_broyden)),
-        SimpleBroyden()
+        SimpleBroyden(),
     )
 
-    broken_tests=Dict(alg=>Int[] for alg in alg_ops)
-    broken_tests[alg_ops[2]]=[1, 5, 8, 11, 18]
-    broken_tests[alg_ops[4]]=[5, 6, 8, 11]
+    broken_tests = Dict(alg => Int[] for alg in alg_ops)
+    broken_tests[alg_ops[2]] = [1, 5, 8, 11, 18]
+    broken_tests[alg_ops[4]] = [5, 6, 8, 11]
     if Sys.isapple()
-        broken_tests[alg_ops[1]]=[1, 5, 11]
-        broken_tests[alg_ops[3]]=[1, 5, 6, 9, 11]
-        if VERSION≥v"1.12"
+        broken_tests[alg_ops[1]] = [1, 5, 11]
+        broken_tests[alg_ops[3]] = [1, 5, 6, 9, 11]
+        if VERSION ≥ v"1.12"
             # Test #4 (Wood function) passes on v1.12+
-            broken_tests[alg_ops[5]]=[1, 5, 11]
-        elseif VERSION≥v"1.11-"
-            broken_tests[alg_ops[5]]=[1, 4, 5, 11]
+            broken_tests[alg_ops[5]] = [1, 5, 11]
+        elseif VERSION ≥ v"1.11-"
+            broken_tests[alg_ops[5]] = [1, 4, 5, 11]
         else
-            broken_tests[alg_ops[5]]=[1, 5, 11]
+            broken_tests[alg_ops[5]] = [1, 5, 11]
         end
     else
-        broken_tests[alg_ops[1]]=[1, 5, 11]
-        broken_tests[alg_ops[3]]=[1, 5, 6, 9, 11]
-        broken_tests[alg_ops[5]]=[1, 5, 11]
+        broken_tests[alg_ops[1]] = [1, 5, 11]
+        broken_tests[alg_ops[3]] = [1, 5, 6, 9, 11]
+        broken_tests[alg_ops[5]] = [1, 5, 11]
     end
 
-    test_on_library(problems, dicts, alg_ops, broken_tests, 1e-3)
+    test_on_library(problems, dicts, alg_ops, broken_tests, 1.0e-3)
 end
 
-@testitem "23 Test Problems: Klement" setup=[RobustnessTesting] tags=[:core] begin
-    alg_ops=(
+@testitem "23 Test Problems: Klement" setup = [RobustnessTesting] tags = [:core] begin
+    alg_ops = (
         Klement(),
         Klement(; init_jacobian = Val(:true_jacobian_diagonal)),
-        SimpleKlement()
+        SimpleKlement(),
     )
 
-    broken_tests=Dict(alg=>Int[] for alg in alg_ops)
-    broken_tests[alg_ops[1]]=[1, 2, 4, 5, 11, 18, 22]
-    broken_tests[alg_ops[2]]=[2, 4, 5, 7, 18, 22]
-    broken_tests[alg_ops[3]]=[1, 2, 4, 5, 11, 22]
+    broken_tests = Dict(alg => Int[] for alg in alg_ops)
+    broken_tests[alg_ops[1]] = [1, 2, 4, 5, 11, 18, 22]
+    broken_tests[alg_ops[2]] = [2, 4, 5, 7, 18, 22]
+    broken_tests[alg_ops[3]] = [1, 2, 4, 5, 11, 22]
 
     test_on_library(problems, dicts, alg_ops, broken_tests)
 end
 
-@testitem "23 Test Problems: PseudoTransient" setup=[RobustnessTesting] tags=[:core] begin
+@testitem "23 Test Problems: PseudoTransient" setup = [RobustnessTesting] tags = [:core] begin
     # PT relies on the root being a stable equilibrium for convergence, so it won't work on
     # most problems
-    alg_ops=(PseudoTransient(),)
+    alg_ops = (PseudoTransient(),)
 
-    broken_tests=Dict(alg=>Int[] for alg in alg_ops)
-    broken_tests[alg_ops[1]]=[1, 2, 3, 11, 15, 16]
+    broken_tests = Dict(alg => Int[] for alg in alg_ops)
+    broken_tests[alg_ops[1]] = [1, 2, 3, 11, 15, 16]
 
     test_on_library(problems, dicts, alg_ops, broken_tests)
 end

--- a/test/cuda_tests.jl
+++ b/test/cuda_tests.jl
@@ -1,4 +1,4 @@
-@testitem "CUDA Tests" tags=[:cuda] skip=:(!isempty(VERSION.prerelease)) begin
+@testitem "CUDA Tests" tags = [:cuda] skip = :(!isempty(VERSION.prerelease)) begin
     using CUDA, NonlinearSolve, LinearSolve, StableRNGs
 
     if CUDA.functional()
@@ -23,7 +23,7 @@
             DFSane(),
             TrustRegion(; linsolve = QRFactorization()),
             TrustRegion(; linsolve = KrylovJL_GMRES(), concrete_jac = true),  # Needed if Zygote not loaded
-            nothing
+            nothing,
         )
 
         @testset "[IIP] GPU Solvers" begin
@@ -44,7 +44,7 @@
     end
 end
 
-@testitem "Termination Conditions: Allocations" tags=[:cuda] skip=:(!isempty(VERSION.prerelease)) begin
+@testitem "Termination Conditions: Allocations" tags = [:cuda] skip = :(!isempty(VERSION.prerelease)) begin
     using CUDA, NonlinearSolveBase, Test, LinearAlgebra
 
     if CUDA.functional()
@@ -53,25 +53,27 @@ end
         u = cu(rand(4))
         uprev = cu(rand(4))
         TERMINATION_CONDITIONS = [
-            RelTerminationMode, AbsTerminationMode
+            RelTerminationMode, AbsTerminationMode,
         ]
         NORM_TERMINATION_CONDITIONS = [
             AbsNormTerminationMode, RelNormTerminationMode, RelNormSafeTerminationMode,
-            AbsNormSafeTerminationMode, RelNormSafeBestTerminationMode, AbsNormSafeBestTerminationMode
+            AbsNormSafeTerminationMode, RelNormSafeBestTerminationMode, AbsNormSafeBestTerminationMode,
         ]
 
         @testset begin
             @testset "Mode: $(tcond)" for tcond in TERMINATION_CONDITIONS
                 @test_nowarn NonlinearSolveBase.check_convergence(
-                    tcond(), du, u, uprev, 1e-3, 1e-3)
+                    tcond(), du, u, uprev, 1.0e-3, 1.0e-3
+                )
             end
 
             @testset "Mode: $(tcond)" for tcond in NORM_TERMINATION_CONDITIONS
                 for nfn in (
-                    Base.Fix1(maximum, abs), Base.Fix2(norm, 2), Base.Fix2(norm, Inf)
-                )
+                        Base.Fix1(maximum, abs), Base.Fix2(norm, 2), Base.Fix2(norm, Inf),
+                    )
                     @test_nowarn NonlinearSolveBase.check_convergence(
-                        tcond(nfn), du, u, uprev, 1e-3, 1e-3)
+                        tcond(nfn), du, u, uprev, 1.0e-3, 1.0e-3
+                    )
                 end
             end
         end

--- a/test/default_alg_tests.jl
+++ b/test/default_alg_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Default Algorithm for AbstractSteadyStateProblem" tags=[:core] begin
+@testitem "Default Algorithm for AbstractSteadyStateProblem" tags = [:core] begin
     using SciMLBase, StaticArrays
 
     # Test with in-place function
@@ -6,100 +6,100 @@
         du[1] = 2 - 2u[1]
         du[2] = u[1] - 4u[2]
     end
-    
+
     u0 = zeros(2)
     prob_iip = SteadyStateProblem(f_iip, u0)
-    
+
     @testset "In-place SteadyStateProblem" begin
         # Test with default algorithm (nothing)
         sol = solve(prob_iip)
         @test SciMLBase.successful_retcode(sol.retcode)
-        @test maximum(abs, sol.resid) < 1e-6
-        
+        @test maximum(abs, sol.resid) < 1.0e-6
+
         # Test with explicit nothing
         sol = solve(prob_iip, nothing)
         @test SciMLBase.successful_retcode(sol.retcode)
-        @test maximum(abs, sol.resid) < 1e-6
-        
+        @test maximum(abs, sol.resid) < 1.0e-6
+
         # Test init interface
         cache = init(prob_iip)
         sol = solve!(cache)
         @test SciMLBase.successful_retcode(sol.retcode)
-        @test maximum(abs, sol.resid) < 1e-6
-        
+        @test maximum(abs, sol.resid) < 1.0e-6
+
         # Test init with nothing
         cache = init(prob_iip, nothing)
         sol = solve!(cache)
         @test SciMLBase.successful_retcode(sol.retcode)
-        @test maximum(abs, sol.resid) < 1e-6
+        @test maximum(abs, sol.resid) < 1.0e-6
     end
-    
+
     # Test with out-of-place function
     f_oop(u, p, t) = [2 - 2u[1], u[1] - 4u[2]]
     u0 = zeros(2)
     prob_oop = SteadyStateProblem(f_oop, u0)
-    
+
     @testset "Out-of-place SteadyStateProblem" begin
         # Test with default algorithm (nothing)
         sol = solve(prob_oop)
         @test SciMLBase.successful_retcode(sol.retcode)
-        @test maximum(abs, sol.resid) < 1e-6
-        
+        @test maximum(abs, sol.resid) < 1.0e-6
+
         # Test with explicit nothing
         sol = solve(prob_oop, nothing)
         @test SciMLBase.successful_retcode(sol.retcode)
-        @test maximum(abs, sol.resid) < 1e-6
-        
+        @test maximum(abs, sol.resid) < 1.0e-6
+
         # Test init interface
         cache = init(prob_oop)
         sol = solve!(cache)
         @test SciMLBase.successful_retcode(sol.retcode)
-        @test maximum(abs, sol.resid) < 1e-6
-        
+        @test maximum(abs, sol.resid) < 1.0e-6
+
         # Test init with nothing
         cache = init(prob_oop, nothing)
         sol = solve!(cache)
         @test SciMLBase.successful_retcode(sol.retcode)
-        @test maximum(abs, sol.resid) < 1e-6
+        @test maximum(abs, sol.resid) < 1.0e-6
     end
-    
+
     # Test that SteadyStateProblem conversion works
     @testset "Problem conversion" begin
         # Create equivalent NonlinearProblem
         function f_nl(u, p)
             [2 - 2u[1], u[1] - 4u[2]]
         end
-        
+
         prob_nl = NonlinearProblem(f_nl, u0)
-        
+
         # Convert SteadyStateProblem to NonlinearProblem
         prob_converted = NonlinearProblem(prob_oop)
-        
+
         # Both should solve to the same solution
         sol_nl = solve(prob_nl)
         sol_converted = solve(prob_converted)
-        
-        @test sol_nl.u ≈ sol_converted.u atol=1e-10
+
+        @test sol_nl.u ≈ sol_converted.u atol = 1.0e-10
     end
-    
+
     # Test with StaticArrays
     @testset "StaticArrays support" begin
         f_static(u, p, t) = @SVector [2 - 2u[1], u[1] - 4u[2]]
         u0_static = @SVector [0.0, 0.0]
         prob_static = SteadyStateProblem(f_static, u0_static)
-        
+
         sol = solve(prob_static)
         @test SciMLBase.successful_retcode(sol.retcode)
-        @test maximum(abs, sol.resid) < 1e-6
+        @test maximum(abs, sol.resid) < 1.0e-6
     end
-    
+
     # Test that solve works with various problem types
     @testset "Mixed problem types" begin
         # Regular arrays
         prob1 = SteadyStateProblem(f_oop, [0.5, 0.5])
         sol1 = solve(prob1)
         @test SciMLBase.successful_retcode(sol1.retcode)
-        
+
         # With parameters
         f_param(u, p, t) = [p[1] - 2u[1], u[1] - 4u[2]]
         prob2 = SteadyStateProblem(f_param, [0.5, 0.5], [2.0])

--- a/test/forward_ad_tests.jl
+++ b/test/forward_ad_tests.jl
@@ -62,21 +62,21 @@ compatible(::KINSOL, ::Val{:oop_cache}) = false
 export test_f!, test_f, jacobian_f, solve_with, compatible
 end
 
-@testitem "ForwardDiff.jl Integration" setup=[ForwardADTesting] tags=[:nopre] begin
+@testitem "ForwardDiff.jl Integration" setup = [ForwardADTesting] tags = [:nopre] begin
     @testset for alg in (
-        NewtonRaphson(),
-        TrustRegion(),
-        LevenbergMarquardt(),
-        PseudoTransient(; alpha_initial = 10.0),
-        Broyden(),
-        Klement(),
-        DFSane(),
-        FastShortcutNonlinearPolyalg(),
-        nothing,
-        NLsolveJL(),
-        CMINPACK(),
-        KINSOL(; globalization_strategy = :LineSearch)
-    )
+            NewtonRaphson(),
+            TrustRegion(),
+            LevenbergMarquardt(),
+            PseudoTransient(; alpha_initial = 10.0),
+            Broyden(),
+            Klement(),
+            DFSane(),
+            FastShortcutNonlinearPolyalg(),
+            nothing,
+            NLsolveJL(),
+            CMINPACK(),
+            KINSOL(; globalization_strategy = :LineSearch),
+        )
         us = (2.0, @SVector[1.0, 1.0], [1.0, 1.0], ones(2, 2), @SArray ones(2, 2))
 
         alg isa CMINPACK && Sys.isapple() && continue
@@ -91,10 +91,10 @@ end
                 if SciMLBase.successful_retcode(sol)
                     gs = abs.(ForwardDiff.derivative(solve_with(Val{mode}(), u0, alg), p))
                     gs_true = abs.(jacobian_f(u0, p))
-                    if !(isapprox(gs, gs_true, atol = 1e-5))
-                        @error "ForwardDiff Failed for u0=$(u0) and p=$(p) with $(alg)" forwardiff_gradient=gs true_gradient=gs_true
+                    if !(isapprox(gs, gs_true, atol = 1.0e-5))
+                        @error "ForwardDiff Failed for u0=$(u0) and p=$(p) with $(alg)" forwardiff_gradient = gs true_gradient = gs_true
                     else
-                        @test abs.(gs)≈abs.(gs_true) atol=1e-5
+                        @test abs.(gs) ≈ abs.(gs_true) atol = 1.0e-5
                     end
                 end
             end
@@ -102,8 +102,8 @@ end
 
         @testset "Jacobian" begin
             for u0 in us,
-                p in ([2.0, 1.0], [2.0 1.0; 3.0 4.0]),
-                mode in (:iip, :oop, :iip_cache, :oop_cache)
+                    p in ([2.0, 1.0], [2.0 1.0; 3.0 4.0]),
+                    mode in (:iip, :oop, :iip_cache, :oop_cache)
                 compatible(u0, p) || continue
                 compatible(u0, alg) || continue
                 compatible(u0, Val(mode)) || continue
@@ -113,11 +113,11 @@ end
                 if SciMLBase.successful_retcode(sol)
                     gs = abs.(ForwardDiff.jacobian(solve_with(Val{mode}(), u0, alg), p))
                     gs_true = abs.(jacobian_f(u0, p))
-                    if !(isapprox(gs, gs_true, atol = 1e-5))
+                    if !(isapprox(gs, gs_true, atol = 1.0e-5))
                         @show sol.retcode, sol.u
-                        @error "ForwardDiff Failed for u0=$(u0) and p=$(p) with $(alg)" forwardiff_jacobian=gs true_jacobian=gs_true
+                        @error "ForwardDiff Failed for u0=$(u0) and p=$(p) with $(alg)" forwardiff_jacobian = gs true_jacobian = gs_true
                     else
-                        @test abs.(gs)≈abs.(gs_true) atol=1e-5
+                        @test abs.(gs) ≈ abs.(gs_true) atol = 1.0e-5
                     end
                 end
             end
@@ -125,7 +125,7 @@ end
     end
 end
 
-@testitem "NLLS Hessian SciML/NonlinearSolve.jl#445" tags=[:core] begin
+@testitem "NLLS Hessian SciML/NonlinearSolve.jl#445" tags = [:core] begin
     using ForwardDiff, FiniteDiff
 
     function objfn(F, init, params)
@@ -150,33 +150,41 @@ end
         )
         resu = solve(
             prob,
-            reltol = 1e-12, abstol = 1e-12
+            reltol = 1.0e-12, abstol = 1.0e-12
         )
         th1, th2 = resu.u
         cable1_base = [-90; 0; 0]
         cable2_base = [-150; 0; 0]
         cable3_base = [150; 0; 0]
         cable1_top = [l1 * cos(th1) / 2; l1 * sin(th1) / 2; 0]
-        cable23_top = [l1 * cos(th1) + l2 * cos(th1 + th2) / 2;
-                       l1 * sin(th1) + l2 * sin(th1 + th2) / 2; 0]
-        c1_length = sqrt((cable1_top[1] - cable1_base[1])^2 +
-                         (cable1_top[2] - cable1_base[2])^2)
-        c2_length = sqrt((cable23_top[1] - cable2_base[1])^2 +
-                         (cable23_top[2] - cable2_base[2])^2)
-        c3_length = sqrt((cable23_top[1] - cable3_base[1])^2 +
-                         (cable23_top[2] - cable3_base[2])^2)
+        cable23_top = [
+            l1 * cos(th1) + l2 * cos(th1 + th2) / 2;
+            l1 * sin(th1) + l2 * sin(th1 + th2) / 2; 0
+        ]
+        c1_length = sqrt(
+            (cable1_top[1] - cable1_base[1])^2 +
+                (cable1_top[2] - cable1_base[2])^2
+        )
+        c2_length = sqrt(
+            (cable23_top[1] - cable2_base[1])^2 +
+                (cable23_top[2] - cable2_base[2])^2
+        )
+        c3_length = sqrt(
+            (cable23_top[1] - cable3_base[1])^2 +
+                (cable23_top[2] - cable3_base[2])^2
+        )
         return c1_length + c2_length + c3_length
     end
 
     grad1 = ForwardDiff.gradient(solve_nlprob, [34.0, 87.0])
     grad2 = FiniteDiff.finite_difference_gradient(solve_nlprob, [34.0, 87.0])
 
-    @test grad1≈grad2 atol=1e-3
+    @test grad1 ≈ grad2 atol = 1.0e-3
 
     hess1 = ForwardDiff.hessian(solve_nlprob, [34.0, 87.0])
     hess2 = FiniteDiff.finite_difference_hessian(solve_nlprob, [34.0, 87.0])
 
-    @test hess1≈hess2 atol=1e-3
+    @test hess1 ≈ hess2 atol = 1.0e-3
 
     function solve_nlprob_with_cache(pxpy)
         px, py = pxpy
@@ -190,36 +198,44 @@ end
             NonlinearFunction(objfn, resid_prototype = zeros(2)),
             initial_guess, p
         )
-        cache = init(prob; reltol = 1e-12, abstol = 1e-12)
+        cache = init(prob; reltol = 1.0e-12, abstol = 1.0e-12)
         resu = solve!(cache)
         th1, th2 = resu.u
         cable1_base = [-90; 0; 0]
         cable2_base = [-150; 0; 0]
         cable3_base = [150; 0; 0]
         cable1_top = [l1 * cos(th1) / 2; l1 * sin(th1) / 2; 0]
-        cable23_top = [l1 * cos(th1) + l2 * cos(th1 + th2) / 2;
-                       l1 * sin(th1) + l2 * sin(th1 + th2) / 2; 0]
-        c1_length = sqrt((cable1_top[1] - cable1_base[1])^2 +
-                         (cable1_top[2] - cable1_base[2])^2)
-        c2_length = sqrt((cable23_top[1] - cable2_base[1])^2 +
-                         (cable23_top[2] - cable2_base[2])^2)
-        c3_length = sqrt((cable23_top[1] - cable3_base[1])^2 +
-                         (cable23_top[2] - cable3_base[2])^2)
+        cable23_top = [
+            l1 * cos(th1) + l2 * cos(th1 + th2) / 2;
+            l1 * sin(th1) + l2 * sin(th1 + th2) / 2; 0
+        ]
+        c1_length = sqrt(
+            (cable1_top[1] - cable1_base[1])^2 +
+                (cable1_top[2] - cable1_base[2])^2
+        )
+        c2_length = sqrt(
+            (cable23_top[1] - cable2_base[1])^2 +
+                (cable23_top[2] - cable2_base[2])^2
+        )
+        c3_length = sqrt(
+            (cable23_top[1] - cable3_base[1])^2 +
+                (cable23_top[2] - cable3_base[2])^2
+        )
         return c1_length + c2_length + c3_length
     end
 
     grad1 = ForwardDiff.gradient(solve_nlprob_with_cache, [34.0, 87.0])
     grad2 = FiniteDiff.finite_difference_gradient(solve_nlprob_with_cache, [34.0, 87.0])
 
-    @test grad1≈grad2 atol=1e-3
+    @test grad1 ≈ grad2 atol = 1.0e-3
 
     hess1 = ForwardDiff.hessian(solve_nlprob_with_cache, [34.0, 87.0])
     hess2 = FiniteDiff.finite_difference_hessian(solve_nlprob_with_cache, [34.0, 87.0])
 
-    @test hess1≈hess2 atol=1e-3
+    @test hess1 ≈ hess2 atol = 1.0e-3
 end
 
-@testitem "reinit! on ForwardDiff cache SciML/NonlinearSolve.jl#391" tags=[:core] begin
+@testitem "reinit! on ForwardDiff cache SciML/NonlinearSolve.jl#391" tags = [:core] begin
     using ForwardDiff
 
     function multiple_solves(ps::Vector)
@@ -247,5 +263,5 @@ end
     ps = collect(1.0:5.0)
 
     @test ForwardDiff.gradient(multiple_solves, ps) ≈
-          ForwardDiff.gradient(multiple_solves_cached, ps)
+        ForwardDiff.gradient(multiple_solves_cached, ps)
 end

--- a/test/issue_tests.jl
+++ b/test/issue_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Correct Best Solution: #565" tags=[:core] begin
+@testitem "Correct Best Solution: #565" tags = [:core] begin
     using NonlinearSolve, StableRNGs
 
     x = collect(0:0.1:10)

--- a/test/mtk_cache_indexing_tests.jl
+++ b/test/mtk_cache_indexing_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Modeling Toolkit Cache Indexing" tags=[:downstream] begin
+@testitem "Modeling Toolkit Cache Indexing" tags = [:downstream] begin
     using ModelingToolkit
     using ModelingToolkit: t_nounits as t
     using SymbolicIndexingInterface
@@ -13,11 +13,13 @@
     nlprob = NonlinearProblem(nlsys, [X => 1.0], [p => 2.0, d => 3.0])
 
     @testset "$integtype" for (alg, integtype) in [
-        (NewtonRaphson(), NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache),
-        (FastShortcutNonlinearPolyalg(),
-            NonlinearSolveBase.NonlinearSolvePolyAlgorithmCache),
-        (SimpleNewtonRaphson(), NonlinearSolveBase.NonlinearSolveNoInitCache)
-    ]
+            (NewtonRaphson(), NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache),
+            (
+                FastShortcutNonlinearPolyalg(),
+                NonlinearSolveBase.NonlinearSolvePolyAlgorithmCache,
+            ),
+            (SimpleNewtonRaphson(), NonlinearSolveBase.NonlinearSolveNoInitCache),
+        ]
         nint = init(nlprob, alg)
         @test nint isa integtype
 

--- a/test/qa_tests.jl
+++ b/test/qa_tests.jl
@@ -1,23 +1,26 @@
-@testitem "Aqua" tags=[:misc] begin
+@testitem "Aqua" tags = [:misc] begin
     using NonlinearSolve, SimpleNonlinearSolve, Aqua
 
-    Aqua.test_all(NonlinearSolve; ambiguities = false, piracies = false,
-        stale_deps = false, deps_compat = false, persistent_tasks = false)
+    Aqua.test_all(
+        NonlinearSolve; ambiguities = false, piracies = false,
+        stale_deps = false, deps_compat = false, persistent_tasks = false
+    )
     Aqua.test_ambiguities(NonlinearSolve; recursive = false)
     Aqua.test_stale_deps(SimpleNonlinearSolve; ignore = [:SciMLJacobianOperators])
     Aqua.test_deps_compat(SimpleNonlinearSolve; ignore = [:SciMLJacobianOperators])
-    Aqua.test_piracies(NonlinearSolve,
+    Aqua.test_piracies(
+        NonlinearSolve,
         treat_as_own = [
             NonlinearProblem, NonlinearLeastSquaresProblem, SciMLBase.AbstractNonlinearProblem,
-            SimpleNonlinearSolve.AbstractSimpleNonlinearSolveAlgorithm
+            SimpleNonlinearSolve.AbstractSimpleNonlinearSolveAlgorithm,
         ]
     )
 end
 
-@testitem "Explicit Imports" tags=[:misc] begin
+@testitem "Explicit Imports" tags = [:misc] begin
     using NonlinearSolve, ADTypes, SimpleNonlinearSolve, SciMLBase
     import FastLevenbergMarquardt, FixedPointAcceleration, LeastSquaresOptim, MINPACK,
-           NLsolve, NLSolvers, SIAMFANLEquations, SpeedMapping
+        NLsolve, NLSolvers, SIAMFANLEquations, SpeedMapping
 
     using ExplicitImports
 

--- a/test/trim/main_once_per_process.jl
+++ b/test/trim/main_once_per_process.jl
@@ -1,5 +1,5 @@
 module MyModule
-include("./optimization_once_per_process.jl")
+    include("./optimization_once_per_process.jl")
 end
 
 function (@main)(argv::Vector{String})::Cint

--- a/test/trim/main_segfault.jl
+++ b/test/trim/main_segfault.jl
@@ -1,5 +1,5 @@
 module MyModule
-include("./optimization_trimmable.jl")
+    include("./optimization_trimmable.jl")
 end
 
 function (@main)(argv::Vector{String})::Cint

--- a/test/trim/runtests.jl
+++ b/test/trim/runtests.jl
@@ -33,28 +33,28 @@ end
         close(err.in)
         out = (
             stdout = String(read(out)), stderr = String(read(err)),
-            exitcode = process.exitcode
+            exitcode = process.exitcode,
         )
         return out
     end
 
     JULIAC = normpath(
         joinpath(
-        Sys.BINDIR, Base.DATAROOTDIR, "julia", "juliac",
-        "juliac.jl"
-    )
+            Sys.BINDIR, Base.DATAROOTDIR, "julia", "juliac",
+            "juliac.jl"
+        )
     )
     @test isfile(JULIAC)
 
     for (mainfile, expectedtopass) in [
-        ("main_trimmable.jl", true),
-    #= The test below should verify that we indeed can't get a trimmed binary
+            ("main_trimmable.jl", true),
+            #= The test below should verify that we indeed can't get a trimmed binary
     # for the "clean" implementation, but will trigger in the future if
     # it does start working. Unfortunately, right now it hangs indefinitely
     # so we are commenting it out. =#
-    # ("main_clean.jl", false),
-        ("main_segfault.jl", false),
-    ]
+            # ("main_clean.jl", false),
+            ("main_segfault.jl", false),
+        ]
         binpath = tempname()
         cmd = `$(Base.julia_cmd()) --project=. --depwarn=error $(JULIAC) --experimental --trim=unsafe-warn --output-exe $(binpath) $(mainfile)`
 

--- a/test/verbosity_tests.jl
+++ b/test/verbosity_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Nonlinear Verbosity" tags=[:verbosity] begin
+@testitem "Nonlinear Verbosity" tags = [:verbosity] begin
     using NonlinearSolve
     using BracketingNonlinearSolve
     using NonlinearSolve: NonlinearVerbosity
@@ -84,49 +84,69 @@
 
     int_prob = IntervalNonlinearProblem(g, (3.0, 5.0))
 
-    @test_logs (:info,
-        r"The interval is not an enclosing interval, opposite signs at the boundaries are required.") solve(
+    @test_logs (
+        :info,
+        r"The interval is not an enclosing interval, opposite signs at the boundaries are required.",
+    ) solve(
         int_prob,
-        ITP(), verbose = NonlinearVerbosity(non_enclosing_interval = SciMLLogging.InfoLevel()))
+        ITP(), verbose = NonlinearVerbosity(non_enclosing_interval = SciMLLogging.InfoLevel())
+    )
 
-    @test_logs (:error,
-        r"The interval is not an enclosing interval, opposite signs at the boundaries are required.") @test_throws ErrorException solve(
+    @test_logs (
+        :error,
+        r"The interval is not an enclosing interval, opposite signs at the boundaries are required.",
+    ) @test_throws ErrorException solve(
         int_prob,
-        ITP(), verbose = NonlinearVerbosity(non_enclosing_interval = SciMLLogging.ErrorLevel()))
+        ITP(), verbose = NonlinearVerbosity(non_enclosing_interval = SciMLLogging.ErrorLevel())
+    )
 
     # Test that the linear verbosity is passed to the linear solve
     f(u, p) = [u[1]^2 - 2u[1] + 1, sum(u)]
     prob = NonlinearProblem(f, [1.0, 1.0])
 
-    @test_logs (:warn,
-        r"LU factorization failed, falling back to QR factorization. `A` is potentially rank-deficient.") match_mode=:any solve(
-        prob,
-        verbose = NonlinearVerbosity(linear_verbosity = SciMLLogging.Detailed()))
-
-    @test_logs (:info,
-        r"LU factorization failed, falling back to QR factorization. `A` is potentially rank-deficient.") match_mode=:any solve(
-        prob,
-        verbose = NonlinearVerbosity(linear_verbosity = LinearVerbosity(default_lu_fallback = SciMLLogging.InfoLevel())))
-
-    @test_logs min_level=0 solve(
-        prob,
-        verbose = NonlinearVerbosity(linear_verbosity = SciMLLogging.Standard()))
-
-    @test_logs (:warn,
-        r"LU factorization failed, falling back to QR factorization. `A` is potentially rank-deficient.") match_mode=:any solve(
+    @test_logs (
+        :warn,
+        r"LU factorization failed, falling back to QR factorization. `A` is potentially rank-deficient.",
+    ) match_mode = :any solve(
         prob,
         verbose = NonlinearVerbosity(linear_verbosity = SciMLLogging.Detailed())
     )
 
-    @test_logs min_level=0 solve(prob,
-        verbose = NonlinearVerbosity(SciMLLogging.None()))
+    @test_logs (
+        :info,
+        r"LU factorization failed, falling back to QR factorization. `A` is potentially rank-deficient.",
+    ) match_mode = :any solve(
+        prob,
+        verbose = NonlinearVerbosity(linear_verbosity = LinearVerbosity(default_lu_fallback = SciMLLogging.InfoLevel()))
+    )
 
-    @test_logs min_level=0 solve(prob,
-        verbose = false)
+    @test_logs min_level = 0 solve(
+        prob,
+        verbose = NonlinearVerbosity(linear_verbosity = SciMLLogging.Standard())
+    )
+
+    @test_logs (
+        :warn,
+        r"LU factorization failed, falling back to QR factorization. `A` is potentially rank-deficient.",
+    ) match_mode = :any solve(
+        prob,
+        verbose = NonlinearVerbosity(linear_verbosity = SciMLLogging.Detailed())
+    )
+
+    @test_logs min_level = 0 solve(
+        prob,
+        verbose = NonlinearVerbosity(SciMLLogging.None())
+    )
+
+    @test_logs min_level = 0 solve(
+        prob,
+        verbose = false
+    )
 
     # Test that caches get correct verbosities
     cache = init(
-        prob, verbose = NonlinearVerbosity(threshold_state = SciMLLogging.InfoLevel()))
+        prob, verbose = NonlinearVerbosity(threshold_state = SciMLLogging.InfoLevel())
+    )
 
     @test cache.verbose.threshold_state == SciMLLogging.InfoLevel()
 
@@ -139,7 +159,7 @@
         @test sol1.retcode == ReturnCode.Success
 
         # Test verbose = false silences all output
-        @test_logs min_level=0 sol2=solve(prob, verbose = false)
+        @test_logs min_level = 0 sol2 = solve(prob, verbose = false)
     end
 
     @testset "solve with Preset verbose" begin
@@ -148,7 +168,7 @@
         @test sol1.retcode == ReturnCode.Success
 
         # Test verbose = SciMLLogging.None() silences output
-        @test_logs min_level=0 sol2=solve(prob, verbose = SciMLLogging.None())
+        @test_logs min_level = 0 sol2 = solve(prob, verbose = SciMLLogging.None())
 
         # Test verbose = SciMLLogging.Detailed() works
         sol3 = solve(prob, verbose = SciMLLogging.Detailed())
@@ -206,6 +226,6 @@
     @testset "init then solve with converted verbose" begin
         # Ensure the converted verbose works through the full solve pipeline
         cache = init(prob, verbose = false)
-        @test_logs min_level=0 sol=solve!(cache)
+        @test_logs min_level = 0 sol = solve!(cache)
     end
 end

--- a/test/wrappers/fixedpoint_tests.jl
+++ b/test/wrappers/fixedpoint_tests.jl
@@ -1,44 +1,44 @@
-@testitem "Simple Scalar Problem" tags=[:wrappers] begin
+@testitem "Simple Scalar Problem" tags = [:wrappers] begin
     import SpeedMapping, SIAMFANLEquations, NLsolve, FixedPointAcceleration
 
     f1(x, p) = cos(x) - x
     prob = NonlinearProblem(f1, 1.1)
 
     for alg in (:Anderson, :MPE, :RRE, :VEA, :SEA, :Simple, :Aitken, :Newton)
-        @test abs(solve(prob, FixedPointAccelerationJL(; algorithm = alg)).resid) ≤ 1e-10
+        @test abs(solve(prob, FixedPointAccelerationJL(; algorithm = alg)).resid) ≤ 1.0e-10
     end
 
-    @test abs(solve(prob, SpeedMappingJL()).resid) ≤ 1e-10
-    @test abs(solve(prob, SpeedMappingJL(; orders = [3, 2])).resid) ≤ 1e-10
-    @test abs(solve(prob, SpeedMappingJL(; stabilize = true)).resid) ≤ 1e-10
+    @test abs(solve(prob, SpeedMappingJL()).resid) ≤ 1.0e-10
+    @test abs(solve(prob, SpeedMappingJL(; orders = [3, 2])).resid) ≤ 1.0e-10
+    @test abs(solve(prob, SpeedMappingJL(; stabilize = true)).resid) ≤ 1.0e-10
 
-    @test abs(solve(prob, NLsolveJL(; method = :anderson)).resid) ≤ 1e-10
-    @test abs(solve(prob, SIAMFANLEquationsJL(; method = :anderson)).resid) ≤ 1e-10
+    @test abs(solve(prob, NLsolveJL(; method = :anderson)).resid) ≤ 1.0e-10
+    @test abs(solve(prob, SIAMFANLEquationsJL(; method = :anderson)).resid) ≤ 1.0e-10
 end
 
 # Simple Vector Problem
-@testitem "Simple Vector Problem" tags=[:wrappers] begin
+@testitem "Simple Vector Problem" tags = [:wrappers] begin
     import SpeedMapping, SIAMFANLEquations, NLsolve, FixedPointAcceleration
 
     f2(x, p) = cos.(x) .- x
     prob = NonlinearProblem(f2, [1.1, 1.1])
 
     for alg in (:Anderson, :MPE, :RRE, :VEA, :SEA, :Simple, :Aitken, :Newton)
-        @test maximum(abs.(solve(prob, FixedPointAccelerationJL()).resid)) ≤ 1e-10
+        @test maximum(abs.(solve(prob, FixedPointAccelerationJL()).resid)) ≤ 1.0e-10
     end
 
-    @test maximum(abs.(solve(prob, SpeedMappingJL()).resid)) ≤ 1e-10
-    @test maximum(abs.(solve(prob, SpeedMappingJL(; orders = [3, 2])).resid)) ≤ 1e-10
-    @test maximum(abs.(solve(prob, SpeedMappingJL(; stabilize = true)).resid)) ≤ 1e-10
+    @test maximum(abs.(solve(prob, SpeedMappingJL()).resid)) ≤ 1.0e-10
+    @test maximum(abs.(solve(prob, SpeedMappingJL(; orders = [3, 2])).resid)) ≤ 1.0e-10
+    @test maximum(abs.(solve(prob, SpeedMappingJL(; stabilize = true)).resid)) ≤ 1.0e-10
     @test maximum(abs.(solve(prob, SIAMFANLEquationsJL(; method = :anderson)).resid)) ≤
-          1e-10
+        1.0e-10
 
-    @test_broken maximum(abs.(solve(prob, NLsolveJL(; method = :anderson)).resid)) ≤ 1e-10
+    @test_broken maximum(abs.(solve(prob, NLsolveJL(; method = :anderson)).resid)) ≤ 1.0e-10
 end
 
 # Fixed Point for Power Method
 # Taken from https://github.com/NicolasL-S/SpeedMapping.jl/blob/95951db8f8a4457093090e18802ad382db1c76da/test/runtests.jl
-@testitem "Power Method" tags=[:wrappers] begin
+@testitem "Power Method" tags = [:wrappers] begin
     using LinearAlgebra
     import SpeedMapping, SIAMFANLEquations, NLsolve, FixedPointAcceleration
 

--- a/test/wrappers/rootfind_tests.jl
+++ b/test/wrappers/rootfind_tests.jl
@@ -1,187 +1,187 @@
-@testitem "Steady State Problems" tags=[:wrappers] retries=5 begin
+@testitem "Steady State Problems" tags = [:wrappers] retries = 5 begin
     import NLSolvers, NLsolve, SIAMFANLEquations, MINPACK, PETSc
 
     function f_iip(du, u, p, t)
-        du[1]=2-2u[1]
-        du[2]=u[1]-4u[2]
+        du[1] = 2 - 2u[1]
+        du[2] = u[1] - 4u[2]
     end
-    u0=zeros(2)
-    prob_iip=SteadyStateProblem(f_iip, u0)
+    u0 = zeros(2)
+    prob_iip = SteadyStateProblem(f_iip, u0)
 
     @testset "$(nameof(typeof(alg)))" for alg in [
-        NLSolversJL(NLSolvers.LineSearch(NLSolvers.Newton(), NLSolvers.Backtracking())),
-        NLsolveJL(),
-        SIAMFANLEquationsJL(),
-        CMINPACK(),
-        PETScSNES(),
-        PETScSNES(; autodiff = missing)
-    ]
+            NLSolversJL(NLSolvers.LineSearch(NLSolvers.Newton(), NLSolvers.Backtracking())),
+            NLsolveJL(),
+            SIAMFANLEquationsJL(),
+            CMINPACK(),
+            PETScSNES(),
+            PETScSNES(; autodiff = missing),
+        ]
         alg isa CMINPACK && Sys.isapple() && continue
         alg isa PETScSNES && Sys.iswindows() && continue
         sol = solve(prob_iip, alg)
         @test SciMLBase.successful_retcode(sol.retcode)
-        @test maximum(abs, sol.resid) < 1e-6
+        @test maximum(abs, sol.resid) < 1.0e-6
     end
 
-    f_oop(u, p, t)=[2-2u[1], u[1]-4u[2]]
-    u0=zeros(2)
-    prob_oop=SteadyStateProblem(f_oop, u0)
+    f_oop(u, p, t) = [2 - 2u[1], u[1] - 4u[2]]
+    u0 = zeros(2)
+    prob_oop = SteadyStateProblem(f_oop, u0)
 
     @testset "$(nameof(typeof(alg)))" for alg in [
-        NLSolversJL(NLSolvers.LineSearch(NLSolvers.Newton(), NLSolvers.Backtracking())),
-        NLsolveJL(),
-        SIAMFANLEquationsJL(),
-        CMINPACK(),
-        PETScSNES(),
-        PETScSNES(; autodiff = missing)
-    ]
+            NLSolversJL(NLSolvers.LineSearch(NLSolvers.Newton(), NLSolvers.Backtracking())),
+            NLsolveJL(),
+            SIAMFANLEquationsJL(),
+            CMINPACK(),
+            PETScSNES(),
+            PETScSNES(; autodiff = missing),
+        ]
         alg isa CMINPACK && Sys.isapple() && continue
         alg isa PETScSNES && Sys.iswindows() && continue
         sol = solve(prob_oop, alg)
         @test SciMLBase.successful_retcode(sol.retcode)
-        @test maximum(abs, sol.resid) < 1e-6
+        @test maximum(abs, sol.resid) < 1.0e-6
     end
 end
 
-@testitem "Nonlinear Root Finding Problems" tags=[:wrappers] retries=5 begin
+@testitem "Nonlinear Root Finding Problems" tags = [:wrappers] retries = 5 begin
     using LinearAlgebra
     import NLSolvers, NLsolve, SIAMFANLEquations, MINPACK, PETSc
 
     function f_iip(du, u, p)
-        du[1]=2-2u[1]
-        du[2]=u[1]-4u[2]
+        du[1] = 2 - 2u[1]
+        du[2] = u[1] - 4u[2]
     end
-    u0=zeros(2)
-    prob_iip=NonlinearProblem{true}(f_iip, u0)
+    u0 = zeros(2)
+    prob_iip = NonlinearProblem{true}(f_iip, u0)
 
     @testset "$(nameof(typeof(alg)))" for alg in [
-        NLSolversJL(NLSolvers.LineSearch(NLSolvers.Newton(), NLSolvers.Backtracking())),
-        NLsolveJL(),
-        SIAMFANLEquationsJL(),
-        CMINPACK(),
-        PETScSNES(),
-        PETScSNES(; autodiff = missing)
-    ]
+            NLSolversJL(NLSolvers.LineSearch(NLSolvers.Newton(), NLSolvers.Backtracking())),
+            NLsolveJL(),
+            SIAMFANLEquationsJL(),
+            CMINPACK(),
+            PETScSNES(),
+            PETScSNES(; autodiff = missing),
+        ]
         alg isa CMINPACK && Sys.isapple() && continue
         alg isa PETScSNES && Sys.iswindows() && continue
         local sol
         sol = solve(prob_iip, alg)
         @test SciMLBase.successful_retcode(sol.retcode)
-        @test maximum(abs, sol.resid) < 1e-6
+        @test maximum(abs, sol.resid) < 1.0e-6
     end
 
-    f_oop(u, p)=[2-2u[1], u[1]-4u[2]]
-    u0=zeros(2)
-    prob_oop=NonlinearProblem{false}(f_oop, u0)
+    f_oop(u, p) = [2 - 2u[1], u[1] - 4u[2]]
+    u0 = zeros(2)
+    prob_oop = NonlinearProblem{false}(f_oop, u0)
     @testset "$(nameof(typeof(alg)))" for alg in [
-        NLSolversJL(NLSolvers.LineSearch(NLSolvers.Newton(), NLSolvers.Backtracking())),
-        NLsolveJL(),
-        SIAMFANLEquationsJL(),
-        CMINPACK(),
-        PETScSNES(),
-        PETScSNES(; autodiff = missing)
-    ]
+            NLSolversJL(NLSolvers.LineSearch(NLSolvers.Newton(), NLSolvers.Backtracking())),
+            NLsolveJL(),
+            SIAMFANLEquationsJL(),
+            CMINPACK(),
+            PETScSNES(),
+            PETScSNES(; autodiff = missing),
+        ]
         alg isa CMINPACK && Sys.isapple() && continue
         alg isa PETScSNES && Sys.iswindows() && continue
         local sol
         sol = solve(prob_oop, alg)
         @test SciMLBase.successful_retcode(sol.retcode)
-        @test maximum(abs, sol.resid) < 1e-6
+        @test maximum(abs, sol.resid) < 1.0e-6
     end
 
-    f_tol(u, p)=u^2-2
-    prob_tol=NonlinearProblem(f_tol, 1.0)
-    for tol in [1e-1, 1e-3, 1e-6, 1e-10, 1e-15],
-        alg in [
-            NLSolversJL(NLSolvers.LineSearch(NLSolvers.Newton(), NLSolvers.Backtracking())),
-            NLsolveJL(),
-            CMINPACK(),
-            PETScSNES(),
-            PETScSNES(; autodiff = missing),
-            SIAMFANLEquationsJL(; method = :newton),
-            SIAMFANLEquationsJL(; method = :pseudotransient),
-            SIAMFANLEquationsJL(; method = :secant)
-        ]
+    f_tol(u, p) = u^2 - 2
+    prob_tol = NonlinearProblem(f_tol, 1.0)
+    for tol in [1.0e-1, 1.0e-3, 1.0e-6, 1.0e-10, 1.0e-15],
+            alg in [
+                NLSolversJL(NLSolvers.LineSearch(NLSolvers.Newton(), NLSolvers.Backtracking())),
+                NLsolveJL(),
+                CMINPACK(),
+                PETScSNES(),
+                PETScSNES(; autodiff = missing),
+                SIAMFANLEquationsJL(; method = :newton),
+                SIAMFANLEquationsJL(; method = :pseudotransient),
+                SIAMFANLEquationsJL(; method = :secant),
+            ]
 
         alg isa CMINPACK&&Sys.isapple()&&continue
         alg isa PETScSNES&&Sys.iswindows()&&continue
-        sol=solve(prob_tol, alg, abstol = tol)
+        sol = solve(prob_tol, alg, abstol = tol)
         @test abs(sol.u[1] - sqrt(2)) < tol
     end
 
-    f_jfnk(u, p)=u^2-2
-    prob_jfnk=NonlinearProblem(f_jfnk, 1.0)
-    for tol in [1e-1, 1e-3, 1e-6, 1e-10, 1e-11]
-        sol=solve(prob_jfnk, SIAMFANLEquationsJL(linsolve = :gmres), abstol = tol)
+    f_jfnk(u, p) = u^2 - 2
+    prob_jfnk = NonlinearProblem(f_jfnk, 1.0)
+    for tol in [1.0e-1, 1.0e-3, 1.0e-6, 1.0e-10, 1.0e-11]
+        sol = solve(prob_jfnk, SIAMFANLEquationsJL(linsolve = :gmres), abstol = tol)
         @test abs(sol.u[1] - sqrt(2)) < tol
     end
 
     # Test the finite differencing technique
     function f!(fvec, x, p)
-        fvec[1]=(x[1]+3)*(x[2]^3-7)+18
-        fvec[2]=sin(x[2]*exp(x[1])-1)
+        fvec[1] = (x[1] + 3) * (x[2]^3 - 7) + 18
+        fvec[2] = sin(x[2] * exp(x[1]) - 1)
     end
 
-    prob=NonlinearProblem{true}(f!, [0.1; 1.2])
-    sol=solve(prob, NLsolveJL(autodiff = :central))
-    @test maximum(abs, sol.resid) < 1e-6
-    sol=solve(prob, SIAMFANLEquationsJL())
-    @test maximum(abs, sol.resid) < 1e-6
+    prob = NonlinearProblem{true}(f!, [0.1; 1.2])
+    sol = solve(prob, NLsolveJL(autodiff = :central))
+    @test maximum(abs, sol.resid) < 1.0e-6
+    sol = solve(prob, SIAMFANLEquationsJL())
+    @test maximum(abs, sol.resid) < 1.0e-6
 
     # Test the autodiff technique
-    sol=solve(prob, NLsolveJL(autodiff = :forward))
-    @test maximum(abs, sol.resid) < 1e-6
+    sol = solve(prob, NLsolveJL(autodiff = :forward))
+    @test maximum(abs, sol.resid) < 1.0e-6
 
     # Custom Jacobian
-    f_custom_jac!(F, u, p)=(F[1:152]=u .^ 2 .- p)
-    j_custom_jac!(J, u, p)=(J[1:152, 1:152]=diagm(2 .* u))
+    f_custom_jac!(F, u, p) = (F[1:152] = u .^ 2 .- p)
+    j_custom_jac!(J, u, p) = (J[1:152, 1:152] = diagm(2 .* u))
 
-    init=ones(152)
-    A=ones(152)
-    A[6]=0.8
+    init = ones(152)
+    A = ones(152)
+    A[6] = 0.8
 
-    f=NonlinearFunction(f_custom_jac!; jac = j_custom_jac!)
-    p=A
+    f = NonlinearFunction(f_custom_jac!; jac = j_custom_jac!)
+    p = A
 
-    ProbN=NonlinearProblem(f, init, p)
+    ProbN = NonlinearProblem(f, init, p)
 
-    sol=solve(ProbN, NLsolveJL(); abstol = 1e-8)
-    @test maximum(abs, sol.resid) < 1e-6
-    sol=solve(
+    sol = solve(ProbN, NLsolveJL(); abstol = 1.0e-8)
+    @test maximum(abs, sol.resid) < 1.0e-6
+    sol = solve(
         ProbN,
         NLSolversJL(NLSolvers.LineSearch(NLSolvers.Newton(), NLSolvers.Backtracking()));
-        abstol = 1e-8
+        abstol = 1.0e-8
     )
-    @test maximum(abs, sol.resid) < 1e-6
-    sol=solve(ProbN, SIAMFANLEquationsJL(; method = :newton); abstol = 1e-8)
-    @test maximum(abs, sol.resid) < 1e-6
-    sol=solve(ProbN, SIAMFANLEquationsJL(; method = :pseudotransient); abstol = 1e-8)
-    @test maximum(abs, sol.resid) < 1e-6
+    @test maximum(abs, sol.resid) < 1.0e-6
+    sol = solve(ProbN, SIAMFANLEquationsJL(; method = :newton); abstol = 1.0e-8)
+    @test maximum(abs, sol.resid) < 1.0e-6
+    sol = solve(ProbN, SIAMFANLEquationsJL(; method = :pseudotransient); abstol = 1.0e-8)
+    @test maximum(abs, sol.resid) < 1.0e-6
     if !Sys.iswindows()
-        sol=solve(ProbN, PETScSNES(); abstol = 1e-8)
-        @test maximum(abs, sol.resid) < 1e-6
+        sol = solve(ProbN, PETScSNES(); abstol = 1.0e-8)
+        @test maximum(abs, sol.resid) < 1.0e-6
     end
 end
 
-@testitem "PETSc SNES Floating Points" tags=[:wrappers] retries=5 skip=:(Sys.iswindows()) begin
+@testitem "PETSc SNES Floating Points" tags = [:wrappers] retries = 5 skip = :(Sys.iswindows()) begin
     import PETSc
 
-    f(u, p)=u .* u .- 2
+    f(u, p) = u .* u .- 2
 
-    u0=[1.0, 1.0]
-    probN=NonlinearProblem{false}(f, u0)
+    u0 = [1.0, 1.0]
+    probN = NonlinearProblem{false}(f, u0)
 
-    sol=solve(probN, PETScSNES(); abstol = 1e-8)
-    @test maximum(abs, sol.resid) < 1e-6
+    sol = solve(probN, PETScSNES(); abstol = 1.0e-8)
+    @test maximum(abs, sol.resid) < 1.0e-6
 
-    u0=[1.0f0, 1.0f0]
-    probN=NonlinearProblem{false}(f, u0)
+    u0 = [1.0f0, 1.0f0]
+    probN = NonlinearProblem{false}(f, u0)
 
-    sol=solve(probN, PETScSNES(); abstol = 1e-5)
-    @test maximum(abs, sol.resid) < 1e-4
+    sol = solve(probN, PETScSNES(); abstol = 1.0e-5)
+    @test maximum(abs, sol.resid) < 1.0e-4
 
-    u0=Float16[1.0, 1.0]
-    probN=NonlinearProblem{false}(f, u0)
+    u0 = Float16[1.0, 1.0]
+    probN = NonlinearProblem{false}(f, u0)
 
-    @test_throws AssertionError solve(probN, PETScSNES(); abstol = 1e-8)
+    @test_throws AssertionError solve(probN, PETScSNES(); abstol = 1.0e-8)
 end


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)