### PR TITLE
NonlinearSolveBase: accept verbose=nothing as default NonlinearVerbosity()

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.25.0"
+version = "2.25.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -65,6 +65,13 @@ function solve(
         end
     elseif verbose isa AbstractVerbosityPreset
         verbose = NonlinearVerbosity(verbose)
+    elseif verbose === nothing
+        # Wrapping `solve`s that forward a caller's `verbose` kwarg without
+        # owning the default (e.g. DiffEqBase → NonlinearSolve bridges) may
+        # pass `nothing` to mean "use the default". Treat it as such rather
+        # than letting `nothing` leak into downstream `verbose.field` accesses
+        # and fail with `getfield(::Nothing, …)`.
+        verbose = NonlinearVerbosity()
     end
 
     alias_spec = if haskey(kwargs, :alias) && kwargs[:alias] isa NonlinearAliasSpecifier
@@ -225,6 +232,13 @@ function init(
         end
     elseif verbose isa AbstractVerbosityPreset
         verbose = NonlinearVerbosity(verbose)
+    elseif verbose === nothing
+        # Wrapping `solve`s that forward a caller's `verbose` kwarg without
+        # owning the default (e.g. DiffEqBase → NonlinearSolve bridges) may
+        # pass `nothing` to mean "use the default". Treat it as such rather
+        # than letting `nothing` leak into downstream `verbose.field` accesses
+        # and fail with `getfield(::Nothing, …)`.
+        verbose = NonlinearVerbosity()
     end
 
     u0 = u0 !== nothing ? u0 : prob.u0


### PR DESCRIPTION
## Summary

Three `solve` entry points in `lib/NonlinearSolveBase/src/solve.jl` (top-level `solve` at lines 50, 194, 495) already normalize `Bool` and `AbstractVerbosityPreset` values of the `verbose` kwarg into a `NonlinearVerbosity`. Extend the branch set to also accept `nothing`, normalizing it to `NonlinearVerbosity()` (the default).

## Why

Wrapping `solve`s that forward a caller's `verbose` kwarg through to `NonlinearSolve` without owning the default may pass `nothing` to mean "inherit the default". Concrete call sites:

- `DiffEqBase` ↔ `NonlinearSolve` bridges used by stiff-ODE implicit solvers.
- `SteadyStateDiffEq.SSRootfind.__solve` forwards its kwargs directly to `NonlinearSolve.solve` (see SciML/SteadyStateDiffEq.jl#122 for the companion fix in the `DynamicSS` branch, where the inner kwargs go to an ODE solve instead).

Prior to this, a caller-forwarded `verbose = nothing` would skip both normalizing branches (`Bool`, `AbstractVerbosityPreset`), land in downstream `verbose.display_level` / `verbose.convergence_failure` field accesses, and fail with:

```
MethodError: no method matching getfield(::Nothing, …)
```

## Fix

One new `elseif verbose === nothing` branch per `solve` entry point, converting to `NonlinearVerbosity()`.

## Version

Bumps `NonlinearSolveBase` to 2.25.1 (patch — additive, non-breaking).