### PR TITLE
Fix nested ForwardDiff over NonlinearLeastSquaresProblem default vjp

### DIFF
--- a/lib/NonlinearSolveBase/src/autodiff.jl
+++ b/lib/NonlinearSolveBase/src/autodiff.jl
@@ -176,60 +176,52 @@ function nlls_generate_vjp_function(prob::NonlinearLeastSquaresProblem, sol, uu)
         # FunctionWrapper type mismatches with nested duals
         raw_f = get_raw_f(prob.f.f)
 
-        # When using ForwardDiff for the inner pullback, materialize the
-        # Jacobian and form `2 * J' * resid` directly. DI's pullback-via-
-        # pushforward emulation uses an output buffer keyed off `eltype(u)`,
-        # which fails when this closure is itself called under an outer
-        # ForwardDiff layer (e.g. `ForwardDiff.gradient(p -> sum(abs2,
-        # solve(NLLS(...; p)).u), p)`): the captured outer-Dual `p` makes
-        # the function output Dual while `u` stays Float64. Forming `J' * r`
-        # via `ForwardDiff.jacobian` (called by DI under AutoForwardDiff)
-        # is robust under nested Duals.
-        is_forwarddiff = autodiff isa AutoForwardDiff
-        if SciMLBase.isinplace(prob)
-            return @closure (
-                du, u, p,
-            ) -> begin
-                resid = Utils.safe_similar(du, length(sol.resid))
-                raw_f(resid, u, p)
-                if is_forwarddiff
-                    # Wrap IIP raw_f as OOP so ForwardDiff.jacobian allocates
-                    # an output buffer of the correctly promoted Dual type
-                    # under nested differentiation.
-                    ff_oop = @closure uu -> begin
+        # `DI.pullback` with `AutoForwardDiff` is emulated via pushforward into
+        # a buffer keyed off `eltype(u)`, which breaks when this vjp closure
+        # runs under an outer ForwardDiff layer (the function output becomes
+        # Dual while `u` stays Float64). For ForwardDiff we materialize the
+        # Jacobian and form `2·J'·r` directly — `DI.jacobian` here dispatches
+        # to `ForwardDiff.jacobian`, which handles nested Duals via fresh tags.
+        if autodiff isa AutoForwardDiff
+            if SciMLBase.isinplace(prob)
+                return @closure (du, u, p) -> begin
+                    ff = @closure uu -> begin
                         T = promote_type(eltype(uu), eltype(p))
-                        r = Utils.safe_similar(resid, T)
+                        r = Utils.safe_similar(uu, T, length(sol.resid))
                         raw_f(r, uu, p)
                         return r
                     end
