### PR TITLE
Fix tspan-Dual ForwardDiff ext: secant step instead of foreign Dual tag

### DIFF
--- a/lib/BracketingNonlinearSolve/Project.toml
+++ b/lib/BracketingNonlinearSolve/Project.toml
@@ -1,6 +1,6 @@
 name = "BracketingNonlinearSolve"
 uuid = "70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
-version = "1.9.1"
+version = "1.10.0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/BracketingNonlinearSolve/ext/BracketingNonlinearSolveForwardDiffExt.jl
+++ b/lib/BracketingNonlinearSolve/ext/BracketingNonlinearSolveForwardDiffExt.jl
@@ -1,13 +1,11 @@
 module BracketingNonlinearSolveForwardDiffExt
 
 using CommonSolve: CommonSolve
-using ForwardDiff: ForwardDiff, Dual, Partials, Tag
+using ForwardDiff: ForwardDiff, Dual, Partials
 using NonlinearSolveBase: nonlinearsolve_forwarddiff_solve, nonlinearsolve_dual_solution
 using SciMLBase: SciMLBase, IntervalNonlinearProblem
 
 using BracketingNonlinearSolve: Bisection, Brent, Alefeld, Falsi, ITP, Ridder, ModAB
-
-struct BracketingNonlinearSolveTag end
 
 const DualIntervalNonlinearProblem{
     T,
@@ -63,16 +61,19 @@ end
 
 # Handle the case where Duals are in tspan (bracket endpoints) rather than in p.
 # This occurs in DiffEqBase callback root-finding where the integrator's time values
-# are Dual numbers carrying parameter sensitivities, but p is not passed to the
-# IntervalNonlinearProblem.
+# are Dual numbers, but p is not passed to the IntervalNonlinearProblem.
 #
-# The derivative of the root w.r.t. the boundary point is zero (the root is where
-# f=0, independent of bracket position). However, f's closure may capture
-# Dual-valued state (e.g. from an ODE integrator), making this a mixed case where
-# dt*/dθ = -(∂f/∂θ)/(∂f/∂t) is nonzero via the implicit function theorem.
-# We use a package-specific ForwardDiff tag (BracketingNonlinearSolveTag) to compute
-# ∂f/∂t, which gives the tag system a well-defined ordering relative to the
-# closure's existing tag.
+# The derivative of the root w.r.t. the bracket position is zero (the root is where
+# f=0, independent of bracket position). However, f's closure may capture Dual-valued
+# state (e.g. from an ODE integrator differentiating w.r.t. parameters), making this
+# a mixed case where dt*/dθ is nonzero via the implicit function theorem:
+#   dt*/dθ = -(∂f/∂θ) / (∂f/∂t)
+#
+# We compute this by evaluating f at the root and a nearby offset point, then applying
+# the secant formula in Dual arithmetic. The offset uses sqrt(ε) spacing so the secant
+# slope is well-conditioned (unlike machine-precision brackets where rounding dominates).
+# Using the same Dual tag T as the tspan avoids introducing a foreign tag that would
+# conflict with the caller's type system (e.g. ODE interpolant buffers typed for T).
 
 const DualTspanIntervalNonlinearProblem{
     T,
@@ -87,30 +88,39 @@ for algT in (Bisection, Brent, Alefeld, Falsi, ITP, Ridder, ModAB)
             prob::DualTspanIntervalNonlinearProblem{T, V, P}, alg::$(algT), args...;
             kwargs...
         ) where {T, V, P}
-        # Strip Duals from tspan and wrap f to strip any Dual output
+        # Strip Duals from tspan and f returns for the solver
         tspan = (ForwardDiff.value(prob.tspan[1]), ForwardDiff.value(prob.tspan[2]))
         f_orig = prob.f
         f_stripped(t, p) = ForwardDiff.value(f_orig(t, p))
         newprob = IntervalNonlinearProblem{false}(f_stripped, tspan, prob.p; prob.kwargs...)
         sol = CommonSolve.solve(newprob, alg, args...; kwargs...)
 
-        # Check if f returns Duals (mixed case: closure captures Dual-valued state)
-        root = sol.u
-        f_at_root = prob.f(root, prob.p)
+        # Check if f's closure captures Dual-valued state (mixed case).
+        # Both calls use Float64 time inputs, so they pass through ODE interpolants
+        # without type conflicts. The Dual return comes from the closure's state.
+        f_at_root = f_orig(sol.u, prob.p)
 
-        if f_at_root isa Dual
-            # Implicit function theorem: dt*/dθ = -(∂f/∂θ) / (∂f/∂t)
-            # Use a package-specific tag to differentiate f w.r.t. t.
-            # This produces a nested Dual; the outer partials give ∂f/∂t and
-            # the inner partials give ∂f/∂θ.
-            TagType = typeof(Tag(BracketingNonlinearSolveTag(), V))
-            root_dual = Dual{TagType}(root, Partials((one(V),)))
-            nested = prob.f(root_dual, prob.p)
-            dfdt = ForwardDiff.value(ForwardDiff.partials(nested)[1])
-            dfdθ = ForwardDiff.partials(ForwardDiff.value(nested))
-            partials = -dfdθ / dfdt
+        if f_at_root isa Dual{T, V, P}
+            # Mixed case: apply implicit function theorem via Dual secant step.
+            # Evaluate f at the root (where f ≈ 0) and a nearby offset point
+            # to get an accurate secant slope for df/dt.
+            delta = sqrt(eps(V)) * max(one(V), abs(sol.u))
+            t_hi = ForwardDiff.value(prob.tspan[2])
+            t_lo = ForwardDiff.value(prob.tspan[1])
+            if sol.u + delta ≤ t_hi
+                t_other = sol.u + delta
+            else
+                t_other = sol.u - delta
+            end
+            f_at_other = f_orig(t_other, prob.p)
+
+            zero_p = Partials{P, V}(ntuple(_ -> zero(V), Val(P)))
+            a = Dual{T, V, P}(sol.u, zero_p)
+            b = Dual{T, V, P}(t_other, zero_p)
+            root_dual = a - f_at_root * (b - a) / (f_at_other - f_at_root)
+            partials = ForwardDiff.partials(root_dual)
         else
-            # Pure tspan-Dual case: derivative w.r.t. boundary is zero
+            # Pure tspan-Dual case: derivative w.r.t. boundary is zero.
             partials = Partials{P, V}(ntuple(_ -> zero(V), Val(P)))
         end
 


### PR DESCRIPTION
## Summary

- Fixes the `MethodError: no method matching Float64(::ForwardDiff.Dual{BracketingNonlinearSolveTag, ...})` that broke DiffEqBase's `ContinuousCallback` AD (https://github.com/SciML/DiffEqBase.jl/actions/runs/22214000471/job/64265452638?pr=1278)
- PR #841 introduced a package-specific `BracketingNonlinearSolveTag` to compute `∂f/∂t` via the implicit function theorem. This created nested Duals that the ODE interpolant's mutating buffers (`Vector{Dual{OuterTag}}`) couldn't hold
- The fix evaluates `f` at the root and a nearby offset point (`sqrt(ε)` spacing), then applies the secant formula in Dual arithmetic with the **same tag `T`** as the tspan — no foreign tag, no type conflicts

### Why this works

At the root where `f(root) ≈ 0`, the secant formula `root = a - f(a)·(b-a)/(f(b)-f(a))` naturally yields the implicit function theorem partials `dt*/dθ = -(∂f/∂θ)/(∂f/∂t)` through standard Dual arithmetic. The `sqrt(ε)` offset ensures the secant slope is well-conditioned (unlike machine-precision brackets where rounding dominates).

### Key changes

- Removed `BracketingNonlinearSolveTag` struct and `Tag` import
- Replaced the nested-Dual IFT computation with a 2-evaluation secant step using the caller's own Dual tag
- Bumped version to 1.10.0

## Test plan

- [x] All 18465 BracketingNonlinearSolve tests pass (including the existing `ForwardDiff with Duals in tspan` tests for both mixed and pure cases, all 7 algorithms)
- [x] DiffEqBase `callback_ad.jl` downstream test passes all 40 tests (previously 19/21 errored with `MethodError`)
- [x] Max relative error vs FiniteDiff jacobians: ~4e-6 (well within `rtol=1e-5`)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)