### PR TITLE
Handle null u0 in SimpleNonlinearSolve for NonlinearLeastSquaresProblem

### DIFF
--- a/lib/SimpleNonlinearSolve/src/SimpleNonlinearSolve.jl
+++ b/lib/SimpleNonlinearSolve/src/SimpleNonlinearSolve.jl
@@ -59,6 +59,9 @@ function CommonSolve.solve(
         prob::NonlinearProblem, alg::AbstractSimpleNonlinearSolveAlgorithm, args...;
         kwargs...
     )
+    if prob.u0 === nothing
+        return NonlinearSolveBase.build_null_solution(prob, args...; kwargs...)
+    end
     prob = convert(ImmutableNonlinearProblem, prob)
     return solve(prob, alg, args...; kwargs...)
 end
@@ -94,6 +97,9 @@ function CommonSolve.solve(
         args...; sensealg = nothing, u0 = nothing, p = nothing,
         initializealg = SciMLBase.NoInit(), kwargs...
     )
+    if prob.u0 === nothing
+        return NonlinearSolveBase.build_null_solution(prob, args...; kwargs...)
+    end
     alg = configure_autodiff(prob, alg)
     cache = SciMLBase.__init(prob, alg, args...; initializealg, kwargs...)
     prob = cache.prob


### PR DESCRIPTION
## Summary

- Add `u0 === nothing` guards in SimpleNonlinearSolve's two `solve` methods (for `NonlinearProblem` and `Union{ImmutableNonlinearProblem, NonlinearLeastSquaresProblem}`), delegating to the existing `NonlinearSolveBase.build_null_solution`
- This matches the null solution handling already present in `NonlinearSolveBase.solve_call`, which SimpleNonlinearSolve bypasses with its own `solve` dispatches
- Added tests for OOP satisfiable, OOP unsatisfiable, and IIP unsatisfiable `NonlinearLeastSquaresProblem` with `nothing` u0

Fixes #842

## Test plan

- [x] Verified the exact MRE from #842 now returns a solution instead of erroring
- [x] Ran full `SimpleNonlinearSolve` core test suite — all 35,588 tests pass (only pre-existing Aqua stale deps failure unrelated to this change)
- [x] New test item covers OOP success (zero residual), OOP failure (nonzero residual), and IIP failure cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)