### PR TITLE
Revise recommended methods for root-finding

### DIFF
--- a/docs/src/solvers/bracketing_solvers.md
+++ b/docs/src/solvers/bracketing_solvers.md
@@ -9,7 +9,10 @@ algorithm is given, a default algorithm will be chosen.
 
 ## Recommended Methods
 
-[`modAB`](@ref) (Modified Anderson-Bjork) is the recommended method for the scalar interval root-finding problems. It combines Bisection with Anderson-Bjork steps to achieve superlinear convergence 0.7 ÷ 0.8, providing optimal convergence rate for poorly behaved functions. According to our benchmarks, it outperforms the other methods in most cases.
+[`modAB`](@ref) (Modified Anderson-Bjork) is the recommended method for the scalar interval 
+root-finding problems. It combines Bisection with Anderson-Bjork steps to achieve superlinear 
+convergence 1.7–1.8, providing optimal convergence rate for poorly behaved functions. 
+According to our benchmarks, it outperforms the other methods in most cases.
 
 [`ITP`](@ref) is particularly well-suited for cases where the function is smooth and well-behaved; and
 achieved superlinear convergence while retaining the optimal worst-case performance of the


### PR DESCRIPTION
Updated the recommended methods section to include `modAB` as the primary method for scalar interval root-finding problems, highlighting its advantages over other methods.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
