### PR TITLE
Fix master CI: pin DifferentiationInterface < 0.7.17 (NLLS Hessian regression)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.19.0"
+version = "4.19.1"
 authors = ["SciML"]
 
 [deps]
@@ -84,7 +84,7 @@ BenchmarkTools = "1.4"
 BracketingNonlinearSolve = "1.6"
 CommonSolve = "0.2.4"
 ConcreteStructs = "0.2.3"
-DifferentiationInterface = "0.7.3"
+DifferentiationInterface = "0.7.3 - 0.7.16"
 ExplicitImports = "1.5"
 FastClosures = "0.3.2"
 FastLevenbergMarquardt = "0.1"

--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.25.0"
+version = "2.25.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]
@@ -70,7 +70,7 @@ ChainRulesCore = "1"
 CommonSolve = "0.2.4"
 Compat = "4.15"
 ConcreteStructs = "0.2.3"
-DifferentiationInterface = "0.6.16, 0.7"
+DifferentiationInterface = "0.6.16, 0.7.0 - 0.7.16"
 Enzyme = "0.13.12"
 EnzymeCore = "0.8"
 ExplicitImports = "1.10.1"

--- a/lib/NonlinearSolveFirstOrder/Project.toml
+++ b/lib/NonlinearSolveFirstOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveFirstOrder"
 uuid = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "2.1.1"
+version = "2.1.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -34,7 +34,7 @@ BandedMatrices = "1.7.5"
 BenchmarkTools = "1.5.0"
 CommonSolve = "0.2.4"
 ConcreteStructs = "0.2.3"
-DifferentiationInterface = "0.7.3"
+DifferentiationInterface = "0.7.3 - 0.7.16"
 Enzyme = "0.13.12"
 ExplicitImports = "1.5"
 FiniteDiff = "2.24"

--- a/lib/NonlinearSolveHomotopyContinuation/Project.toml
+++ b/lib/NonlinearSolveHomotopyContinuation/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveHomotopyContinuation"
 uuid = "2ac3b008-d579-4536-8c91-a1a5998c2f8b"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com> and contributors"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -27,7 +27,7 @@ ADTypes = "1.11.0"
 Aqua = "0.8"
 CommonSolve = "0.2.4"
 ConcreteStructs = "0.2.3"
-DifferentiationInterface = "0.7.3"
+DifferentiationInterface = "0.7.3 - 0.7.16"
 DocStringExtensions = "0.9.3"
 Enzyme = "0.13"
 HomotopyContinuation = "2.12.0"

--- a/lib/SciMLJacobianOperators/Project.toml
+++ b/lib/SciMLJacobianOperators/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLJacobianOperators"
 uuid = "19f34311-ddf3-4b8b-af20-060888a46c0e"
-version = "0.1.13"
+version = "0.1.14"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]
@@ -20,7 +20,7 @@ Aqua = "0.8.7"
 ArrayInterface = "7.16"
 ConcreteStructs = "0.2.3"
 ConstructionBase = "1.5"
-DifferentiationInterface = "0.7.3"
+DifferentiationInterface = "0.7.3 - 0.7.16"
 Enzyme = "0.13.11"
 ExplicitImports = "1.9.0"
 FastClosures = "0.3.2"

--- a/lib/SimpleNonlinearSolve/Project.toml
+++ b/lib/SimpleNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleNonlinearSolve"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 authors = ["SciML"]
-version = "2.11.1"
+version = "2.11.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -47,7 +47,7 @@ BracketingNonlinearSolve = "1.6"
 ChainRulesCore = "1.24"
 CommonSolve = "0.2.4"
 ConcreteStructs = "0.2.3"
-DifferentiationInterface = "0.7.3"
+DifferentiationInterface = "0.7.3 - 0.7.16"
 Enzyme = "0.13.11"
 ExplicitImports = "1.9"
 FastClosures = "0.3.2"


### PR DESCRIPTION
## Summary

