### PR TITLE
test/cuda: tolerate upstream GPUCompiler deprecation warnings

### DIFF
--- a/test/cuda_test_helpers.jl
+++ b/test/cuda_test_helpers.jl
@@ -1,0 +1,30 @@
+# Helpers shared between CUDA `@testitem`s in `cuda_tests.jl`. Each `@testitem`
+# runs in a fresh module on its own worker, so this file is `include`d from
+# inside each one.
+
+# Variant of `@test_nowarn` that ignores benign GPUCompiler deprecation warnings
+# emitted by CUDA.jl's libdevice linking on released CUDA.jl versions (<= v6.1.0).
+# The upstream fix is on CUDA.jl master (commit dbddf1f46, "Adapt to
+# GPUCompiler.jl changes, using lazy-linking") but is not in any tagged release
+# yet, so we filter only those exact upstream warnings and continue to fail on
+# anything else (including any warning that NonlinearSolve itself emits).
+const _GPUCOMPILER_DEPRECATION_PATTERNS = (
+    r"┌ Warning: 3-arg `link_libraries!\(job, mod, undefined_fns\)` is deprecated.*?\n(?:[│└].*?\n)+"s,
+    r"┌ Warning: `GPUCompiler\.link_library!` is deprecated.*?\n(?:[│└].*?\n)+"s,
+)
+
+_strip_known_gpu_warnings(s::AbstractString) = foldl(
+    (acc, pat) -> replace(acc, pat => ""),
+    _GPUCOMPILER_DEPRECATION_PATTERNS;
+    init = String(s),
+)
+
+macro test_nowarn_except_gpu_deprecations(ex)
+    return quote
+        Test.@test_warn (s -> begin
+            filtered = $(_strip_known_gpu_warnings)(s)
+            print(stderr, filtered)
+            isempty(filtered)
+        end) $(esc(ex))
+    end
+end

--- a/test/cuda_tests.jl
+++ b/test/cuda_tests.jl
@@ -1,5 +1,6 @@
 @testitem "CUDA Tests" tags = [:cuda] skip = :(!isempty(VERSION.prerelease)) begin
-    using CUDA, NonlinearSolve, LinearSolve, StableRNGs, ADTypes
+    using CUDA, NonlinearSolve, LinearSolve, StableRNGs, ADTypes, Test
+    include(joinpath(@__DIR__, "cuda_test_helpers.jl"))
 
     if CUDA.functional()
         CUDA.allowscalar(false)
@@ -31,7 +32,9 @@
 
         @testset "[IIP] GPU Solvers" begin
             @testset "$(nameof(typeof(alg)))" for alg in SOLVERS
-                @test_nowarn sol = solve(prob, alg; abstol = 1.0f-5, reltol = 1.0f-5)
+                @test_nowarn_except_gpu_deprecations sol = solve(
+                    prob, alg; abstol = 1.0f-5, reltol = 1.0f-5
+                )
             end
         end
 
@@ -41,7 +44,9 @@
 
         @testset "[OOP] GPU Solvers" begin
             @testset "$(nameof(typeof(alg)))" for alg in SOLVERS
-                @test_nowarn sol = solve(prob, alg; abstol = 1.0f-5, reltol = 1.0f-5)
+                @test_nowarn_except_gpu_deprecations sol = solve(
+                    prob, alg; abstol = 1.0f-5, reltol = 1.0f-5
+                )
             end
         end
     end
@@ -49,6 +54,7 @@ end
 
 @testitem "Termination Conditions: Allocations" tags = [:cuda] skip = :(!isempty(VERSION.prerelease)) begin
     using CUDA, NonlinearSolveBase, Test, LinearAlgebra
+    include(joinpath(@__DIR__, "cuda_test_helpers.jl"))
 
     if CUDA.functional()
         CUDA.allowscalar(false)
@@ -65,7 +71,7 @@ end
 
         @testset begin
             @testset "Mode: $(tcond)" for tcond in TERMINATION_CONDITIONS
