### PR TITLE
fix issue #535

### DIFF
--- a/lib/NonlinearSolveBase/src/descent/newton.jl
+++ b/lib/NonlinearSolveBase/src/descent/newton.jl
@@ -105,7 +105,15 @@ function InternalAPI.solve!(
         if normal_form(cache)
             @assert !preinverted_jacobian(cache)
             if idx === Val(1)
-                @bb cache.JᵀJ_cache = transpose(J) × J
+                # For sparse J, @bb cannot update entries in-place
++               # It will update entries absent from the initial sparsity pattern of
++               # cache.JᵀJ_cache, corrupting the normal equations.
++               # Fresh memory is therefore allocated in case of sparse matrix
++               if ArrayInterface.isstructured(J)
++                   cache.JᵀJ_cache = transpose(J) * J
++               else
++                   @bb cache.JᵀJ_cache = transpose(J) × J
++               end
             end
             @bb cache.Jᵀfu_cache = transpose(J) × vec(fu)
             @static_timeit cache.timer "linear solve" begin

--- a/lib/NonlinearSolveBase/src/descent/newton.jl
+++ b/lib/NonlinearSolveBase/src/descent/newton.jl
@@ -106,7 +106,7 @@ function InternalAPI.solve!(
             @assert !preinverted_jacobian(cache)
             if idx === Val(1)
                 # For sparse J, @bb cannot update entries in-place
-+               # It will update entries absent from the initial sparsity pattern of
++               # It cannot update entries absent from the initial sparsity pattern of
 +               # cache.JᵀJ_cache, corrupting the normal equations.
 +               # Fresh memory is therefore allocated in case of sparse matrix
 +               if ArrayInterface.isstructured(J)

--- a/lib/NonlinearSolveBase/src/descent/newton.jl
+++ b/lib/NonlinearSolveBase/src/descent/newton.jl
@@ -105,15 +105,7 @@ function InternalAPI.solve!(
         if normal_form(cache)
             @assert !preinverted_jacobian(cache)
             if idx === Val(1)
-                # For sparse J, @bb cannot update entries in-place
-+               # It cannot update entries absent from the initial sparsity pattern of
-+               # cache.JᵀJ_cache, corrupting the normal equations.
-+               # Fresh memory is therefore allocated in case of sparse matrix
-+               if ArrayInterface.isstructured(J)
-+                   cache.JᵀJ_cache = transpose(J) * J
-+               else
-+                   @bb cache.JᵀJ_cache = transpose(J) × J
-+               end
+                @bb cache.JᵀJ_cache = transpose(J) × J
             end
             @bb cache.Jᵀfu_cache = transpose(J) × vec(fu)
             @static_timeit cache.timer "linear solve" begin

--- a/lib/NonlinearSolveFirstOrder/src/gauss_newton.jl
+++ b/lib/NonlinearSolveFirstOrder/src/gauss_newton.jl
@@ -9,7 +9,7 @@ matrices via colored automatic differentiation and preconditioned linear solvers
 for large-scale and numerically-difficult nonlinear systems.
 """
 function GaussNewton(;
-        concrete_jac = nothing, linsolve = nothing, linesearch = missing,
+        concrete_jac = nothing, linsolve = nothing, linesearch = BackTracking(),
         autodiff = nothing, vjp_autodiff = nothing, jvp_autodiff = nothing
     )
     return GeneralizedFirstOrderAlgorithm(;

--- a/lib/NonlinearSolveFirstOrder/test/least_squares_tests.jl
+++ b/lib/NonlinearSolveFirstOrder/test/least_squares_tests.jl
@@ -87,3 +87,50 @@ end
         @test norm(collect(sol_static.u) - sol_vec.u) < 1.0e-6
     end
 end
+
+@testitem "NLSS using GaussNewton for sparse matrices" tags = [:core] begin
+    using NonlinearSolveFirstOrder, LinearAlgebra, SparseArrays, SciMLBase
+
+    # Overdetermined: 4 residuals, 3 unknowns.
+    # Has an exact solution at u = [1.0, 1.0, 1.0].
+    function f!(r, u, p)
+        r[1] = u[1]^2 + u[2]^2 - 2.0
+        r[2] = u[2]^2 + u[3]^2 - 2.0
+        r[3] = u[1] * u[2] - 1.0
+        r[4] = u[2] * u[3] - 1.0
+    end
+
+    function jac!(J, u, p)
+        fill!(J, 0)
+        J[1, 1] = 2 * u[1];  J[1, 2] = 2 * u[2]
+        J[2, 2] = 2 * u[2];  J[2, 3] = 2 * u[3]
+        J[3, 1] = u[2];      J[3, 2] = u[1]
+        J[4, 2] = u[3];      J[4, 3] = u[2]
+    end
+
+    proto = sparse([1, 1, 2, 2, 3, 3, 4, 4], [1, 2, 2, 3, 1, 2, 2, 3], ones(8), 4, 3)
+
+    prob_sparse = NonlinearLeastSquaresProblem(
+        NonlinearFunction(f!;
+            jac = jac!,
+            resid_prototype = zeros(4),
+            jac_prototype = proto,
+        ),
+        [0.5, 0.5, 0.5],
+    )
+    prob_dense = NonlinearLeastSquaresProblem(
+        NonlinearFunction(f!;
+            jac = jac!,
+            resid_prototype = zeros(4),
+        ),
+        [0.5, 0.5, 0.5],
+    )
+
+    sol_sparse = solve(prob_sparse, GaussNewton(); maxiters = 100, abstol = 1.0e-8)
+    sol_dense  = solve(prob_dense,  GaussNewton(); maxiters = 100, abstol = 1.0e-8)
+
+    @test SciMLBase.successful_retcode(sol_sparse)
+    @test SciMLBase.successful_retcode(sol_dense)
+    # Sparse and dense analytical Jacobians must converge to the same solution
+    @test norm(sol_sparse.u - sol_dense.u) < 1.0e-6
+end


### PR DESCRIPTION
…or issue #535

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context
The problem lied with the fact that in newton.jl the multiplication with the transpose was happening in-place due to `@bb` and that hampered the sparsity pattern for sparse matrices. Hence illogical step values were observed. The fix is to replace the `@bb` in-place multiplication with a fresh allocation `cache.JᵀJ_cache = transpose(J) * J` when J is sparse.
Would appreciate any advice or corrections.