### PR TITLE
chore: temporarily disable downgrade tests

### DIFF
--- a/.github/workflows/CI_BracketingNonlinearSolve.yml
+++ b/.github/workflows/CI_BracketingNonlinearSolve.yml
@@ -36,7 +36,10 @@ jobs:
       project: "lib/BracketingNonlinearSolve"
       local_dependencies: "lib/NonlinearSolveBase,lib/SciMLJacobianOperators"
 
+  # NOTE: Downgrade tests are temporarily skipped due to Resolver.jl incompatibility
+  # with [sources] in Project.toml. See issue #774 for tracking.
   downgrade:
+    if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
       julia_version: "1.11"

--- a/.github/workflows/CI_NonlinearSolve.yml
+++ b/.github/workflows/CI_NonlinearSolve.yml
@@ -62,7 +62,10 @@ jobs:
       local_dependencies: "lib/BracketingNonlinearSolve,lib/NonlinearSolveBase,lib/NonlinearSolveFirstOrder,lib/NonlinearSolveQuasiNewton,lib/NonlinearSolveSpectralMethods,lib/SimpleNonlinearSolve"
       test_args: "GROUP=${{ matrix.group }}"
 
+  # NOTE: Downgrade tests are temporarily skipped due to Resolver.jl incompatibility
+  # with [sources] in Project.toml. See issue #774 for tracking.
   downgrade:
+    if: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI_NonlinearSolveBase.yml
+++ b/.github/workflows/CI_NonlinearSolveBase.yml
@@ -35,7 +35,10 @@ jobs:
       project: "lib/NonlinearSolveBase"
       local_dependencies: "lib/SciMLJacobianOperators"
 
+  # NOTE: Downgrade tests are temporarily skipped due to Resolver.jl incompatibility
+  # with [sources] in Project.toml. See issue #774 for tracking.
   downgrade:
+    if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
       julia_version: "1.11"

--- a/.github/workflows/CI_NonlinearSolveFirstOrder.yml
+++ b/.github/workflows/CI_NonlinearSolveFirstOrder.yml
@@ -36,7 +36,10 @@ jobs:
       project: "lib/NonlinearSolveFirstOrder"
       local_dependencies: "lib/NonlinearSolveBase,lib/SciMLJacobianOperators"
 
+  # NOTE: Downgrade tests are temporarily skipped due to Resolver.jl incompatibility
+  # with [sources] in Project.toml. See issue #774 for tracking.
   downgrade:
+    if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
       julia_version: "1.11"

--- a/.github/workflows/CI_NonlinearSolveHomotopyContinuation.yml
+++ b/.github/workflows/CI_NonlinearSolveHomotopyContinuation.yml
@@ -35,7 +35,10 @@ jobs:
       project: "lib/NonlinearSolveHomotopyContinuation"
       local_dependencies: "lib/NonlinearSolveBase"
 
+  # NOTE: Downgrade tests are temporarily skipped due to Resolver.jl incompatibility
+  # with [sources] in Project.toml. See issue #774 for tracking.
   downgrade:
+    if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
       julia_version: "1.11"

--- a/.github/workflows/CI_NonlinearSolveQuasiNewton.yml
+++ b/.github/workflows/CI_NonlinearSolveQuasiNewton.yml
@@ -36,7 +36,10 @@ jobs:
       project: "lib/NonlinearSolveQuasiNewton"
       local_dependencies: "lib/NonlinearSolveBase,lib/SciMLJacobianOperators"
 
+  # NOTE: Downgrade tests are temporarily skipped due to Resolver.jl incompatibility
+  # with [sources] in Project.toml. See issue #774 for tracking.
   downgrade:
+    if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
       julia_version: "1.11"

--- a/.github/workflows/CI_NonlinearSolveSciPy.yml
+++ b/.github/workflows/CI_NonlinearSolveSciPy.yml
@@ -35,7 +35,10 @@ jobs:
       project: "lib/NonlinearSolveSciPy"
       local_dependencies: "lib/NonlinearSolveBase,lib/SciMLJacobianOperators"
 
