### PR TITLE
Avoid dense N×N Jacobian allocation for Anderson (#862)

### DIFF
--- a/ext/NonlinearSolveNLsolveExt.jl
+++ b/ext/NonlinearSolveNLsolveExt.jl
@@ -1,7 +1,7 @@
 module NonlinearSolveNLsolveExt
 
 using LineSearches: Static
-using NLsolve: NLsolve, OnceDifferentiable, nlsolve
+using NLsolve: NLsolve, NonDifferentiable, OnceDifferentiable, nlsolve
 
 using NonlinearSolveBase: NonlinearSolveBase, Utils, TraceMinimal, is_fw_wrapped, get_raw_f
 using NonlinearSolve: NonlinearSolve, NLsolveJL
@@ -29,7 +29,11 @@ function SciMLBase.__solve(
 
     f!, u0, resid = NonlinearSolveBase.construct_extension_function_wrapper(prob; alias_u0)
 
-    if prob.f.jac === nothing && alg.autodiff isa Symbol
+    # Anderson and Broyden do not use a Jacobian — use NonDifferentiable to avoid
+    # allocating a dense N×N Jacobian (matches NLsolve.nlsolve's own behavior).
+    if alg.method in (:anderson, :broyden)
+        df = NonDifferentiable(f!, Utils.safe_vec(u0), Utils.safe_vec(resid); inplace = true)
+    elseif prob.f.jac === nothing && alg.autodiff isa Symbol
         df = OnceDifferentiable(f!, u0, resid; alg.autodiff)
     else
         autodiff = alg.autodiff isa Symbol ? nothing : alg.autodiff

--- a/ext/NonlinearSolveSIAMFANLEquationsExt.jl
+++ b/ext/NonlinearSolveSIAMFANLEquationsExt.jl
@@ -18,6 +18,9 @@ function siamfanlequations_retcode_mapping(sol)
         return ReturnCode.Failure
     elseif sol.errcode == -1
         return ReturnCode.Default
+    elseif sol.errcode == -2
+        # aasol reports -2 when the Anderson iteration is diverging.
+        return ReturnCode.Unstable
     else
         error(lazy"Unknown SIAMFANLEquations return code: $(sol.errcode)")
     end
@@ -108,7 +111,13 @@ function SciMLBase.__solve(
                 )
             end
         else
-            if prob.f.jac === nothing && alg.autodiff === missing
+            # Anderson acceleration does not use a Jacobian — skip allocating FPS.
+            if method == :anderson
+                sol = aasol(
+                    f, u, m, zeros(T, N, 2 * m + 4);
+                    atol, rtol, maxit = maxiters, beta
+                )
+            elseif prob.f.jac === nothing && alg.autodiff === missing
                 FPS = zeros_like(u, N, N)
                 if method == :newton
                     sol = nsol(
@@ -118,11 +127,6 @@ function SciMLBase.__solve(
                     sol = ptcsol(
                         f, u, FS, FPS;
                         atol, rtol, maxit = maxiters, delta0 = delta, printerr
-                    )
-                elseif method == :anderson
-                    sol = aasol(
-                        f, u, m, zeros(T, N, 2 * m + 4);
-                        atol, rtol, maxit = maxiters, beta
                     )
                 end
             else

--- a/test/wrappers/fixedpoint_tests.jl
+++ b/test/wrappers/fixedpoint_tests.jl
@@ -106,3 +106,38 @@ end
     sol = solve(prob, NLsolveJL(; method = :anderson))
     @test_broken vec(sol.u)' * A[:, 3] ≈ 32.916472867168096
 end
+
+# Issue #862: NLsolveJL and SIAMFANLEquationsJL Anderson must NOT allocate a dense
+# N×N Jacobian (Anderson acceleration is Jacobian-free).
+@testitem "Anderson does not allocate dense Jacobian (#862)" tags = [:wrappers] begin
+    import NLsolve, SIAMFANLEquations
+
+    # N large enough that a dense N×N Float64 matrix would dominate the
+    # measured allocation, but small enough to solve quickly.
+    N = 3_200
+    # Simple fixed point: f(x) = 0 at x_i = 0.739... (cos(x) = x).
+    F!(F, x, p) = (F .= cos.(x) .- x)
+    x0 = fill(0.5, N)
+    prob = NonlinearProblem(NonlinearFunction(F!), x0)
+
+    # Cap iterations so per-iteration allocations don't dwarf the one-shot
+    # Jacobian allocation we're guarding against.
+    maxit = 10
+
+    # Warm up compilation
+    solve(prob, NLsolveJL(; method = :anderson, m = 5); maxiters = maxit)
+    solve(prob, SIAMFANLEquationsJL(; method = :anderson, m = 5); maxiters = maxit)
+
+    # An N×N Float64 matrix is 8·N² bytes ≈ 82 MB at N=3200.
+    dense_jac_bytes = 8 * N * N
+
+    allocs_nlsolve = @allocated solve(
+        prob, NLsolveJL(; method = :anderson, m = 5); maxiters = maxit
+    )
+    @test allocs_nlsolve < dense_jac_bytes ÷ 4
+
+    allocs_siam = @allocated solve(
+        prob, SIAMFANLEquationsJL(; method = :anderson, m = 5); maxiters = maxit
+    )
+    @test allocs_siam < dense_jac_bytes ÷ 4
+end


### PR DESCRIPTION
## Summary

Fixes #862. `NLsolveJL` and `SIAMFANLEquationsJL` unconditionally allocated a dense N×N Jacobian even when the user requested Anderson acceleration, which is a Jacobian-free method. The reporter hit OOM at N=50k (20 GB Jacobian).

- **NLsolveJL**: for `method ∈ (:anderson, :broyden)`, construct `NLsolve.NonDifferentiable` instead of `OnceDifferentiable`. Matches what `NLsolve.nlsolve` itself does ([NLsolve source](https://github.com/JuliaNLSolvers/NLsolve.jl/blob/master/src/nlsolve/nlsolve.jl#L46-L50)).
- **SIAMFANLEquationsJL**: dispatch `:anderson` to `aasol` before the `FPS = zeros(N, N)` allocation — only Newton / pseudo-transient need `FPS`.
- **SIAMFANLEquationsJL**: map aasol's `errcode == -2` (divergence) to `ReturnCode.Unstable` so a diverging Anderson run does not crash with an `error(lazy"Unknown SIAMFANLEquations return code: -2")`.

## Verification

On the issue's MRE at N=50k (dense Jacobian would be 20 GB):
```
NLsolveJL Anderson, 3 iterations:        9.2 MB (no OOM)
SIAMFANLEquationsJL Anderson, 3 iters:  11.3 MB (no OOM)
```

At the test size N=3200 (dense Jacobian = 82 MB):
```
Before fix: NLsolveJL allocates ~164 MB / solve (Jacobian + overhead)
After fix:  NLsolveJL allocates   ~0.8 MB / solve
After fix:  SIAMFANLEquationsJL   ~0.8 MB / solve
```

## Test plan

- [x] `wrappers` test group passes locally (`fixedpoint_tests.jl`, `rootfind_tests.jl`) on Julia 1.10
- [x] New test `Anderson does not allocate dense Jacobian (#862)` in `test/wrappers/fixedpoint_tests.jl` asserts total allocations are below `8·N²/4` — well below the dense-Jacobian threshold, but with headroom for solver state.
- [x] Manually confirmed the test fails if the pre-fix code path (`OnceDifferentiable`) is used (measured ~164 MB, threshold 20 MB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)