-                    J = DI.jacobian(ff_oop, autodiff, u)
-                    mul!(reshape(du, 1, :), reshape(resid, 1, :), J, 2, false)
-                else
-                    # Using `Constant` lead to dual ordering issues
-                    ff = @closure (du, u) -> raw_f(du, u, p)
-                    resid2 = copy(resid)
-                    DI.pullback!(ff, resid2, (du,), autodiff, u, (resid,))
-                    @. du *= 2
+                    J = DI.jacobian(ff, autodiff, u)
+                    mul!(du, J', ff(u), 2, false)
+                    return nothing
                 end
+            else
+                return @closure (u, p) -> begin
+                    J = DI.jacobian(Base.Fix2(raw_f, p), autodiff, u)
+                    return 2 .* (J' * raw_f(u, p))
+                end
+            end
+        end
+
+        if SciMLBase.isinplace(prob)
+            return @closure (du, u, p) -> begin
+                resid = Utils.safe_similar(du, length(sol.resid))
+                raw_f(resid, u, p)
+                # Using `Constant` lead to dual ordering issues
+                ff = @closure (du, u) -> raw_f(du, u, p)
+                resid2 = copy(resid)
+                DI.pullback!(ff, resid2, (du,), autodiff, u, (resid,))
+                @. du *= 2
                 return nothing
             end
         else
-            return @closure (
-                u,
-                p,
-            ) -> begin
+            return @closure (u, p) -> begin
                 v = raw_f(u, p)
-                if is_forwarddiff
-                    J = DI.jacobian(Base.Fix2(raw_f, p), autodiff, u)
-                    res = 2 .* (J' * v)
-                    return res
-                else
-                    # Using `Constant` lead to dual ordering issues
-                    res = only(DI.pullback(Base.Fix2(raw_f, p), autodiff, u, (v,)))
-                    ArrayInterface.can_setindex(res) || return 2 .* res
-                    @. res *= 2
-                    return res
-                end
+                # Using `Constant` lead to dual ordering issues
+                res = only(DI.pullback(Base.Fix2(raw_f, p), autodiff, u, (v,)))
+                ArrayInterface.can_setindex(res) || return 2 .* res
+                @. res *= 2
+                return res
             end
         end
     end

--- a/lib/NonlinearSolveBase/src/autodiff.jl
+++ b/lib/NonlinearSolveBase/src/autodiff.jl
@@ -176,17 +176,41 @@ function nlls_generate_vjp_function(prob::NonlinearLeastSquaresProblem, sol, uu)
         # FunctionWrapper type mismatches with nested duals
         raw_f = get_raw_f(prob.f.f)
 
+        # When using ForwardDiff for the inner pullback, materialize the
+        # Jacobian and form `2 * J' * resid` directly. DI's pullback-via-
+        # pushforward emulation uses an output buffer keyed off `eltype(u)`,
+        # which fails when this closure is itself called under an outer
+        # ForwardDiff layer (e.g. `ForwardDiff.gradient(p -> sum(abs2,
+        # solve(NLLS(...; p)).u), p)`): the captured outer-Dual `p` makes
+        # the function output Dual while `u` stays Float64. Forming `J' * r`
+        # via `ForwardDiff.jacobian` (called by DI under AutoForwardDiff)
+        # is robust under nested Duals.
+        is_forwarddiff = autodiff isa AutoForwardDiff
         if SciMLBase.isinplace(prob)
             return @closure (
                 du, u, p,
             ) -> begin
                 resid = Utils.safe_similar(du, length(sol.resid))
                 raw_f(resid, u, p)
-                # Using `Constant` lead to dual ordering issues
-                ff = @closure (du, u) -> raw_f(du, u, p)
-                resid2 = copy(resid)
-                DI.pullback!(ff, resid2, (du,), autodiff, u, (resid,))
-                @. du *= 2
+                if is_forwarddiff
+                    # Wrap IIP raw_f as OOP so ForwardDiff.jacobian allocates
+                    # an output buffer of the correctly promoted Dual type
+                    # under nested differentiation.
+                    ff_oop = @closure uu -> begin
+                        T = promote_type(eltype(uu), eltype(p))
+                        r = Utils.safe_similar(resid, T)
+                        raw_f(r, uu, p)
+                        return r
+                    end
+                    J = DI.jacobian(ff_oop, autodiff, u)
+                    mul!(reshape(du, 1, :), reshape(resid, 1, :), J, 2, false)
+                else
+                    # Using `Constant` lead to dual ordering issues
+                    ff = @closure (du, u) -> raw_f(du, u, p)
+                    resid2 = copy(resid)
+                    DI.pullback!(ff, resid2, (du,), autodiff, u, (resid,))
+                    @. du *= 2
+                end
                 return nothing
             end
         else
@@ -195,11 +219,17 @@ function nlls_generate_vjp_function(prob::NonlinearLeastSquaresProblem, sol, uu)
                 p,
             ) -> begin
                 v = raw_f(u, p)
-                # Using `Constant` lead to dual ordering issues
-                res = only(DI.pullback(Base.Fix2(raw_f, p), autodiff, u, (v,)))
-                ArrayInterface.can_setindex(res) || return 2 .* res
-                @. res *= 2
-                return res
+                if is_forwarddiff
+                    J = DI.jacobian(Base.Fix2(raw_f, p), autodiff, u)
+                    res = 2 .* (J' * v)
+                    return res
+                else
+                    # Using `Constant` lead to dual ordering issues
+                    res = only(DI.pullback(Base.Fix2(raw_f, p), autodiff, u, (v,)))
+                    ArrayInterface.can_setindex(res) || return 2 .* res
+                    @. res *= 2
+                    return res
+                end
             end
         end
     end


### PR DESCRIPTION
> **Draft — please ignore until reviewed by @ChrisRackauckas.**

## Summary

Fixes the `MethodError: no method matching Float64(::ForwardDiff.Dual{...})` that triggers in CI for the `core` test group on master, e.g.

- `lib/SimpleNonlinearSolve/test/core/forward_diff_tests.jl:90` — `ForwardDiff.jl Integration NonlinearLeastSquaresProblem`
- `test/forward_ad_tests.jl:128` — `NLLS Hessian SciML/NonlinearSolve.jl#445`

These showed up unrelated to the PR that surfaced them (e.g. https://github.com/SciML/NonlinearSolve.jl/actions/runs/25295011499/job/74152282985, https://github.com/SciML/NonlinearSolve.jl/actions/runs/25295011493/job/74152283034) — they regress on master.

## Root cause

`NonlinearSolveBase.nlls_generate_vjp_function` (no user `jac`/`vjp` branch) uses `DI.pullback` with `AutoForwardDiff()` for small problems. Under `DifferentiationInterface`, `AutoForwardDiff`'s pullback is emulated via pushforward, and the emulation writes the cotangent into a buffer keyed off `eltype(u)`.

When the returned closure is itself called under an outer ForwardDiff layer — e.g. `ForwardDiff.gradient(p -> sum(abs2, solve(NLLS(...; p)).u), p)` or any `ForwardDiff.hessian` of a solve — the inner solve unwraps `p` to `Float64` and computes `uu::Vector{Float64}`, but the closure runs under `nonlinearsolve_∂f_∂p`'s `ForwardDiff.jacobian(Base.Fix1(vjp_fn, uu), p)`, where `p` is reseeded as `Vector{Dual}`. So inside the closure:

- `u::Vector{Float64}`
- `p::Vector{Dual{tag_outer, ...}}`
- `Base.Fix2(raw_f, p)(u)` outputs `Vector{Dual{tag_outer, ...}}`

DI's pushforward emulation then tries to splat the Dual cotangent values into a `Vector{Float64}` output buffer (`arroftup_to_tupofarr` in DI's `linalg.jl`), and `setindex!` rejects them.

## Fix

When the inner backend is `AutoForwardDiff`, materialize the Jacobian via `DI.jacobian` and form `2 * J' * resid` directly. `DI.jacobian` with `AutoForwardDiff` dispatches to `ForwardDiff.jacobian`, which handles nested Duals natively using fresh tags per layer.

For the IIP branch, the raw in-place function is wrapped as an OOP closure so that `ForwardDiff.jacobian` allocates an output buffer of the correctly-promoted Dual type. Using the raw IIP form would force the Dual nesting order of a pre-allocated output buffer, which doesn't compose under nested tags.

Reverse-mode backends — used for larger NLLS problems via `select_reverse_mode_autodiff` — keep going through `DI.pullback` (they don't have this issue, since reverse-mode AD has a real pullback rather than pushforward emulation).

Bumps `NonlinearSolveBase` to 2.25.1.

## Test plan

- [x] Local repro of `forward_diff_tests.jl:90`'s OOP NLLS test passes after fix (gradient computed correctly)
- [x] Local repro of `forward_ad_tests.jl:128`'s `NLLS Hessian` test passes for both the IIP gradient and the IIP Hessian after fix (matches `FiniteDiff.finite_difference_gradient` / `finite_difference_hessian` to atol=1e-3)
- [x] Full `SimpleNonlinearSolve` `core` group passes locally on Julia 1.11 (`35706 Pass, 4 Broken, 35710 Total | 11m11.3s`)
- [x] `Runic.jl --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)