### PR TITLE
Remove Julia 1.12 version guard from adjoint tests

### DIFF
--- a/test/Adjoint/adjoint_tests__item1.jl
+++ b/test/Adjoint/adjoint_tests__item1.jl
@@ -1,33 +1,27 @@
 using NonlinearSolve
 
-# Skip adjoint tests on Julia 1.12+ due to Enzyme/SciMLSensitivity compatibility issues
-# To re-enable: change condition to `false` or `VERSION >= v"1.13"`
-@static if VERSION < v"1.12"
-    using ForwardDiff, ReverseDiff, SciMLSensitivity, Tracker, Zygote, Enzyme, Mooncake
+using ForwardDiff, ReverseDiff, SciMLSensitivity, Tracker, Zygote, Enzyme, Mooncake
 
-    ff(u, p) = u .^ 2 .- p
+ff(u, p) = u .^ 2 .- p
 
-    function solve_nlprob(p)
-        prob = NonlinearProblem{false}(ff, [1.0, 2.0], p)
-        sol = solve(prob, NewtonRaphson())
-        res = sol isa AbstractArray ? sol : sol.u
-        return sum(abs2, res)
-    end
-
-    p = [3.0, 2.0]
-
-    ∂p_zygote = only(Zygote.gradient(solve_nlprob, p))
-    ∂p_forwarddiff = ForwardDiff.gradient(solve_nlprob, p)
-    ∂p_tracker = Tracker.data(only(Tracker.gradient(solve_nlprob, p)))
-    ∂p_reversediff = ReverseDiff.gradient(solve_nlprob, p)
-    ∂p_enzyme = Enzyme.gradient(Enzyme.set_runtime_activity(Enzyme.Reverse), solve_nlprob, p)[1]
-
-    cache = Mooncake.prepare_gradient_cache(solve_nlprob, p)
-    ∂p_mooncake = Mooncake.value_and_gradient!!(cache, solve_nlprob, p)[2][2]
-
-    @test ∂p_zygote ≈ ∂p_tracker ≈ ∂p_reversediff ≈ ∂p_enzyme
-    @test ∂p_zygote ≈ ∂p_forwarddiff ≈ ∂p_tracker ≈ ∂p_reversediff ≈ ∂p_enzyme
-    @test ∂p_forwarddiff ≈ ∂p_mooncake
-else
-    @info "Skipping adjoint tests on Julia $(VERSION) - Enzyme/SciMLSensitivity not compatible with 1.12+"
+function solve_nlprob(p)
+    prob = NonlinearProblem{false}(ff, [1.0, 2.0], p)
+    sol = solve(prob, NewtonRaphson())
+    res = sol isa AbstractArray ? sol : sol.u
+    return sum(abs2, res)
 end
+
+p = [3.0, 2.0]
+
+∂p_zygote = only(Zygote.gradient(solve_nlprob, p))
+∂p_forwarddiff = ForwardDiff.gradient(solve_nlprob, p)
+∂p_tracker = Tracker.data(only(Tracker.gradient(solve_nlprob, p)))
+∂p_reversediff = ReverseDiff.gradient(solve_nlprob, p)
+∂p_enzyme = Enzyme.gradient(Enzyme.set_runtime_activity(Enzyme.Reverse), solve_nlprob, p)[1]
+
+cache = Mooncake.prepare_gradient_cache(solve_nlprob, p)
+∂p_mooncake = Mooncake.value_and_gradient!!(cache, solve_nlprob, p)[2][2]
+
+@test ∂p_zygote ≈ ∂p_tracker ≈ ∂p_reversediff ≈ ∂p_enzyme
+@test ∂p_zygote ≈ ∂p_forwarddiff ≈ ∂p_tracker ≈ ∂p_reversediff ≈ ∂p_enzyme
+@test ∂p_forwarddiff ≈ ∂p_mooncake


### PR DESCRIPTION
## Summary
- Removes the `@static if VERSION < v"1.12"` guard that skipped all adjoint tests (Enzyme, Zygote, ForwardDiff, ReverseDiff, Tracker, Mooncake) on Julia 1.12+
- Enzyme now supports Julia 1.12 per @wsmoses: https://github.com/SciML/SciMLSensitivity.jl/issues/1358#issuecomment-4106376032

## Test plan
- [ ] CI passes adjoint tests on Julia 1.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>