### PR TITLE
Fix Runic CI workflow and formatting

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
       - uses: fredrikekre/runic-action@v1
         with:
           version: '1'

--- a/lib/BracketingNonlinearSolve/src/modAB.jl
+++ b/lib/BracketingNonlinearSolve/src/modAB.jl
@@ -68,7 +68,7 @@ function SciMLBase.__solve(
         end
         if iszero(y3)
             return build_exact_solution(prob, alg, x3, y3, ReturnCode.Success)
-        elseif (x2-x1) < 2ϵ
+        elseif (x2 - x1) < 2ϵ
             return build_bracketing_solution(prob, alg, x3, y3, x1, x2, ReturnCode.Success)
         end
         x0 = x3


### PR DESCRIPTION
## Problem

The Runic CI check was failing with:
```
Error: runic-action: julia is a required dependency but does not seem to be available.
```

## Fix

1. **Add `julia-actions/setup-julia` step** to FormatCheck.yml before running runic-action
2. **Fix spacing in modAB.jl**: `(x2-x1)` → `(x2 - x1)`

Closes the Runic CI issue from #828.