### PR TITLE
Disable workflow telemetry and cache in all CI workflows

### DIFF
--- a/.github/workflows/CI_BracketingNonlinearSolve.yml
+++ b/.github/workflows/CI_BracketingNonlinearSolve.yml
@@ -31,6 +31,8 @@ jobs:
           - macos-latest
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: ${{ matrix.version }}
       os: ${{ matrix.os }}
       project: "lib/BracketingNonlinearSolve"
@@ -42,6 +44,8 @@ jobs:
     if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: "1.11"
       project: "lib/BracketingNonlinearSolve"
       downgrade_testing: true

--- a/.github/workflows/CI_NonlinearSolve.yml
+++ b/.github/workflows/CI_NonlinearSolve.yml
@@ -52,6 +52,8 @@ jobs:
             version: "lts"
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: ${{ matrix.version }}
       os: ${{ matrix.os }}
       project: "."
@@ -76,6 +78,8 @@ jobs:
           - macos-latest
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: "pre"
       os: ${{ matrix.os }}
       project: "."
@@ -97,6 +101,8 @@ jobs:
           - nopre
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       project: "."
       julia_version: "1.11"
       downgrade_testing: true

--- a/.github/workflows/CI_NonlinearSolveBase.yml
+++ b/.github/workflows/CI_NonlinearSolveBase.yml
@@ -30,6 +30,8 @@ jobs:
           - macos-latest
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: ${{ matrix.version }}
       os: ${{ matrix.os }}
       project: "lib/NonlinearSolveBase"
@@ -41,6 +43,8 @@ jobs:
     if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: "1.11"
       project: "lib/NonlinearSolveBase"
       downgrade_testing: true

--- a/.github/workflows/CI_NonlinearSolveFirstOrder.yml
+++ b/.github/workflows/CI_NonlinearSolveFirstOrder.yml
@@ -31,6 +31,8 @@ jobs:
           - macos-latest
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: ${{ matrix.version }}
       os: ${{ matrix.os }}
       project: "lib/NonlinearSolveFirstOrder"
@@ -42,6 +44,8 @@ jobs:
     if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: "1.11"
       project: "lib/NonlinearSolveFirstOrder"
       downgrade_testing: true

--- a/.github/workflows/CI_NonlinearSolveHomotopyContinuation.yml
+++ b/.github/workflows/CI_NonlinearSolveHomotopyContinuation.yml
@@ -30,6 +30,8 @@ jobs:
           - macos-latest
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: ${{ matrix.version }}
       os: ${{ matrix.os }}
       project: "lib/NonlinearSolveHomotopyContinuation"
@@ -41,6 +43,8 @@ jobs:
     if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: "1.11"
       project: "lib/NonlinearSolveHomotopyContinuation"
       downgrade_testing: true

--- a/.github/workflows/CI_NonlinearSolveQuasiNewton.yml
+++ b/.github/workflows/CI_NonlinearSolveQuasiNewton.yml
@@ -31,6 +31,8 @@ jobs:
           - macos-latest
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: ${{ matrix.version }}
       os: ${{ matrix.os }}
       project: "lib/NonlinearSolveQuasiNewton"
@@ -42,6 +44,8 @@ jobs:
     if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: "1.11"
       project: "lib/NonlinearSolveQuasiNewton"
       downgrade_testing: true

--- a/.github/workflows/CI_NonlinearSolveSciPy.yml
+++ b/.github/workflows/CI_NonlinearSolveSciPy.yml
@@ -30,6 +30,8 @@ jobs:
           - macos-latest
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: ${{ matrix.version }}
       os: ${{ matrix.os }}
       project: "lib/NonlinearSolveSciPy"
@@ -41,6 +43,8 @@ jobs:
     if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: "1.11"
       project: "lib/NonlinearSolveSciPy"
       downgrade_testing: true

--- a/.github/workflows/CI_NonlinearSolveSpectralMethods.yml
+++ b/.github/workflows/CI_NonlinearSolveSpectralMethods.yml
@@ -31,6 +31,8 @@ jobs:
           - macos-latest
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: ${{ matrix.version }}
       os: ${{ matrix.os }}
       project: "lib/NonlinearSolveSpectralMethods"
@@ -42,6 +44,8 @@ jobs:
     if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: "1.11"
       project: "lib/NonlinearSolveSpectralMethods"
       downgrade_testing: true

--- a/.github/workflows/CI_SCCNonlinearSolve.yml
+++ b/.github/workflows/CI_SCCNonlinearSolve.yml
@@ -31,6 +31,8 @@ jobs:
           - macos-latest
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: ${{ matrix.version }}
       os: ${{ matrix.os }}
       project: "lib/SCCNonlinearSolve"
@@ -42,6 +44,8 @@ jobs:
     if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: "1.11"
       project: "lib/SCCNonlinearSolve"
       downgrade_testing: true

--- a/.github/workflows/CI_SciMLJacobianOperators.yml
+++ b/.github/workflows/CI_SciMLJacobianOperators.yml
@@ -29,6 +29,8 @@ jobs:
           - macos-latest
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: ${{ matrix.version }}
       os: ${{ matrix.os }}
       project: "lib/SciMLJacobianOperators"
@@ -39,6 +41,8 @@ jobs:
     if: false
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: "1.11"
       project: "lib/SciMLJacobianOperators"
       downgrade_testing: true

--- a/.github/workflows/CI_SimpleNonlinearSolve.yml
+++ b/.github/workflows/CI_SimpleNonlinearSolve.yml
@@ -36,6 +36,8 @@ jobs:
           - alloc_check
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: ${{ matrix.version }}
       os: ${{ matrix.os }}
       project: "lib/SimpleNonlinearSolve"
@@ -55,6 +57,8 @@ jobs:
           - alloc_check
     uses: LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main
     with:
+      enable_telemetry: false
+      enable_cache: false
       julia_version: "1.11"
       project: "lib/SimpleNonlinearSolve"
       downgrade_testing: true


### PR DESCRIPTION
## Summary

Pass `enable_telemetry: false` and `enable_cache: false` to every `LuxDL/Lux.jl/.github/workflows/CommonCI.yml@main` call site — 23 occurrences across all 11 `CI_*.yml` workflow files.

## Why

Both features have been causing spurious CI job failures on the self-hosted SciML runners, most recently observed on #910 where 5+ jobs reported FAILURE despite `Testing … tests passed`:

**Telemetry** (`catchpoint/workflow-telemetry-action@v2`):
```
##[error][Workflow Telemetry] AxiosError
##[error]AxiosError: Request failed with status code 413
```

**Cache** (`julia-actions/cache@v3`):
```
error: could not lock config file /home/chrisrackauckas/.gitconfig: File exists
##[error]Process completed with exit code 255.
```
```
##[warning]uploadCacheArchiveSDK: Server failed to authenticate the request.
```

The `enable_telemetry` and `enable_cache` inputs were added in LuxDL/Lux.jl#1695 (defaults `true` for backward compatibility with other consumers). Setting them explicitly to `false` here makes NonlinearSolve.jl CI resilient to the self-hosted runner environment regardless of any future default changes upstream.

## Test plan

- [ ] CI jobs no longer fail from telemetry/cache infrastructure errors.
- [ ] All actual Julia test suites still run and report results normally.
- Note: this PR depends on LuxDL/Lux.jl#1695 being merged first for the inputs to be recognized. Until then, the unknown inputs are silently ignored by GitHub Actions (they just use the defaults from the upstream workflow definition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)