### PR TITLE
HomotopySweep: solve the λspan[1] system first (fixes silent convergence to the wrong root)

### DIFF
--- a/lib/NonlinearSolveBase/src/homotopy_sweep.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_sweep.jl
@@ -3,9 +3,12 @@
         initial_step_factor = 0.1, min_dλ = nothing)
 
 Natural-parameter continuation solver for a [`SciMLBase.HomotopyProblem`](@ref). The
-scalar continuation parameter ``λ`` is swept across the problem's `λspan`; each step
-fixes ``λ``, solves the resulting standard nonlinear system with `inner`, and
-warm-starts from the previous step's solution.
+scalar continuation parameter ``λ`` is swept across the problem's `λspan`. The sweep
+first solves the system at `λspan[1]` (for the canonical `(0, 1)` span, the
+`simplified` system — the form the homotopy is designed to make solvable from a cold
+start) starting from `u0`; each subsequent step fixes ``λ``, solves the resulting
+standard nonlinear system with `inner`, and warm-starts from the previous step's
+solution.
 
 Keyword arguments:
 
@@ -22,9 +25,9 @@ Keyword arguments:
     to `sqrt(eps(typeof(λ)))` at solve time, so the floor scales with precision.
 
 When the sweep cannot reach the end of `λspan`, the returned solution carries a failure
-retcode: its `u` is the last converged iterate (at some ``λ`` short of `λspan[2]`),
-while `resid` comes from the failed step (`nothing` on the `ReturnCode.Stalled` path,
-where no step ran).
+retcode: its `u` is the last converged iterate (at some ``λ`` short of `λspan[2]`, or
+`u0` itself if the initial `λspan[1]` anchor solve failed), while `resid` comes from the
+failed step (`nothing` on the `ReturnCode.Stalled` path, where no step ran).
 
 This is the embedding-homotopy / continuation analogue used to robustly initialize
 systems whose target form is hard to solve cold; it is unrelated to the polynomial
