### PR TITLE
test: compare matrix/vector resizing solutions with `≈` instead of `==`

### DIFF
--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -418,7 +418,12 @@ end
             PseudoTransient(), RobustMultiNewton(), FastShortcutNonlinearPolyalg(),
             Broyden(), Klement(), LimitedMemoryBroyden(; threshold = 2),
         )
-        @test vec(solve(prob, alg).u) == solve(vecprob, alg).u
+        # The matrix and vectorized `u0` take slightly different reshape/BLAS kernel
+        # paths, which can differ by ~1 ULP (observed on arm64 CI runners). Compare
+        # approximately with a tight tolerance rather than bit-exactly: `rtol = 1e-12`
+        # is ~10⁴× looser than the observed last-bit noise yet ~10⁴× tighter than the
+        # solvers' own convergence tolerance, so it still catches any real regression.
+        @test vec(solve(prob, alg).u) ≈ solve(vecprob, alg).u rtol = 1.0e-12
     end
 end
 
@@ -436,7 +441,12 @@ end
             PseudoTransient(), RobustMultiNewton(), FastShortcutNonlinearPolyalg(),
             Broyden(), Klement(), LimitedMemoryBroyden(; threshold = 2),
         )
-        @test vec(solve(prob, alg).u) == solve(vecprob, alg).u
+        # The matrix and vectorized `u0` take slightly different reshape/BLAS kernel
+        # paths, which can differ by ~1 ULP (observed on arm64 CI runners). Compare
+        # approximately with a tight tolerance rather than bit-exactly: `rtol = 1e-12`
+        # is ~10⁴× looser than the observed last-bit noise yet ~10⁴× tighter than the
+        # solvers' own convergence tolerance, so it still catches any real regression.
+        @test vec(solve(prob, alg).u) ≈ solve(vecprob, alg).u rtol = 1.0e-12
     end
 end
 


### PR DESCRIPTION
> [!NOTE]
> Draft — please ignore until reviewed by @ChrisRackauckas.

## Problem

The "Out-of-place Matrix Resizing" and "Inplace Matrix Resizing" testitems (`test/core_tests.jl`) assert that solving a problem with a 2×2 matrix `u0` yields a **bit-identical** result to solving the vectorized problem:

```julia
@test vec(solve(prob, alg).u) == solve(vecprob, alg).u
```

The matrix and vector paths go through slightly different reshape/BLAS kernels, which can differ by **1 ULP** on arm64. This fails on `macos-latest` (Apple Silicon) CI runners, e.g.:

- `NewtonRaphson`: `1.414213562373095` vs `1.4142135623730951` (the two values straddle the exactly-rounded `sqrt(2)`; residuals `±4.4e-16`).
- `LimitedMemoryBroyden`: `-0.334710407027607` vs `-0.33471040702760707`.

The values are bit-identical on x86_64, which is why this is intermittent (architecture-dependent). The exact-`==` assertion has been latent since it was introduced in `f49c3082` (2024-10-31); it's not a correctness issue — both branches converge to the true root to full double precision.

## Fix

Compare with `≈` at `rtol = 1e-12`:
- ~10⁴× **tighter** than the solvers' own convergence tolerance (~1e-6…1e-8 residual), so a real regression in the resizing path is still caught.
- ~10⁴× **looser** than the observed ~1-ULP (`~1.6e-16`) last-bit noise.

## Verification

Ran both testitems' bodies across all 9 algorithms locally on x86_64 (Linux) — **18/18 pass** (values are bit-identical there, so `≈` is satisfied trivially; no behavior change on x86_64). The arm64 case is covered by the ULP analysis above; I don't have an arm64 box to run it on directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)