-                @test_nowarn NonlinearSolveBase.check_convergence(
+                @test_nowarn_except_gpu_deprecations NonlinearSolveBase.check_convergence(
                     tcond(), du, u, uprev, 1.0e-3, 1.0e-3
                 )
             end
@@ -74,7 +80,7 @@ end
                 for nfn in (
                         Base.Fix1(maximum, abs), Base.Fix2(norm, 2), Base.Fix2(norm, Inf),
                     )
-                    @test_nowarn NonlinearSolveBase.check_convergence(
+                    @test_nowarn_except_gpu_deprecations NonlinearSolveBase.check_convergence(
                         tcond(nfn), du, u, uprev, 1.0e-3, 1.0e-3
                     )
                 end


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Summary
Fixes the GPU CI failure on master (run https://github.com/SciML/NonlinearSolve.jl/actions/runs/26425154624):

```
Error in testset "Mode: NonlinearSolveBase.RelTerminationMode"  -> Test Failed (@test_nowarn)
Error in testset "GeneralizedFirstOrderAlgorithm"               -> Test Failed (@test_nowarn)
```

Both failures are the same root cause: `@test_nowarn` captures *all* stderr, and recent GPUCompiler.jl (>=1.13.0) releases emit two `Base.depwarn`s during CUDA's libdevice linking:

- `3-arg link_libraries!(job, mod, undefined_fns) is deprecated; migrate your override to the 2-arg form ...`
- `GPUCompiler.link_library! is deprecated; call LLVM.link!(mod, copy(lib)) directly ...`

These come from `GPUCompiler/src/deprecated.jl:15` and are triggered by CUDA.jl's `CUDACore/src/compiler/compilation.jl`, which still calls the deprecated 3-arg `link_libraries!` and `GPUCompiler.link_library!`. NonlinearSolve.jl is not the producer.

## Why we cannot fix this upstream-only
The fix is already on **CUDA.jl master** (commit `dbddf1f46`, "Adapt to GPUCompiler.jl changes, using lazy-linking"), but no tagged CUDA.jl release contains it yet — the latest is v6.1.0, which still calls the deprecated APIs. So we cannot resolve it from NonlinearSolve by tightening a compat bound; there is no version to pin to.

## What this PR does
- Adds `test/cuda_test_helpers.jl` with a focused macro `@test_nowarn_except_gpu_deprecations`. It captures stderr like `@test_nowarn`, strips only those two specific upstream deprecation warning blocks via tight regexes, and asserts the remainder is empty.
- Updates the two failing `@test_nowarn` call sites in `test/cuda_tests.jl` to use the new macro.
- Each `@testitem` `include`s the helper (testitems run in fresh modules).

Crucially, the macro preserves the **original intent** of these `@test_nowarn` calls: any *other* warning (in particular anything emitted by NonlinearSolve itself — scalar-indexing, allocation, CPU-fallback warnings, etc.) still fails the test. We are filtering exactly two upstream deprecation message bodies and nothing else.

A comment at the top of the helper file documents the rationale and the cleanup step once a CUDA.jl release containing `dbddf1f46` ships: delete the helper and restore the original `@test_nowarn` calls.

## Verification
**GPU CI cannot be reproduced locally** (no GPU available in this environment), so the only true confirmation will come from the SciML GPU runner picking this branch up. Locally I verified:

- `Pkg.instantiate()` and precompile succeed on the patched project (Julia 1.12.4).
- `test/cuda_tests.jl` and `test/cuda_test_helpers.jl` parse cleanly.
- In a sandbox `julia` session, the `@test_nowarn_except_gpu_deprecations` macro:
  - **passes** when stderr contains only the two known deprecation blocks (verbatim from the CI log), and
  - **fails** (Test.FallbackTestSetException) when stderr contains any other warning.

## Test plan
- [ ] GPU CI run on this PR — the two previously failing testsets pass while continuing to catch genuine NonlinearSolve warnings.