### PR TITLE
NonlinearSolveBase: bring solve_up Enzyme rule to parity with DiffEqBase (MTK DAE init under runtime activity)

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.29.0"
+version = "2.29.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseEnzymeExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseEnzymeExt.jl
@@ -88,12 +88,20 @@ _accum_nested!(::Any, ::Nothing) = nothing
 _accum_nested!(::Nothing, ::Any) = nothing
 _accum_nested!(::Nothing, ::Nothing) = nothing
 
+# `solve_up`'s differentiable inputs (prob/u0/p) are positional; its keyword
+# arguments are solver configuration (abstol/reltol/saveat/sensealg/...). Mark
+# them inactive so the custom rule applies when this `solve_up` is reached under
+# `set_runtime_activity` (e.g. the MTK DAE init NonlinearProblem solve), where a
+# config kwarg may otherwise be promoted to active and raise
+# NonConstantKeywordArgException. Mirrors the DiffEqBase `solve_up` declaration.
+Enzyme.EnzymeRules.inactive_kwarg(::typeof(NonlinearSolveBase.solve_up), prob, sensealg::Union{Nothing, SciMLBase.AbstractSensitivityAlgorithm}, u0, p, args...; kwargs...) = nothing
+
+_solve_up_rt_valtype(::Type{<:Enzyme.Annotation{T}}) where {T} = T
+
 function Enzyme.EnzymeRules.augmented_primal(
         config::Enzyme.EnzymeRules.RevConfigWidth{1},
         func::Const{typeof(NonlinearSolveBase.solve_up)}, ::Type{RT}, prob,
-        sensealg::Union{
-            Const{Nothing}, Const{<:SciMLBase.AbstractSensitivityAlgorithm},
-        },
+        sensealg::Enzyme.Annotation{<:Union{Nothing, SciMLBase.AbstractSensitivityAlgorithm}},
         u0, p, args...; kwargs...
     ) where {RT <: Enzyme.Annotation}
     @inline function copy_or_reuse(val, idx)
@@ -115,7 +123,18 @@ function Enzyme.EnzymeRules.augmented_primal(
         kwargs...
     )
 
-    dres = Enzyme.make_zero(res[1])
+    mz = Enzyme.make_zero(res[1])
+    # As in DiffEqBase's solve_up rule: when the return slot is abstract and the
+    # solution's guessed activity is MixedDuplicated, the shadow must be a
+    # `Ref`-wrapped value (Enzyme's by-reference MixedDuplicated representation),
+    # otherwise `create_activity_wrapper` builds `MixedDuplicated(::Solution)` and
+    # errors. The reverse rule dereferences it before handing it to the pullback.
+    dres = if Base.isabstracttype(_solve_up_rt_valtype(RT)) &&
+            (Enzyme.guess_activity(Core.Typeof(res[1]), Enzyme.Reverse) <: Enzyme.MixedDuplicated)
+        Ref(mz)
+    else
+        mz
+    end
     primal = EnzymeRules.needs_primal(config) ? res[1] : nothing
     shadow = EnzymeRules.needs_shadow(config) ? dres : nothing
     tup = (dres, res[2])
@@ -126,13 +145,13 @@ end
 function Enzyme.EnzymeRules.reverse(
         config::Enzyme.EnzymeRules.RevConfigWidth{1},
         func::Const{typeof(NonlinearSolveBase.solve_up)}, ::Type{RT}, tape, prob,
-        sensealg::Union{
-            Const{Nothing}, Const{<:SciMLBase.AbstractSensitivityAlgorithm},
-        },
+        sensealg::Enzyme.Annotation{<:Union{Nothing, SciMLBase.AbstractSensitivityAlgorithm}},
         u0, p, args...; kwargs...
     ) where {RT <: Enzyme.Annotation}
     dres, clos = tape
-    dargs = clos(dres)
+    # unwrap the Ref-wrapped MixedDuplicated shadow produced by augmented_primal
+    dval = dres isa Base.RefValue ? dres[] : dres
+    dargs = clos(dval)
     # Mirror the `diff_tunables` choice the inner adjoint will make. When the
     # user passes a concrete sensealg, honor its `diff_tunables` field. When
     # the outer sensealg is `nothing` (default), `_concrete_solve_adjoint`
