### PR TITLE
feat: add `solve(::SCCNonlinearProblem, ::Nothing)` method

### DIFF
--- a/lib/SCCNonlinearSolve/src/SCCNonlinearSolve.jl
+++ b/lib/SCCNonlinearSolve/src/SCCNonlinearSolve.jl
@@ -30,6 +30,10 @@ function CommonSolve.solve(
     return CommonSolve.solve(prob, SCCAlg(nothing, nothing); sensealg, u0, p, kwargs...)
 end
 
+function CommonSolve.solve(prob::SciMLBase.SCCNonlinearProblem, ::Nothing; kwargs...)
+    return CommonSolve.solve(prob; kwargs...)
+end
+
 function CommonSolve.solve(
         prob::SciMLBase.SCCNonlinearProblem,
         alg::SciMLBase.AbstractNonlinearAlgorithm;


### PR DESCRIPTION
This is necessary for a specialized code path when `SCCNonlinearProblem` contains a single `LinearProblem`. It's phrased this way instead of `LinearProblem` because the initialization infrastructure knows how to deal with the `SCCNonlinearProblem`, but not `LinearProblem`.