### PR TITLE
Handle empty u in construct_jacobian_cache

### DIFF
--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -35,6 +35,12 @@ function construct_jacobian_cache(
         autodiff = nothing, vjp_autodiff = nothing, jvp_autodiff = nothing,
         linsolve = missing
     )
+    # Empty state vector (e.g. u0=nothing converted to Float64[]) — nothing to differentiate
+    if length(u) == 0
+        J = Utils.safe_similar(fu, promote_type(eltype(fu), eltype(u)), length(fu), 0)
+        return JacobianCache(J, f, fu, p, stats, autodiff, nothing)
+    end
+
     has_analytic_jac = SciMLBase.has_jac(f)
     linsolve_needs_jac = !concrete_jac(alg) && (
         linsolve === missing ||

--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -176,6 +176,9 @@ end
 
 ## Actually Compute the Jacobian
 function (cache::JacobianCache)(u)
+    # Empty state vector — Jacobian is 0×0, nothing to compute
+    length(u) == 0 && return cache.J
+
     cache.stats.njacs += 1
     (; f, J, p) = cache
     if SciMLBase.isinplace(f)

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -542,3 +542,71 @@ end
     solve!(iter)
     @test precs.i == 1
 end
+
+@testitem "Empty u0 (u0=nothing pathway)" tags = [:core] begin
+    using SymbolicIndexingInterface
+
+    # Mimics MTK systems with no state variables — only parameters and observed quantities.
+    # OrdinaryDiffEqCore converts u0=nothing to Float64[] before reaching NonlinearSolve.
+    sys = SymbolCache(nothing, Dict(:a => 1, :b => 2), nothing)
+
+    function observed_fn(sym)
+        if sym == :result
+            return (u, p) -> p[1] + p[2]
+        end
+        return nothing
+    end
+
+    @testset "IIP" begin
+        f_iip!(resid, u, p) = nothing
+        nlfunc = NonlinearFunction(f_iip!; observed = observed_fn, sys = sys)
+        prob = NonlinearProblem{true}(nlfunc, Float64[], [3.0, 4.0])
+
+        # init/solve cycle
+        cache = @test_nowarn init(prob, NewtonRaphson())
+        @test state_values(cache) == Float64[]
+        @test parameter_values(cache) == [3.0, 4.0]
+
+        # parameter mutation through symbolic indexing
+        cache.ps[:a] = 10.0
+        cache.ps[:b] = 20.0
+        @test parameter_values(cache) == [10.0, 20.0]
+
+        sol = solve!(cache)
+        @test SciMLBase.successful_retcode(sol)
+        @test isempty(sol.u)
+    end
+
+    @testset "OOP" begin
+        f_oop(u, p) = Float64[]
+        nlfunc = NonlinearFunction(f_oop; observed = observed_fn, sys = sys)
+        prob = NonlinearProblem(nlfunc, Float64[], [5.0, 6.0])
+
+        sol = @test_nowarn solve(prob, NewtonRaphson())
+        @test SciMLBase.successful_retcode(sol)
+        @test isempty(sol.u)
+    end
+
+    @testset "Default algorithm" begin
+        f_iip!(resid, u, p) = nothing
+        nlfunc = NonlinearFunction(f_iip!; observed = observed_fn, sys = sys)
+        prob = NonlinearProblem{true}(nlfunc, Float64[], [1.0, 2.0])
+
+        sol = @test_nowarn solve(prob)
+        @test SciMLBase.successful_retcode(sol)
+        @test isempty(sol.u)
+    end
+
+    @testset "Step interface" begin
+        f_iip!(resid, u, p) = nothing
+        nlfunc = NonlinearFunction(f_iip!; observed = observed_fn, sys = sys)
+        prob = NonlinearProblem{true}(nlfunc, Float64[], [1.0, 2.0])
+
+        cache = init(prob, NewtonRaphson())
+        for i in 1:10
+            step!(cache)
+            cache.force_stop && break
+        end
+        @test SciMLBase.successful_retcode(cache.retcode)
+    end
+end


### PR DESCRIPTION
## Summary

When `u` has length 0 (e.g. from `u0=nothing` converted to `Float64[]` by OrdinaryDiffEqCore for MTK systems with only callbacks/observed and no state variables), `construct_jacobian_cache` passes it to ForwardDiff/DifferentiationInterface which errors: `chunk size cannot be greater than ForwardDiff.structural_length(x) (1 > 0)`.

**Fix** (two guards in `NonlinearSolveBase/src/jacobian.jl`):
- `construct_jacobian_cache`: early return with an empty 0-column Jacobian when `length(u) == 0`, skipping AD setup
- `JacobianCache` callable: early return the empty Jacobian when `length(u) == 0`, preventing `DI.jacobian!` from being called with `nothing` extras

**Test** (`test/core_tests.jl`): comprehensive test of the empty `u0` pathway without MTK dependencies:
- `SymbolCache` with no state variables, parameters, and an observed function
- IIP and OOP `NonlinearProblem` with `Float64[]` as u0
- Parameter mutation via symbolic indexing
- `init`/`solve!`, direct `solve`, default algorithm, and step interface

## Test plan

- [x] `NonlinearSolveBase` tests pass (16/16)
- [x] New "Empty u0 (u0=nothing pathway)" test passes (13/13)
- [x] `ImplicitDiscreteSolve` tests pass with this fix dev'd in (6 test sets, 27 tests including the `u0=nothing` case with `@test_nowarn`)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)