### PR TITLE
Bump NonlinearSolveBase v2.11.2 and NonlinearSolve v4.15.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.14.0"
+version = "4.15.0"
 authors = ["SciML"]
 
 [deps]

--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.11.1"
+version = "2.11.2"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary

- Bump `NonlinearSolveBase` 2.11.1 → 2.11.2 (Mooncake 0.5 compat, AbstractMessageLevel fix)
- Bump `NonlinearSolve` 4.14.0 → 4.15.0 (PETSc 0.4 compat and extension API updates)

These version bumps cover all code changes since the last tagged releases (`NonlinearSolveBase-v2.11.1` and `NonlinearSolveFirstOrder-v1.11.1`).

## Registration commands

After merge, run in the Registrator comment on the PR or a commit:

```
@JuliaRegistrator register subdir=lib/NonlinearSolveBase
```

```
@JuliaRegistrator register
```

(Register NonlinearSolveBase first since NonlinearSolve depends on it, though the compat range `"2.2"` already covers both versions.)

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)