@@ -159,6 +178,11 @@ function Enzyme.EnzymeRules.reverse(
         if ptr isa Enzyme.Const
             continue
         end
+        # `sensealg` is inactive config; skip its slot whether it arrived as
+        # Const or a runtime-activity-promoted Duplicated/MixedDuplicated.
+        if ptr === sensealg
+            continue
+        end
         if darg == ChainRulesCore.NoTangent()
             continue
         end
@@ -168,8 +192,14 @@ function Enzyme.EnzymeRules.reverse(
             _accum_tangent!(ptr.dval, darg; diff_tunables)
         end
     end
-    Enzyme.make_zero!(dres.u)
-    return ntuple(_ -> nothing, Val(length(args) + 4))
+    Enzyme.make_zero!(dval.u)
+    # One return slot per (prob, sensealg, u0, p, args...). Active args (e.g. the
+    # init polyalgorithm promoted to `Active` under runtime activity) require a
+    # cotangent value, not `nothing`; these are inactive config, so return a
+    # zeroed value. Const/Duplicated/MixedDuplicated slots return `nothing`.
+    return map(_rev_arg_cotangent, (prob, sensealg, u0, p, args...))
 end
+
+@inline _rev_arg_cotangent(x) = x isa Enzyme.Active ? Enzyme.make_zero(x.val) : nothing
 
 end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Summary

`NonlinearSolveBase`'s `solve_up` Enzyme rule (`NonlinearSolveBaseEnzymeExt.jl`) is a clone of the *older* DiffEqBase `solve_up` rule and is missing the modernizations DiffEqBase has since received. This surfaces when reverse-mode Enzyme runs through an MTK DAE solve whose initialization solves a `NonlinearProblem` (e.g. `BrownFullBasicInit` / `DefaultInit`) under `set_runtime_activity` — exactly the `SciMLSensitivity` `test/mtk.jl` Enzyme path. The rule hits four errors in sequence; each fix advances past the previous error:

1. **`NonConstantKeywordArgException`** — no `inactive_kwarg` declaration. `solve_up`'s differentiable inputs (`prob`/`u0`/`p`) are positional; kwargs are solver config → declare them inactive (mirrors the DiffEqBase declaration).
2. **`MethodError` on `augmented_primal`/`reverse`** — the rule required `sensealg::Const`, but under runtime activity a `SteadyStateAdjoint` sensealg arrives `Duplicated`. Widen to `Enzyme.Annotation{<:Union{Nothing, AbstractSensitivityAlgorithm}}` and skip the sensealg slot in reverse (mirrors OrdinaryDiffEq #3678/#3681).
3. **`MethodError: MixedDuplicated(::NonlinearSolution)`** — the shadow must be `Ref`-wrapped for the abstract-MixedDuplicated case; dereference in reverse (mirrors OrdinaryDiffEq #3700).
4. **`ReverseRuleReturnError`** — the auto-selected init polyalgorithm is promoted to `Active` under runtime activity, so the reverse rule must return a cotangent (`make_zero`) for `Active` args, not `nothing`.

The changes are no-ops for the existing concrete-`Const`-sensealg / non-abstract paths.

## Verification

- Each change was confirmed to advance the MTK DAE Enzyme test past its specific error, in sequence (env: Julia 1.11, Enzyme 0.13.152, DiffEqBase 7.5.4, ModelingToolkit 11.26.6, SciMLSensitivity 7.111.1).
- These are exact analogs of the DiffEqBase `solve_up` fixes that are gradient-verified (OrdinaryDiffEq #3700 / SciMLSensitivity #1463 reproduce a bit-for-bit / ForwardDiff-matching gradient).
- A non-singular `BrownFullBasicInit` DAE-init gradient check through this path (vs ForwardDiff) is running; I'll post the result.

## Relationship / remaining blocker

Companion to **SciML/SciMLSensitivity#1463** (the SciMLSensitivity-side fixes for the same MTK DAE + `GaussAdjoint(EnzymeVJP())` chain).

`SciMLSensitivity` `test/mtk.jl` still does not fully pass after these fixes, but for a **separate, backend-independent** reason: several of its setups use `guesses = [w2 => 0.0]` with the constraint `0 = x² + y² - w2²`, making the algebraic-constraint Jacobian `dhda = -2·w2` singular in the GaussAdjoint DAE adjoint (`SciMLSensitivity/src/adjoint_common.jl:770`, `dhda' \ gᵤ`). That `SingularException` is hit by Zygote/ReverseDiff through the same `GaussAdjoint` too (verification in progress) — i.e. it is not related to these Enzyme-rule fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
