### PR TITLE
Simplify root CI to grouped-tests.yml (matrix from test/test_groups.toml)

### DIFF
--- a/.github/workflows/CI_NonlinearSolve.yml
+++ b/.github/workflows/CI_NonlinearSolve.yml
@@ -26,58 +26,9 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
-  test:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - Core
-          - NoPre
-          - Verbosity
-          - Downstream
-          - Bounds
-          - Adjoint
-          - Wrappers
-          - QA
-          - Trim
-        version:
-          - "lts"
-          - "1"
-          - "pre"
-        os:
-          - ubuntu-latest
-          - macos-latest
-        runner:
-          - ""
-        exclude:
-          # Trim was introduced in Julia 1.12; only run it on the current
-          # release and prerelease channels (skip lts == 1.10).
-          - group: Trim
-            version: "lts"
-          # QA only runs on lts and 1 (matches the SciML test-group matrix).
-          - group: QA
-            version: "pre"
-          # Enzyme/SciMLSensitivity-backed groups are not compatible with the
-          # prerelease (1.13+) Julia channel; the test files also self-guard.
-          - group: Adjoint
-            version: "pre"
-          - group: Bounds
-            version: "pre"
-        include:
-          # GPU group: dep-adding (CUDA) sub-env on a self-hosted GPU runner,
-          # folded in from the former bespoke GPU.yml workflow.
-          - group: CUDA
-            version: "1"
-            os: ubuntu-latest
-            runner: '["self-hosted", "Linux", "X64", "gpu"]'
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+  tests:
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
       group-env-name: NONLINEARSOLVE_TEST_GROUP
       check-bounds: auto
-      os: "${{ matrix.os }}"
-      runner: "${{ matrix.runner }}"
-      project: "."
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,48 @@
+# Root NonlinearSolve.jl test-group matrix, consumed by the reusable
+# grouped-tests.yml@v1 caller (.github/workflows/CI_NonlinearSolve.yml). Each
+# group runs on every Julia version it lists and, where an `os` list is given,
+# once per OS. runtests.jl dispatches on NONLINEARSOLVE_TEST_GROUP.
+
+[Core]
+versions = ["lts", "1", "pre"]
+os = ["ubuntu-latest", "macos-latest"]
+
+[NoPre]
+versions = ["lts", "1", "pre"]
+os = ["ubuntu-latest", "macos-latest"]
+
+[Verbosity]
+versions = ["lts", "1", "pre"]
+os = ["ubuntu-latest", "macos-latest"]
+
+[Downstream]
+versions = ["lts", "1", "pre"]
+os = ["ubuntu-latest", "macos-latest"]
+
+# Enzyme/SciMLSensitivity-backed; not compatible with the prerelease channel.
+[Bounds]
+versions = ["lts", "1"]
+os = ["ubuntu-latest", "macos-latest"]
+
+# Enzyme/SciMLSensitivity-backed; not compatible with the prerelease channel.
+[Adjoint]
+versions = ["lts", "1"]
+os = ["ubuntu-latest", "macos-latest"]
+
+[Wrappers]
+versions = ["lts", "1", "pre"]
+os = ["ubuntu-latest", "macos-latest"]
+
+[QA]
+versions = ["lts", "1"]
+os = ["ubuntu-latest", "macos-latest"]
+
+# Trimming was introduced in Julia 1.12; skip lts (1.10).
+[Trim]
+versions = ["1", "pre"]
+os = ["ubuntu-latest", "macos-latest"]
+
+# GPU group: CUDA sub-env on a self-hosted GPU runner (ubuntu only).
+[CUDA]
+versions = ["1"]
+runner = ["self-hosted", "Linux", "X64", "gpu"]


### PR DESCRIPTION
## Summary

Converts the **root** test workflow (`.github/workflows/CI_NonlinearSolve.yml`, status-check name `CI (NonlinearSolve)` / job `Tests`) from a hand-maintained `group × version × os` matrix calling `tests.yml@v1` into the thin `grouped-tests.yml@v1` caller. The matrix now lives in a new `test/test_groups.toml` at the repo root and is computed by `SciML/.github`'s `compute_affected_sublibraries.jl --root-matrix`.

The sublibrary CI (`SublibraryCI.yml`, calls `sublibrary-project-tests.yml@v1`) is **untouched**.

## What changed

- New `test/test_groups.toml` declaring the root groups: Core, NoPre, Verbosity, Downstream, Bounds, Adjoint, Wrappers, QA, Trim (all on `os = [ubuntu-latest, macos-latest]`), plus CUDA on the self-hosted GPU runner. Per-group `versions` encode the old `exclude:` rules (Trim drops `lts`; QA/Adjoint/Bounds drop `pre`).
- `CI_NonlinearSolve.yml` is now a thin caller. Same filename and `name:` (branch-protection status check preserved); `on:` triggers and `concurrency:` kept verbatim. `with:` carries only the non-defaults: `group-env-name: NONLINEARSOLVE_TEST_GROUP` and `check-bounds: auto`.

## Verified matrix match

Ran `compute_affected_sublibraries.jl <repo> --root-matrix` (SciML/.github@v1) against the new TOML and compared the emitted `(group, version, runner)` set to the old workflow's effective matrix:

```
emitted count: 47
original count: 47
MISSING: 0    EXTRA: 0    -> EXACT MATCH
```

`runtests.jl` dispatches on `NONLINEARSOLVE_TEST_GROUP` (falls back to `GROUP`), matching `group-env-name`. TOML and both workflow YAMLs parse cleanly. Package test suite not run (CI validates).

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)