### PR TITLE
[Probe — do not merge] Trigger HC CI on unmodified master allroots test

### DIFF
--- a/lib/NonlinearSolveHomotopyContinuation/src/interface_types.jl
+++ b/lib/NonlinearSolveHomotopyContinuation/src/interface_types.jl
@@ -1,5 +1,7 @@
 abstract type HomotopySystemVariant end
 
+# Marker types for the in-place / out-of-place / scalar dispatch on
+# `HomotopySystemWrapper`.
 struct Inplace <: HomotopySystemVariant end
 struct OutOfPlace <: HomotopySystemVariant end
 struct Scalar <: HomotopySystemVariant end


### PR DESCRIPTION
## What

Diagnostic-only PR. Branched off plain `master` (no other changes) with a single no-op comment in `lib/NonlinearSolveHomotopyContinuation/src/interface_types.jl` to trigger the `CI (NonlinearSolveHomotopyContinuation)` workflow.

## Why

The "no real solutions" `length(_sol) == 1` failures observed on #910 (`c196f61`, `bffb6cd`, `d3fbe2c`) need to be confirmed as a master-side flake, not a regression introduced by #910's NonlinearSolveBase changes. This branch carries no changes to `NonlinearSolveBase`, no changes to the test file, and no changes to any HC source — it just touches a comment so the workflow's path filter fires.

If `CI (NonlinearSolveHomotopyContinuation)` reports the same `Evaluated: 2 == 1` failures here, that confirms the assertion is flaky on master itself and #910 is not the cause.

The actual fix is in #914 (seed the HC path tracker + relax the assertion to the wrapper's true invariant).

## Test plan

- [ ] CI runs and either passes (HC's non-determinism happens to land on `length == 1` this time) or fails with the same `Evaluated: 2 == 1` pattern (HC's non-determinism lands on `length >= 2`).
- [ ] PR closed without merging once CI signal is collected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)