### PR TITLE
QA: run ubuntu-only (drop os matrix from the QA group)

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -35,7 +35,6 @@ os = ["ubuntu-latest", "macos-latest"]
 
 [QA]
 versions = ["lts", "1"]
-os = ["ubuntu-latest", "macos-latest"]
 
 # Trimming was introduced in Julia 1.12; skip lts (1.10).
 [Trim]


### PR DESCRIPTION
## Summary

The `[QA]` test group in `test/test_groups.toml` was running on a multi-OS matrix (`ubuntu-latest`, `macos-latest`). QA consists of Aqua/JET static-analysis checks, which are platform-independent — so the windows/macos QA jobs were wasted CI.

This PR removes the `os = [...]` line from the `[QA]` group only, so QA now runs solely on its `versions` (`lts`, `1`) on the default `ubuntu-latest`. No other group's OS axis is touched; the Core/functional groups keep their multi-OS coverage.

## Verification

- The TOML still parses cleanly (validated with Julia's `TOML.parsefile`).
- `[QA]` no longer has an `os` key; `versions` remains `["lts", "1"]`.
- All functional groups (Core, NoPre, Verbosity, Downstream, Bounds, Adjoint, Wrappers, Trim) retain their `os` axis; CUDA retains its self-hosted runner spec.

Ignore until reviewed by @ChrisRackauckas.