### PR TITLE
Fix CI deprecation warnings in GitHub Actions workflows

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@latest
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
 

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout Actions Repository
         uses: actions/checkout@v6
       - name: Check spelling
-        uses: crate-ci/typos@v1.18.0 
+        uses: crate-ci/typos@v1.43.3


### PR DESCRIPTION
## Summary
- **CompatHelper.yml**: Replace `julia-actions/setup-julia@latest` with `@v2` (the `@latest` tag is deprecated and generates CI annotation warnings)
- **SpellCheck.yml**: Update `crate-ci/typos` from `v1.18.0` to `v1.43.3` (v1.18.0 uses deprecated Node.js 16 runtime, generating deprecation warnings)

## Test plan
- [ ] Verify CompatHelper workflow runs without deprecation warnings
- [ ] Verify SpellCheck workflow runs without deprecation warnings
- [ ] Confirm no functional changes to CI behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)