### PR TITLE
ci: add centralized sublibrary downgrade CI

### DIFF
--- a/.github/workflows/DowngradeSublibraries.yml
+++ b/.github/workflows/DowngradeSublibraries.yml
@@ -1,0 +1,24 @@
+name: Downgrade Sublibraries
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  downgrade-sublibraries:
+    uses: "SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1"
+    secrets: "inherit"
+    with:
+      julia-version: "lts"
+      skip: "Pkg,TOML,Statistics,LinearAlgebra,SparseArrays,InteractiveUtils,Random,Test,NonlinearSolve,NonlinearSolveBase,NonlinearSolveFirstOrder,NonlinearSolveQuasiNewton,NonlinearSolveSpectralMethods,NonlinearSolveHomotopyContinuation,NonlinearSolveSciPy,BracketingNonlinearSolve,SimpleNonlinearSolve,SCCNonlinearSolve,SciMLJacobianOperators"
+      allow-reresolve: true
+      # Every lib/* sublibrary is downgrade-tested (projects auto-discovered, no exclusions).


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

This adds a centralized sublibrary downgrade CI workflow (`.github/workflows/DowngradeSublibraries.yml`) that downgrade-tests **all** `lib/*` sublibraries via the SciML reusable workflow `SciML/.github/.github/workflows/sublibrary-downgrade.yml@v1` — matching the pattern already used in OrdinaryDiffEq.jl.

The reusable workflow auto-discovers every `lib/<name>` with a `Project.toml` (10 sublibraries here) and, for each, runs `julia-downgrade-compat` + `julia-buildpkg` + `julia-runtest` on `project: lib/<sub>`. Triggered on push/PR to `master`, ignoring `docs/**`, with a concurrency group.

### Configuration
- `julia-version: lts`
- `allow-reresolve: true`
- No `projects` / `exclude` — every `lib/*` sublibrary is tested.
- No group-env: the sublib test harnesses default `GROUP` to `All` (run everything) when unset, so no test-group env var is required.

### `skip` list and rationale
Deps NOT downgraded:
- **Stdlibs** (no meaningful downgrade): `Pkg, TOML, Statistics, LinearAlgebra, SparseArrays, InteractiveUtils, Random, Test`.
- **In-repo packages** (the repo's own core/base packages that sublibs path/dev-depend on via `[sources]`): `NonlinearSolve` (root), `NonlinearSolveBase, NonlinearSolveFirstOrder, NonlinearSolveQuasiNewton, NonlinearSolveSpectralMethods, NonlinearSolveHomotopyContinuation, NonlinearSolveSciPy, BracketingNonlinearSolve, SimpleNonlinearSolve, SCCNonlinearSolve, SciMLJacobianOperators`. These are skipped so the downgrade step does not pin in-repo code — sublibraries are tested against the **current** in-repo versions, not their lowest declared compat bounds.

### Note
These are **new** CI checks that have never run before, so they may surface pre-existing lowest-bound compat issues in the sublibraries on the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)