### PR TITLE
fix math formatting, add a blurb

### DIFF
--- a/docs/src/basics/nonlinear_problem.md
+++ b/docs/src/basics/nonlinear_problem.md
@@ -10,8 +10,8 @@ NonlinearSolve.jl tackles four related types of nonlinear systems:
  3. Steady state problems, i.e., find the ``u`` such that ``u' = f(u,t)`` has reached steady
     state, i.e., ``0 = f(u, ∞)``.
  4. The nonlinear least squares problem, which is an under/over-constrained nonlinear system
-    which might not be satisfiable, i.e. there may be no `u` such that `f(u) = 0`, and thus
-    we find the `u` which minimizes `||f(u)||` in the least squares sense.
+    which might not be satisfiable, i.e. there may be no ``u`` such that ``f(u) = 0``, and thus
+    we find the ``u`` which minimizes ``\|f(u)\|_2^2`` in the least squares sense.
 
 The first is for solving scalar rootfinding problems, i.e., finding a single number, and
 requires that a bracketing interval is known. For a bracketing interval, one must have that
@@ -29,11 +29,16 @@ boundaries are assumed to be known. For a system of nonlinear equations, `f` can
 an array, and the solver seeks the value of `u` for which all outputs of `f` are
 simultaneously zero.
 
-The last type if equivalent to a nonlinear system, but with the extra interpretation of
+The third type is equivalent to a nonlinear system, but with the extra interpretation of
 having a potentially preferred unique root. That is, when there are multiple `u` such
-that `f(u) = 0`, the `NonlinearProblem` does not have a preferred solution, while for the
-`SteadyStateProblem` the preferred solution is the `u(∞)` that would arise from solving the
-ODE `u' = f(u,t)`.
+that ``f(u) = 0``, the `NonlinearProblem` does not have a preferred solution, while for the
+`SteadyStateProblem` the preferred solution is the ``u(∞)`` that would arise from solving the
+ODE ``u' = f(u,t)``.
+
+The fourth type is an overdetermined nonlinear system, which has more constraints than free
+variables, and thus is usually not possible to solve exactly. In these contexts, it is usually
+convenient to minimize the Euclidean norm, as it is continuously differentiable if the
+original function is.
 
 !!! warning
     


### PR DESCRIPTION
Trivial PR that

1. makes the page use math formatting consistently,

2. explains the nonlinear LS problem similarly to the previous three cases. "Last" in the existing docs refers to case (3), so it is a bit confusing, and case (4) did not have a similar short summary.