@@ -89,13 +92,38 @@ function CommonSolve.solve(
     dλ = alg.nsteps === nothing ? λT(alg.initial_step_factor) * span : span / alg.nsteps
     min_dλ = alg.min_dλ === nothing ? sqrt(eps(λT)) : λT(alg.min_dλ)
     u = copy(prob.u0)
-    local last_sol
+
+    # Anchor: solve the system at λ = λspan[1] from u0 BEFORE stepping. For the
+    # canonical (0, 1) span this is the pure `simplified` system — the one the
+    # homotopy contract is designed to make solvable from a cold start (OMC's
+    # reference implementation also solves λ = 0 first). Without this anchor the
+    # first inner solve runs at λ0 + dλ warm-started from u0, so a poor u0 can
+    # converge onto the wrong branch and the sweep then tracks that branch all
+    # the way to a wrong root with a success retcode.
+    anchor_f = SciMLBase.NonlinearFunction{iip}(FixLambda(prob.f, λ))
+    last_sol = solve(
+        NonlinearProblem{iip}(anchor_f, copy(u), prob.p),
+        alg.inner, args...; prob.kwargs..., kwargs...
+    )
+    if !SciMLBase.successful_retcode(last_sol)
+        # the λ = λspan[1] system itself failed from u0: the homotopy premise is
+        # broken, so no continuation is possible. `u` stays u0.
+        return SciMLBase.build_solution(
+            prob, alg, u, last_sol.resid;
+            retcode = last_sol.retcode, original = last_sol
+        )
+    end
+    u = copy(last_sol.u)
+    # Zero-width λspan (λ0 == λend): the anchor IS the single target solve.
+    λ == λend && return SciMLBase.build_solution(
+        prob, alg, u, last_sol.resid; retcode = ReturnCode.Success
+    )
 
     while true
         next_λ = abs(λend - λ) <= abs(dλ) ? λend : λ + dλ
         if next_λ == λ && next_λ != λend
-            # dλ underflowed below eps(λ): no further progress is possible. λend is
-            # excluded so that a zero-width λspan still solves the target system once.
+            # dλ underflowed below eps(λ) mid-continuation: no further progress is
+            # possible (the zero-width span is already handled by the anchor above).
             return SciMLBase.build_solution(
                 prob, alg, u, nothing; retcode = ReturnCode.Stalled
             )

--- a/test/Core/homotopy_sweep_tests__item10.jl
+++ b/test/Core/homotopy_sweep_tests__item10.jl
@@ -2,10 +2,12 @@ using NonlinearSolve
 
 using SciMLBase
 
-# rootless residual on a large-magnitude span: bisection drives dλ below
-# eps(λ) ≈ 1.2e-7 long before the absolute sqrt(eps) floor stops it, so the
-# stall guard must fire instead of looping forever.
-H(u, p, λ) = [u[1]^2 + 1.0]
+# Stall guard: bisection must stop (not hang) once dλ underflows eps(λ) on a
+# large-magnitude span. The λ = λspan[1] anchor is solvable from u0 (residual is
+# exactly 0 there), so the sweep gets past the anchor and into continuation; every
+# λ > λspan[1] is then rootless, so bisection drives dλ below eps(1e9) ≈ 1.2e-7 —
+# long before the absolute sqrt(eps) floor — and the stall guard fires.
+H(u, p, λ) = [u[1]^2 + (λ - 1.0e9)]
 prob = HomotopyProblem(H, [0.0]; λspan = (1.0e9, 2.0e9))
 sol = solve(prob, HomotopySweep(; inner = NewtonRaphson()); maxiters = 5)
 @test sol.retcode == SciMLBase.ReturnCode.Stalled

--- a/test/Core/homotopy_sweep_tests__item15.jl
+++ b/test/Core/homotopy_sweep_tests__item15.jl
@@ -1,0 +1,18 @@
+using NonlinearSolve
+
+using SciMLBase
+
+# Regression for the λ = λspan[1] anchor. The sweep must solve the `simplified`
+# system FIRST; otherwise a poor u0 converges onto the wrong branch at the initial
+# λ0 + dλ step and the continuation tracks that branch to a WRONG root with a
+# success retcode.
+#   actual     u^2 - 4   has roots ±2;
+#   simplified u   - 4    is linear (root +4), solvable from ANY guess and in the
+#                         basin of the POSITIVE root.
+# Anchoring at λ = 0 lands the sweep on +2. Without the anchor, the first solve at
+# λ = 0.1 from u0 = -10 converges to the negative branch and the sweep returns -2.
+H(u, p, λ) = [(1 - λ) * (u[1] - 4.0) + λ * (u[1]^2 - 4.0)]
+prob = HomotopyProblem(H, [-10.0]; λspan = (0.0, 1.0))
+sol = solve(prob, HomotopySweep())
+@test SciMLBase.successful_retcode(sol)
+@test sol.u[1] ≈ 2.0 atol = 1.0e-5    # +2 via the λ=0 anchor (pre-fix: -2)

--- a/test/Core/homotopy_sweep_tests__item16.jl
+++ b/test/Core/homotopy_sweep_tests__item16.jl
@@ -1,0 +1,15 @@
+using NonlinearSolve
+
+using SciMLBase
+
+# Anchor-failure contract. If the λ = λspan[1] system is itself unsolvable from u0,
+# the homotopy premise is broken: the sweep fails fast with the inner failure
+# retcode (NOT Stalled), a non-`nothing` resid, and `u` left at u0 — rather than
+# silently stepping past the unsolved anchor.
+H(u, p, λ) = [u[1]^2 + 1.0]    # rootless at every λ, including λ = λspan[1]
+prob = HomotopyProblem(H, [0.5]; λspan = (0.0, 1.0))
+sol = solve(prob, HomotopySweep(; inner = NewtonRaphson()); maxiters = 25)
+@test !SciMLBase.successful_retcode(sol)
+@test sol.retcode != SciMLBase.ReturnCode.Stalled    # anchor failure, not a stall
+@test sol.resid !== nothing
+@test sol.u[1] ≈ 0.5                                  # u0 unchanged

--- a/test/Core/homotopy_sweep_tests__item17.jl
+++ b/test/Core/homotopy_sweep_tests__item17.jl
@@ -1,0 +1,12 @@
+using NonlinearSolve
+
+using SciMLBase
+
+# Zero-width λspan: the anchor IS the single target solve, so the sweep solves the
+# system once and returns success (the degenerate case the anchor subsumes; the
+# continuation loop is never entered).
+H(u, p, λ) = [u[1]^2 - 4.0]
+prob = HomotopyProblem(H, [1.5]; λspan = (0.7, 0.7))
+sol = solve(prob, HomotopySweep(; inner = NewtonRaphson()))
+@test SciMLBase.successful_retcode(sol)
+@test sol.u[1] ≈ 2.0 atol = 1.0e-8

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,7 +126,10 @@ else
             @time @safetestset "HomotopySweep handles a decreasing λspan" include("Core/homotopy_sweep_tests__item11.jl")
             @time @safetestset "HomotopySweep stays in Float32 (no promotion)" include("Core/homotopy_sweep_tests__item12.jl")
             @time @safetestset "HomotopySweep inner solver is composable" include("Core/homotopy_sweep_tests__item13.jl")
-            return @time @safetestset "HomotopyProblem defaults to HomotopySweep when alg is nothing" include("Core/homotopy_sweep_tests__item14.jl")
+            @time @safetestset "HomotopyProblem defaults to HomotopySweep when alg is nothing" include("Core/homotopy_sweep_tests__item14.jl")
+            @time @safetestset "HomotopySweep anchors at λspan[1] (right branch, not wrong root)" include("Core/homotopy_sweep_tests__item15.jl")
+            @time @safetestset "HomotopySweep fails fast when the λspan[1] anchor is unsolvable" include("Core/homotopy_sweep_tests__item16.jl")
+            return @time @safetestset "HomotopySweep solves a zero-width λspan exactly once" include("Core/homotopy_sweep_tests__item17.jl")
         end,
         groups = Dict(
             "PolyAlgorithms" => function ()


### PR DESCRIPTION
## Summary

`HomotopySweep` (merged in #962) never solves the system at `λspan[1]`. The loop initializes `λ = λspan[1]` but the first inner solve runs at `λspan[1] + dλ` (default `0.1·span`), warm-started directly from `u0`. For the canonical `(0, 1)` span that means the pure `simplified` system — the form the homotopy is specifically designed to make solvable from a cold start — is skipped, and the first solve happens on a system already 10% deformed toward `actual`.

This is not only a robustness loss. Adaptive bisection fires **only on inner-solve failure**, never on convergence to the wrong root — so when a poor `u0` converges onto the wrong branch at `λspan[1] + dλ`, the sweep tracks that branch all the way to `λ = 1` and returns a **wrong root with a success retcode**.

## Reproduction (silent wrong root)

```julia
# actual u^2 - 4 has roots ±2; simplified u - 4 is linear (root +4), in the basin
# of the POSITIVE root and solvable from any guess.
H(u, p, λ) = [(1 - λ) * (u[1] - 4.0) + λ * (u[1]^2 - 4.0)]
prob = HomotopyProblem(H, [-10.0]; λspan = (0.0, 1.0))
sol = solve(prob, HomotopySweep())
sol.u[1]   # -2.0  (retcode Success) — WRONG; correct λ=0-anchored answer is +2.0
```

At `λ = 0` the system is linear `u - 4 = 0 → u = 4` (the positive basin). The merged sweep instead first solves at `λ = 0.1` from `u0 = -10`, which converges to the negative branch `≈ -12.26`, then tracks it to `-2`.

## Why `λspan[1]`-first is the intended behavior

The homotopy contract is that `simplified` is chosen to converge from a cold start; that payoff only materializes if the sweep actually solves at `λspan[1]`. This is also what `HomotopyProblem` already documents: its `u0` field is *"the initial guess (a solution of the simplified system at `λspan[1]`)"*. So the solver should establish that solution first and continue from it — not skip straight to a system already deformed toward `actual`.

## Fix

Solve the system at `λ = λspan[1]` from `u0` **before** the stepping loop; continue from that converged iterate. ~15 lines, loop body unchanged.

Contracts preserved:

- **Zero-width `λspan`** (`λ0 == λend`): the anchor is the single target solve; success short-circuits, failure returns the inner retcode — same one-solve behavior as before, now handled explicitly by the anchor rather than the loop's `λend`-exclusion.
- **Adaptive bisection** is unchanged for every continuation step. The anchor deliberately does not bisect: if `simplified` fails from `u0`, the homotopy premise is broken, so it fails fast with the inner retcode.
- **Failure contract** (docstring updated): `u` is the last converged iterate, or `u0` itself if the `λspan[1]` anchor solve failed. (The pre-fix code already returned never-converged `u0` on a first-step failure, so the fix makes the documented contract more honest, not less.)

## Behavior change (intended)

One input class flips from success to failure: a span whose `λspan[1]` system is **not** solvable from `u0`, but whose interior/target systems happen to be. Pre-fix, the first solve ran at `λspan[1] + dλ` and could opportunistically succeed there; post-fix the anchor solves `λspan[1]` first, fails, and returns the inner failure retcode (with `u = u0`). This is the correct outcome: `HomotopyProblem` documents `u0` as a solution of the `simplified` system at `λspan[1]`, so a `u0` from which `λspan[1]` is unsolvable is a malformed homotopy problem — failing fast is more honest than opportunistically tracking an arbitrary branch from a partially-deformed start. (`item10`'s old fixture was exactly this case, hence its rewrite.)

## Tests

- **`item15`** — wrong-branch regression: the reproduction above must return `+2` (pre-fix: `-2`).
- **`item16`** — anchor-failure contract: a system rootless at `λspan[1]` fails fast with the inner failure retcode (not `Stalled`), `resid !== nothing`, `u` left at `u0`.
- **`item17`** — zero-width `λspan` still solves exactly once and succeeds.
- **`item10`** rewritten to stay anchor-compatible: its `λspan[1]` system is now solvable (residual `0` at `u0`), so the sweep reaches continuation and the stall guard still fires when `dλ` underflows `eps(λ)` mid-sweep on a large-magnitude span. (The old fixture was rootless at `λspan[1]`, which the anchor now correctly rejects up front — a behavior change, hence the rewrite.)

All other `homotopy_sweep` items pass unchanged (the rescue test `item5`, the happy paths, etc.).

## Scope

`lib/NonlinearSolveBase/src/homotopy_sweep.jl` + tests only. No API change, no signature change, no new defaults.
