### PR TITLE
Bump minor versions for NonlinearSolve and NonlinearSolveBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.16.0"
+version = "4.17.0"
 authors = ["SciML"]
 
 [deps]

--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.19.0"
+version = "2.20.0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary
- NonlinearSolve: 4.16.0 → 4.17.0
- NonlinearSolveBase: 2.19.0 → 2.20.0

Version bumps to trigger releases after #838 is merged.

## Test plan
- [ ] CI passes (no code changes, version bumps only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)