+  # NOTE: Downgrade tests are temporarily skipped due to Resolver.jl incompatibility
+  # with [sources] in Project.toml. See issue #774 for tracking.
   downgrade:
+    if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
       julia_version: "1.11"

--- a/.github/workflows/CI_NonlinearSolveSpectralMethods.yml
+++ b/.github/workflows/CI_NonlinearSolveSpectralMethods.yml
@@ -36,7 +36,10 @@ jobs:
       project: "lib/NonlinearSolveSpectralMethods"
       local_dependencies: "lib/NonlinearSolveBase,lib/SciMLJacobianOperators"
 
+  # NOTE: Downgrade tests are temporarily skipped due to Resolver.jl incompatibility
+  # with [sources] in Project.toml. See issue #774 for tracking.
   downgrade:
+    if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
       julia_version: "1.11"

--- a/.github/workflows/CI_SCCNonlinearSolve.yml
+++ b/.github/workflows/CI_SCCNonlinearSolve.yml
@@ -36,7 +36,10 @@ jobs:
       project: "lib/SCCNonlinearSolve"
       local_dependencies: "lib/NonlinearSolveBase,lib/SciMLJacobianOperators"
 
+  # NOTE: Downgrade tests are temporarily skipped due to Resolver.jl incompatibility
+  # with [sources] in Project.toml. See issue #774 for tracking.
   downgrade:
+    if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
       julia_version: "1.11"

--- a/.github/workflows/CI_SciMLJacobianOperators.yml
+++ b/.github/workflows/CI_SciMLJacobianOperators.yml
@@ -33,7 +33,10 @@ jobs:
       os: ${{ matrix.os }}
       project: "lib/SciMLJacobianOperators"
 
+  # NOTE: Downgrade tests are temporarily skipped due to Resolver.jl incompatibility
+  # with [sources] in Project.toml. See issue #774 for tracking.
   downgrade:
+    if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
       julia_version: "1.11"

--- a/.github/workflows/CI_SimpleNonlinearSolve.yml
+++ b/.github/workflows/CI_SimpleNonlinearSolve.yml
@@ -42,7 +42,10 @@ jobs:
       local_dependencies: "lib/BracketingNonlinearSolve,lib/NonlinearSolveBase,lib/SciMLJacobianOperators"
       test_args: "GROUP=${{ matrix.group }}"
 
+  # NOTE: Downgrade tests are temporarily skipped due to Resolver.jl incompatibility
+  # with [sources] in Project.toml. See issue #774 for tracking.
   downgrade:
+    if: false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Temporarily skips downgrade tests in all CI workflows due to Resolver.jl incompatibility with `[sources]` in Project.toml

## Problem

The downgrade tests are failing because `Resolver.jl` (which powers `julia-downgrade-compat`) cannot handle packages defined via `[sources]` in `Project.toml`. When building its dependency dictionary, it only pulls from the Julia General Registry and omits locally-defined packages.

## Affected Workflows

All 11 CI workflows with downgrade tests:
- CI_NonlinearSolve.yml
- CI_BracketingNonlinearSolve.yml
- CI_NonlinearSolveBase.yml
- CI_NonlinearSolveFirstOrder.yml
- CI_NonlinearSolveHomotopyContinuation.yml
- CI_NonlinearSolveQuasiNewton.yml
- CI_NonlinearSolveSciPy.yml
- CI_NonlinearSolveSpectralMethods.yml
- CI_SCCNonlinearSolve.yml
- CI_SciMLJacobianOperators.yml
- CI_SimpleNonlinearSolve.yml

## Test plan

- [ ] Verify CI passes without downgrade tests
- [ ] Re-enable once Resolver.jl adds `[sources]` support

Fixes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)