### PR TITLE
Fix deprecation warnings in MTK cache indexing tests

### DIFF
--- a/test/mtk_cache_indexing_tests.jl
+++ b/test/mtk_cache_indexing_tests.jl
@@ -7,7 +7,7 @@
     @parameters p d
     @variables X(t)
     eqs = [0 ~ sin(X + p) - d * sqrt(X + 1)]
-    @mtkbuild nlsys = NonlinearSystem(eqs, [X], [p, d])
+    @mtkcompile nlsys = System(eqs, [X], [p, d])
 
     # Creates an integrator.
     nlprob = NonlinearProblem(nlsys, [X => 1.0], [p => 2.0, d => 3.0])


### PR DESCRIPTION
## Summary
- Replace deprecated `@mtkbuild` with `@mtkcompile` and `NonlinearSystem` with `System` in `test/mtk_cache_indexing_tests.jl` following the ModelingToolkitBase API changes.
- These deprecations cause test failures when running with `JULIA_DEPWARN=error`.

## Test plan
- [x] Verified tests pass locally with `JULIA_DEPWARN=error` (136,742 pass, 94 broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)