### PR TITLE
Cap HomotopyContinuation compat at 2.18.1 in NonlinearSolveHomotopyContinuation

### DIFF
--- a/lib/NonlinearSolveHomotopyContinuation/Project.toml
+++ b/lib/NonlinearSolveHomotopyContinuation/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveHomotopyContinuation"
 uuid = "2ac3b008-d579-4536-8c91-a1a5998c2f8b"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com> and contributors"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -30,7 +30,7 @@ ConcreteStructs = "0.2.3"
 DifferentiationInterface = "0.7.3"
 DocStringExtensions = "0.9.3"
 Enzyme = "0.13"
-HomotopyContinuation = "2.12.0"
+HomotopyContinuation = "2.12.0 - 2.18.1"
 LinearAlgebra = "1.10"
 NaNMath = "1.1"
 NonlinearSolve = "4.10"


### PR DESCRIPTION
## Summary

- Cap `HomotopyContinuation` compat in `lib/NonlinearSolveHomotopyContinuation/Project.toml` from `"2.12.0"` (which allows all of `2.x`) to `"2.12.0 - 2.18.1"`, excluding `v2.18.2` which regresses the `AllRoots` "no real solutions" tests.
- Bump `NonlinearSolveHomotopyContinuation` patch `0.1.8` → `0.1.9`.

## Why

`HomotopyContinuation.jl v2.18.2` was released 2026-04-12 and includes PR [#694 "patch decompose for dimension 0"](https://github.com/JuliaHomotopyContinuation/HomotopyContinuation.jl/pull/694). This changes the numerical behavior of `HC.results(orig_sol; only_real = true)` on systems with no real roots: it now surfaces 2 near-real complex roots that previously failed its imaginary-part threshold.

The `AllRoots` "no real solutions" testset in `lib/NonlinearSolveHomotopyContinuation/test/allroots.jl:152-158`:

```julia
@testset "no real solutions" begin
    _prob = remake(prob; p = zeros(2))
    _sol = solve(_prob, _alg)
    @test !_sol.converged
    @test length(_sol) == 1
    @test !SciMLBase.successful_retcode(_sol.u[1])
end
```

Under `v2.18.1` and earlier, `HC.results(; only_real = true)` returns an empty vector; our wrapper hits the `isempty(realsols)` branch in `lib/NonlinearSolveHomotopyContinuation/src/solve.jl:72` and returns a length-1 sentinel `EnsembleSolution`. Under `v2.18.2`, the same call returns 2 near-real solutions, the wrapper exits that branch, runs denominator/unpolynomialize, and returns a length-2 `EnsembleSolution` — so `@test length(_sol) == 1` fires with `Evaluated: 2 == 1`. HC's own path tracking still reports `# total solutions (real): 6 (0)` either way — only the post-filter is affected.

Reproduces on a fresh depot against the current source, independent of any changes under review. Affects every case in the `vector u - (oop|iip) + (forwarddiff|jac|enzyme)` matrix (6 failures out of 169 in `AllRoots`). Shows up as consistent failures on `CI (NonlinearSolveHomotopyContinuation)` for every PR that resolves `HC v2.18.2` (e.g. #910).

## What we should do next

This cap is a holding pattern, not a fix:

1. **File an upstream issue / PR** against `JuliaHomotopyContinuation/HomotopyContinuation.jl` asking whether the loosened `only_real = true` threshold after #694 is intentional. Two possibilities:
   - The change was unintentional — they tighten the threshold back and release `2.18.3`; we can widen our compat to `"2.12.0, >=2.18.3"` (or just drop the cap).
   - The change is the new intended behavior — we update our wrapper / test to not rely on `HC.results` discarding near-real paths; instead, filter on `successful_retcode` or on a local imaginary-part threshold before building the ensemble. In that case the cap can be lifted once the test is updated.
2. **Lift the cap** once one of those lands. The cap should not survive indefinitely — HC `2.x` patch releases otherwise carry bug fixes we'd want.

## Test plan

- [x] `lib/NonlinearSolveHomotopyContinuation` tests pass locally against `HomotopyContinuation v2.18.1`.
- [x] Same tests fail against `v2.18.2` (reproduces the 6 "no real solutions" failures independent of any NonlinearSolveBase changes).
- [ ] CI `CI (NonlinearSolveHomotopyContinuation)` goes green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)