Pins `DifferentiationInterface` compat to `< 0.7.17` across the NonlinearSolve package set to fix the NLLS Hessian master CI red ([test/forward_ad_tests.jl:128](https://github.com/SciML/NonlinearSolve.jl/blob/master/test/forward_ad_tests.jl#L128), \"NLLS Hessian SciML/NonlinearSolve.jl#445\").

**Note:** the branch is named `fix-master-mooncake` because the failure was originally triaged as part of a suspected Mooncake regression affecting three SciML repos. The actual root cause turned out to be a `DifferentiationInterface` regression — Mooncake is not involved in this failure path. Branch name kept for traceability.

## Root cause

`DifferentiationInterface` v0.7.17 (released 2026-04-29) included [PR #974](https://github.com/JuliaDiff/DifferentiationInterface.jl/pull/974) (\"fix: make wrong-mode pushforward/pullback return the correct array type\"), which rewrote `arroftup_to_tupofarr` in `DifferentiationInterface/src/utils/linalg.jl`:

```julia
# Before:
arroftup_to_tupofarr(x::AbstractArray{<:NTuple{B}}) where {B} =
    ntuple(b -> getindex.(x, b), Val(B))

# After:
function arroftup_to_tupofarr(tx::AbstractArray{<:NTuple{B, <:Number}},
                              x::AbstractArray{<:Number}) where {B}
    return ntuple(b -> similar(x) .= getindex.(tx, b), Val(B))
end
```

When nesting ForwardDiff (e.g. `ForwardDiff.hessian` over a `NonlinearLeastSquaresProblem` solve, which is what the NLLS Hessian test exercises), the eltype of `x` is `Dual{InnerTag, Float64, N}` while `tx` carries the outer-tagged Duals. `similar(x)` allocates with the inner-Dual eltype, and the `.= getindex.(tx, b)` assignment then tries to convert outer Duals into inner Duals, which falls through to `Float64(::ForwardDiff.Dual)` and fails with `MethodError`.

This is the exact stacktrace from the failing CI run ([run 25311679337](https://github.com/SciML/NonlinearSolve.jl/actions/runs/25311679337)):

```
MethodError: no method matching Float64(::ForwardDiff.Dual{...})
  ...
  @ DifferentiationInterface ~/.julia/packages/DifferentiationInterface/IS0Dg/src/utils/linalg.jl:47
  @ ./ntuple.jl:48 [inlined]
  @ ~/.julia/packages/DifferentiationInterface/IS0Dg/src/first_order/pullback.jl:498 [inlined]
  ...
  @ NonlinearSolveBaseForwardDiffExt ~/work/NonlinearSolve.jl/.../NonlinearSolveBaseForwardDiffExt.jl:178
```

## Bisect evidence

| Date       | Commit  | DI version | Status  |
|------------|---------|------------|---------|
| 2026-04-25 | 0ea19b8 | 0.7.16     | green   |
| 2026-04-27 | b15bf2b | 0.7.17     | red     |
| 2026-05-04 | d637062 | 0.7.17     | red     |

Between green and red, only a docs commit (`b15bf2b`) landed in NonlinearSolve. The DI bump from 0.7.16 → 0.7.17 happened in the resolver due to compat allowing the new release.

## Fix

Pin DI compat to `\"0.6.16, 0.7.3 - 0.7.16\"` (NonlinearSolveBase) and `\"0.7.3 - 0.7.16\"` (others) across:

- `Project.toml` (NonlinearSolve)
- `lib/NonlinearSolveBase/Project.toml`
- `lib/NonlinearSolveFirstOrder/Project.toml`
- `lib/NonlinearSolveHomotopyContinuation/Project.toml`
- `lib/SciMLJacobianOperators/Project.toml`
- `lib/SimpleNonlinearSolve/Project.toml`

Patch versions bumped accordingly.

## Follow-up

This is a known-bad-version pin, not a real fix. The upstream regression should be reported to JuliaDiff/DifferentiationInterface.jl with a minimal reproducer; once a 0.7.x release fixes it, the upper bound here should be relaxed.

I have not opened the upstream issue (per CLAUDE.md, JuliaDiff is not a SciML-org repo and requires explicit permission). Recommend asking the DI maintainers (gdalle / adrhill) to either revert the `arroftup_to_tupofarr` rewrite or make it preserve the actual eltype of `tx` (e.g. via `similar(x, eltype(eltype(tx)))` or an `ntuple(b -> getindex.(tx, b), Val(B))`-style fallback when `eltype(tx) !== eltype(x)`).

## Test plan

- [ ] CI passes on this branch (NLLS Hessian test in particular)
- [ ] Other affected tests (forward_ad_tests.jl, core_tests.jl) remain green
- [ ] Once upstream DI 0.7.18+ ships a fix, relax the upper bound in a follow-up PR

---

**Please ignore until reviewed by @ChrisRackauckas.**

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)