### PR TITLE
Fix Ensemble Nonlinear Problems test under SciMLBase 3.x prob_func API

### DIFF
--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -173,7 +173,8 @@ end
 end
 
 @testitem "Ensemble Nonlinear Problems" tags = [:nopre] begin
-    prob_func(prob, i, repeat) = remake(prob; u0 = prob.u0[:, i])
+    prob_func(prob, i::Integer, repeat) = remake(prob; u0 = prob.u0[:, i])
+    prob_func(prob, ctx) = remake(prob; u0 = prob.u0[:, ctx.sim_id])
 
     prob_nls_oop = NonlinearProblem((u, p) -> u .* u .- p, rand(4, 128), 2.0)
     prob_nls_iip = NonlinearProblem((du, u, p) -> du .= u .* u .- p, rand(4, 128), 2.0)


### PR DESCRIPTION
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

The `Ensemble Nonlinear Problems` test in `test/core_tests.jl:175` errors on `master` (and on any PR running CI against current SciMLBase) with:

```
MethodError: no method matching prob_func(::NonlinearProblem{...}, ::SciMLBase.EnsembleContext{...})
Closest candidates are:
  prob_func(::Any, ::Any, ::Any)
```

SciMLBase 3 dropped arity detection on `EnsembleProblem.prob_func` and now calls it as `prob_func(prob, ctx::EnsembleContext)` (single 2-arg form). SciMLBase 2.x calls it as `prob_func(prob, i, repeat)`. The test only defined the 3-arg form, so it now fails under the resolved SciMLBase 3.x.

`NonlinearSolve`'s `Project.toml` still allows `SciMLBase = "2.154, 3"`, so we keep dual-version support by defining both methods and letting dispatch pick:

```julia
prob_func(prob, i::Integer, repeat) = remake(prob; u0 = prob.u0[:, i])
prob_func(prob, ctx) = remake(prob; u0 = prob.u0[:, ctx.sim_id])
```

This is the same trick docs in SciMLBase 3 use (`ctx.sim_id`) while still matching the SciMLBase 2.x 3-arg call site at `basic_ensemble_solve.jl:242`.

## Verification

- Reproduced the original `MethodError` locally on Julia 1.11 + SciMLBase 3.13.0 — matches the CI failure on run [25933443375](https://github.com/SciML/NonlinearSolve.jl/actions/runs/25933443375) and [25989281906](https://github.com/SciML/NonlinearSolve.jl/actions/runs/25989281906/job/76392368261?pr=932).
- After the fix:
  - Standalone reproducer over all 4 problem types × `EnsembleThreads()` / `EnsembleSerial()` passes on **SciMLBase 3.13.0**.
  - Same reproducer pinned to **SciMLBase 2.154.0** (the lower compat bound) also passes — the 3-arg method is the one dispatched there.
  - Ran the actual `@testitem "Ensemble Nonlinear Problems"` via `ReTestItems.runtests(...; name = "Ensemble Nonlinear Problems")` against the dev'd packages — `Pass | Total: 8 | 8`.

## Test plan

- [ ] CI green on `core_tests.jl` (group: `nopre`).
- [ ] Downgrade CI green (SciMLBase 2.154 lower bound still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)