### PR TITLE
fix: typo and documentation linkcheck failures

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -13,3 +13,4 @@ MTK = "MTK"
 
 # NonlinearSolve specific terms
 LSO = "LSO"  # Legitimate abbreviation used in optimization contexts
+clos = "clos"  # Variable name for closure in Enzyme extension

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -51,6 +51,7 @@ makedocs(;
         "https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/hybrd.c",
         "https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/hybrj.c",
         "https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/lmder.c",
+        "https://net-informations.com/faq/net/stack-heap.htm",  # Unreliable external site
     ],
     checkdocs = :exports,
     warnonly = [:missing_docs],

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseReverseDiffExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseReverseDiffExt.jl
@@ -105,7 +105,7 @@ end
 #         prob, sensealg, ArrayInterface.aos_to_soa(u0), p, args...; kwargs...)
 # end
 
-# Required becase ReverseDiff.@grad function SciMLBase.solve_up is not supported!
+# Required because ReverseDiff.@grad function SciMLBase.solve_up is not supported!
 import NonlinearSolveBase: solve_up
 ReverseDiff.@grad function solve_up(prob, sensealg, u0, p, args...; kwargs...)
     out = NonlinearSolveBase._solve_adjoint(


### PR DESCRIPTION
## Summary

Fixes spell check and documentation CI failures.

## Changes

1. **Typo fix**: `becase` → `because` in `NonlinearSolveBaseReverseDiffExt.jl:108`
2. **Typos config**: Added `clos` to `.typos.toml` (variable name for closure in Enzyme extension)
3. **Linkcheck**: Added unreliable URL `https://net-informations.com/faq/net/stack-heap.htm` to ignore list

## Test plan

- [ ] Spell check CI passes
- [ ] Documentation CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)