### PR TITLE
NonlinearSolveBase: unwrap FunctionWrappersWrapper on the EnzymeOriginator adjoint path (MTK DAE init)

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.30.0"
+version = "2.30.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -738,6 +738,19 @@ function _solve_adjoint(
     alg = extract_alg(args, kwargs, prob.kwargs)
     _prob = get_concrete_problem(prob; u0 = u0, p = p, kwargs...)
 
+    # Enzyme cannot differentiate through FunctionWrappers' `llvmcall`, so its
+    # traced forward solve runs on the unwrapped function (see
+    # `maybe_unwrap_prob_for_enzyme`, #940). That unwrap is keyed off the solver's
+    # own autodiff, which for an MTK DAE initialization is ForwardDiff even when
+    # the *outer* differentiation is Enzyme — so it does not fire here. Key off
+    # the originator instead: the EnzymeOriginator adjoint primal must have the
+    # same (unwrapped) type as Enzyme's traced forward, otherwise the custom
+    # `solve_up` rule's returned primal type mismatches the inferred return type
+    # (`EnzymeRuntimeException: Expected return type of primal to be ...`).
+    if originator isa SciMLBase.EnzymeOriginator && is_fw_wrapped(_prob.f.f)
+        @set! _prob.f.f = get_raw_f(_prob.f.f)
+    end
+
     if has_kwargs(_prob)
         kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
     end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Summary

Follow-up to #944 (which fixed the `solve_up` Enzyme rule plumbing). With that landed, Enzyme reverse-mode through an MTK DAE solve gets *into* the initialization `NonlinearProblem` solve and then fails with:

```
EnzymeRuntimeException: Enzyme execution failed.
Expected return type of primal to be SciMLBase.NonlinearSolution{...} but did not find a value of that type
  get_initial_values  (the OverrideInit init solve, under Enzyme reverse)
```

**Root cause — a `FunctionWrappersWrapper` type-instability:**
- The custom `solve_up` rule re-runs the solve via `_solve_adjoint` → `get_concrete_problem`, which `maybe_wrap_nonlinear_f`-wraps the IIP function in `AutoSpecializeCallable{FunctionWrappersWrapper}` (confirmed by instrumenting `typeof(res[1])`).
- That wrapping is type-unstable. Enzyme's *traced forward* unwraps it via `maybe_unwrap_prob_for_enzyme` (#940), so the return type Enzyme infers carries the bare `GeneratedFunctionWrapper`; the *adjoint* re-wraps it, so the rule's primal type no longer matches → Enzyme aborts.
- `maybe_unwrap_prob_for_enzyme` keys off the **solver's own** autodiff, which for an MTK DAE init is **ForwardDiff** even when the *outer* differentiation is Enzyme — so it doesn't fire here.

**Fix:** key off the originator instead — unwrap `_prob.f.f` via `get_raw_f` when `originator isa EnzymeOriginator`, so the adjoint primal matches the (unwrapped) type Enzyme's traced forward produces. No-op for non-Enzyme originators and for already-unwrapped functions.

## Verification status (please read)

- The fix is a 13-line addition; the edit is confirmed sound (the stack loads and forward-solves with `retcode = Success`).
- **Strong evidence it clears the error, but not yet a completed end-to-end gradient check.** Pre-fix, the MTK-init Enzyme reverse threw the `EnzymeRuntimeException` ~21 min into compilation; with the fix, the run reached ~26 min in the *full* reverse compile **with no such error** before the process was OOM-killed.
- The completed correct-gradient comparison (vs ForwardDiff) is **pending**: the test machine is under heavy multi-agent load and repeatedly system-OOM-kills this ~26-min Enzyme compile (`oom_kill 77` on the session cgroup). I'll post the gradient comparison once it completes in a less-contended window / via CI.

Companion to **SciML/SciMLSensitivity#1463**; built on **#944** (merged) and DiffEqBase 7.5.4 / OrdinaryDiffEq#3700 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
