### PR TITLE
chore: temporarily skip pre (Julia 1.13) tests

### DIFF
--- a/.github/workflows/CI_NonlinearSolve.yml
+++ b/.github/workflows/CI_NonlinearSolve.yml
@@ -41,14 +41,10 @@ jobs:
           - "1"
           - "1.11"
           - "lts"
-          - "pre"
         os:
           - ubuntu-latest
           - macos-latest
         exclude:
-          # Don't run nopre tests on prerelease Julia
-          - group: nopre
-            version: "pre"
           # Don't run trim tests on Julia versions below 1.12
           - group: trim
             version: "1.11"
@@ -57,6 +53,30 @@ jobs:
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
       julia_version: ${{ matrix.version }}
+      os: ${{ matrix.os }}
+      project: "."
+      local_dependencies: "lib/BracketingNonlinearSolve,lib/NonlinearSolveBase,lib/NonlinearSolveFirstOrder,lib/NonlinearSolveQuasiNewton,lib/NonlinearSolveSpectralMethods,lib/SimpleNonlinearSolve"
+      test_args: "GROUP=${{ matrix.group }}"
+
+  # NOTE: Pre (Julia 1.13) tests are temporarily skipped due to ReTestItems incompatibility
+  # with Julia 1.13 ScopedValues API changes. See issue #776 for tracking.
+  test-pre:
+    if: false
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          - core
+          - downstream
+          - wrappers
+          - misc
+          - trim
+        os:
+          - ubuntu-latest
+          - macos-latest
+    uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
+    with:
+      julia_version: "pre"
       os: ${{ matrix.os }}
       project: "."
       local_dependencies: "lib/BracketingNonlinearSolve,lib/NonlinearSolveBase,lib/NonlinearSolveFirstOrder,lib/NonlinearSolveQuasiNewton,lib/NonlinearSolveSpectralMethods,lib/SimpleNonlinearSolve"


### PR DESCRIPTION
## Summary

- Temporarily skips pre (Julia 1.13) tests due to ReTestItems incompatibility with ScopedValues API changes

## Problem

Pre tests are failing because ReTestItems uses `setindex!` on `ScopedValue`, which is no longer supported in Julia 1.13:

```
MethodError: no method matching setindex!(::Base.ScopedValues.ScopedValue{Bool}, ::Bool)
```

## Changes

- Removed `"pre"` from the main test matrix
- Added separate `test-pre` job with `if: false` to skip (consistent with downgrade tests approach)

## Test plan

- [ ] Verify CI passes without pre tests
- [ ] Re-enable once ReTestItems is updated for Julia 1.13 compatibility

Fixes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)