### PR TITLE
NonlinearSolveBase: mark nonlinear-solve algorithms Enzyme-inactive

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.30.1"
+version = "2.30.2"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseEnzymeExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseEnzymeExt.jl
@@ -96,6 +96,21 @@ _accum_nested!(::Nothing, ::Nothing) = nothing
 # NonConstantKeywordArgException. Mirrors the DiffEqBase `solve_up` declaration.
 Enzyme.EnzymeRules.inactive_kwarg(::typeof(NonlinearSolveBase.solve_up), prob, sensealg::Union{Nothing, SciMLBase.AbstractSensitivityAlgorithm}, u0, p, args...; kwargs...) = nothing
 
+# Nonlinear-solve algorithms are pure solver configuration (Vals, Rationals,
+# Nothing/Missing sentinels, nested immutable sub-algorithms, and a ForwardDiff
+# tag type parameter) with no differentiable floating-point data. When a
+# `NonlinearProblem` is solved under `Enzyme.set_runtime_activity(Reverse)` — e.g.
+# the MTK DAE-initialization solve reached through `solve_up` with the default
+# `NonlinearSolvePolyAlgorithm` as a positional `args...` — Enzyme can otherwise
+# promote that configuration argument to `Duplicated`. That trips the
+# `roots_activep != activep` assertion in `enzyme_custom_setup_args`, or leaves a
+# spurious algorithm shadow that corrupts activity bookkeeping for the genuinely
+# active `u0`/`p` (silently dropping a cotangent component). Declaring the whole
+# algorithm hierarchy inactive forces `Const`, so `activep == roots_activep`.
+# Mirrors SciMLBase's `inactive_type(::Type{<:AbstractSensitivityAlgorithm})` and
+# LinearSolve's `inactive_type(::Type{<:SciMLLinearSolveAlgorithm})`.
+Enzyme.EnzymeRules.inactive_type(::Type{<:NonlinearSolveBase.AbstractNonlinearSolveAlgorithm}) = true
+
 _solve_up_rt_valtype(::Type{<:Enzyme.Annotation{T}}) where {T} = T
 
 function Enzyme.EnzymeRules.augmented_primal(

--- a/lib/NonlinearSolveBase/test/enzyme_inactive_algorithm.jl
+++ b/lib/NonlinearSolveBase/test/enzyme_inactive_algorithm.jl
@@ -1,0 +1,37 @@
+module EnzymeInactiveAlgorithmTests
+
+using Test
+using NonlinearSolveBase
+# `NonlinearSolveBaseEnzymeExt` (which carries the `inactive_type` declaration)
+# is triggered by `["ChainRulesCore", "Enzyme"]`; both must be loaded for the
+# extension method to be active.
+using ChainRulesCore
+using Enzyme
+
+# Nonlinear-solve algorithms are pure solver configuration (Vals, Rationals,
+# Nothing/Missing sentinels, nested immutable sub-algorithms, and a ForwardDiff
+# tag type parameter) with no differentiable floating-point data. When a
+# `NonlinearProblem` is solved under `Enzyme.set_runtime_activity(Reverse)` — e.g.
+# the ModelingToolkit DAE-initialization solve reached through `solve_up` with the
+# default `NonlinearSolvePolyAlgorithm` as a positional `args...` — Enzyme can
+# otherwise promote that configuration argument to `Duplicated`, tripping the
+# `roots_activep != activep` assertion in `enzyme_custom_setup_args` (or leaving a
+# spurious algorithm shadow that corrupts activity bookkeeping for the genuinely
+# active inputs). `NonlinearSolveBaseEnzymeExt` declares the whole
+# `AbstractNonlinearSolveAlgorithm` hierarchy inactive so Enzyme treats it as
+# `Const`. This is a regression test for that declaration.
+@testset "Enzyme inactive_type covers the nonlinear-solve algorithm hierarchy" begin
+    @test Enzyme.EnzymeRules.inactive_type(NonlinearSolveBase.AbstractNonlinearSolveAlgorithm)
+
+    # The abstract-supertype declaration must cover the default polyalgorithm
+    # wrapper (the argument actually promoted in the DAE-init solve) and any
+    # concrete sub-algorithm.
+    poly = NonlinearSolveBase.NonlinearSolvePolyAlgorithm((nothing,))
+    @test poly isa NonlinearSolveBase.AbstractNonlinearSolveAlgorithm
+    @test Enzyme.EnzymeRules.inactive_type(typeof(poly))
+
+    # Sanity: a genuinely differentiable type is not affected by this declaration.
+    @test !Enzyme.EnzymeRules.inactive_type(Vector{Float64})
+end
+
+end

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -138,4 +138,8 @@ using InteractiveUtils, Test
     @testset "PolyAlgorithm solution type is concrete (#878)" begin
         include("polyalg_solution_type.jl")
     end
+
+    @testset "EnzymeExt algorithms are inactive_type" begin
+        include("enzyme_inactive_algorithm.jl")
+    end
 end


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft, opened by an agent.

## What

Declare the whole `AbstractNonlinearSolveAlgorithm` hierarchy `Enzyme.EnzymeRules.inactive_type`, in `NonlinearSolveBaseEnzymeExt`:

```julia
Enzyme.EnzymeRules.inactive_type(::Type{<:NonlinearSolveBase.AbstractNonlinearSolveAlgorithm}) = true
```

## Why

When a `NonlinearProblem` is solved under `Enzyme.set_runtime_activity(Reverse)` — most notably the **ModelingToolkit DAE-initialization** solve reached through `get_initial_values` → `solve_up` — the default `NonlinearSolvePolyAlgorithm` arrives at the `solve_up` custom Enzyme rule as a positional `args...`. Nonlinear-solve algorithms are pure solver configuration (`Val`s, `Rational`s, `Nothing`/`Missing` sentinels, nested immutable sub-algorithms, and a `ForwardDiff` tag type parameter) with **no differentiable floating-point data**, but without an inactivity declaration `set_runtime_activity` promotes that configuration argument to `Duplicated`. That manifests, nondeterministically, as either:

- the `roots_activep (DFT_CONSTANT) != activep (DFT_DUP_ARG)` assertion inside Enzyme's `enzyme_custom_setup_args`, or
- a spurious algorithm shadow that corrupts activity bookkeeping for the genuinely-active `u0`/`p`, silently dropping a cotangent component.

Marking the algorithm hierarchy inactive forces `Const`, so `activep == roots_activep == DFT_CONSTANT`. This mirrors the established, shipping pattern in `SciMLBase` (`inactive_type(::Type{<:AbstractSensitivityAlgorithm})`) and `LinearSolve` (`inactive_type(::Type{<:SciMLLinearSolveAlgorithm})`).

This is type-safe (the abstract supertype covers the polyalg wrapper, every nested member algorithm, and the bare-algorithm case) and semantically exact (algorithms are never a differentiation target — gradients flow only through `prob`/`u0`/`p`). It is precompile-safe: a more-specific method on an already-loaded `EnzymeRules.inactive_type`, no parent-module method overwritten.

## Context

This is the NonlinearSolveBase half of getting **Enzyme reverse-mode AD to work on the outside of an MTK DAE solve** (the `within_autodiff` wrap-skip and the `inactive_kwarg` for the `solve_up` rule are already merged). A downstream SciMLSensitivity PR will flip the corresponding `mtk.jl` test on and bump its lower bound once this is tagged.

## Test

Adds `lib/NonlinearSolveBase/test/enzyme_inactive_algorithm.jl` (wired into `runtests.jl`), a deterministic regression test that the declaration covers `AbstractNonlinearSolveAlgorithm`, the concrete `NonlinearSolvePolyAlgorithm`, and does not touch unrelated differentiable types.

Verified locally (Julia 1.11, NonlinearSolveBase dev'd from this branch + `Enzyme`/`ChainRulesCore` to trigger the extension):

```
NonlinearSolveBase 2.30.2
Test Summary:                                                       | Pass  Total  Time
Enzyme inactive_type covers the nonlinear-solve algorithm hierarchy |    4      4  0.2s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)