### PR TITLE
Fix Jacobian diagonal calculation in LM when using StaticArrays

### DIFF
--- a/lib/NonlinearSolveFirstOrder/src/levenberg_marquardt.jl
+++ b/lib/NonlinearSolveFirstOrder/src/levenberg_marquardt.jl
@@ -145,7 +145,7 @@ function InternalAPI.solve!(
     elseif ArrayInterface.can_setindex(cache.J_diag_cache)
         sum!(abs2, Utils.safe_vec(cache.J_diag_cache), J')
     else
-        cache.J_diag_cache = dropdims(sum(abs2, J'; dims = 1); dims = 1)
+        cache.J_diag_cache = vec(sum(abs2, J; dims = 1))
     end
     cache.DᵀD = update_levenberg_marquardt_diagonal!!(
         cache.DᵀD, Utils.safe_vec(cache.J_diag_cache)


### PR DESCRIPTION
The issue seems to be that with an overdetermined system the code was reducing along the wrong dimension.

Fixes #560. Debugged with Claude :robot: 

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API