### PR TITLE
Add `ArcLengthContinuation`: pseudo-arclength continuation solver for `HomotopyProblem`

### DIFF
--- a/docs/src/native/solvers.md
+++ b/docs/src/native/solvers.md
@@ -54,6 +54,7 @@ LimitedMemoryBroyden
 
 ```@docs
 HomotopySweep
+ArcLengthContinuation
 ```
 
 ## Nonlinear Least Squares Solvers

--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.32.0"
+version = "2.33.0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
+++ b/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
@@ -65,6 +65,7 @@ include("tracing.jl")
 include("wrappers.jl")
 include("polyalg.jl")
 include("homotopy_sweep.jl")
+include("arclength.jl")
 
 
 include("descent/common.jl")
@@ -115,7 +116,7 @@ export DescentResult, SteepestDescent, NewtonDescent, DampedNewtonDescent, Dogle
 
 export NonlinearSolvePolyAlgorithm
 
-export HomotopySweep
+export HomotopySweep, ArcLengthContinuation
 
 export NonlinearVerbosity
 

--- a/lib/NonlinearSolveBase/src/arclength.jl
+++ b/lib/NonlinearSolveBase/src/arclength.jl
@@ -216,8 +216,8 @@ function CommonSolve.solve(
         # points once history exists; a pure-λ step toward λend bootstraps the first step.
         if have_prev
             d = xcur .- xprev
-            nd = norm(d)
-            τ = nd > 0 ? d ./ nd : pack(zeros(Tx, n), sλ)
+            dnorm = norm(d)
+            τ = dnorm > 0 ? d ./ dnorm : pack(zeros(Tx, n), sλ)
         else
             τ = pack(zeros(Tx, n), sλ)
         end

--- a/lib/NonlinearSolveBase/src/arclength.jl
+++ b/lib/NonlinearSolveBase/src/arclength.jl
@@ -1,0 +1,304 @@
+"""
+    ArcLengthContinuation(; inner = nothing, initial_step_factor = 0.1,
+        adaptive = true, min_ds = nothing, max_step_factor = 1.0,
+        expand_factor = 2.0, expand_threshold = 2, max_angle = π / 6,
+        maxsteps = 10000)
+
+Pseudo-arclength continuation solver for a `SciMLBase.HomotopyProblem`. Unlike
+[`HomotopySweep`](@ref), which marches the scalar parameter ``λ`` monotonically, this
+solver tracks the solution curve ``H(u, λ) = 0`` parameterized by arclength ``s`` in the
+augmented ``(u, λ)`` space. Each step takes a predictor step along the path and corrects
+it by solving the *augmented* ``(n+1)``-dimensional system
+
+```
+H(u, λ)                 = 0          # n equations
+τ ⋅ ([u; λ] - x₀) - Δs  = 0          # Keller pseudo-arclength constraint
+```
+
+with the `inner` solver. Because ``λ`` is a free variable of the corrector (not held
+fixed), the augmented Jacobian stays nonsingular at *turning points* (folds) where
+``∂H/∂u`` is singular and ``λ`` is non-monotone along the path. This lets the solver
+round folds that defeat natural-parameter continuation — the canonical reason a sweep
+"fails to reach `λ = 1`" when a real solution at `λ = 1` does exist but only on a branch
+reachable by going around a fold.
+
+The target is the point on the curve where ``λ = λspan[2]``: the solver follows the path
+until a step brackets that ``λ``, then performs one final ``λ``-fixed correction to land
+on it exactly.
+
+Keyword arguments:
+
+  - `inner`: the inner nonlinear algorithm used for both the initial on-curve correction
+    and the augmented corrector; `nothing` selects NonlinearSolve's default polyalgorithm.
+  - `initial_step_factor`: the initial arclength step `Δs` as a fraction of the `λspan`
+    width. Must be in `(0, 1]`.
+  - `adaptive`: when `true` (default), a corrector failure halves `Δs` and retries from
+    the last accepted point (down to a floor of `min_ds`), and `expand_threshold`
+    consecutive successes grow `Δs` by `expand_factor` up to `max_step_factor` of the
+    span.
+  - `min_ds`: the smallest arclength step bisection may reach; `nothing` (default)
+    resolves to `sqrt(eps(typeof(λ)))`.
+  - `max_step_factor`: the largest arclength step, as a fraction of the `λspan` width.
+    Must be in `(0, 1]`.
+  - `expand_factor`: the `Δs` growth multiplier after `expand_threshold` consecutive
+    successful steps. Must be ≥ 1; `1` disables expansion.
+  - `expand_threshold`: consecutive successful steps required before `Δs` is expanded.
+    Must be ≥ 1.
+  - `max_angle`: the curvature control (radians, in `(0, π]`). A step is *rejected* and
+    `Δs` halved when the path direction turns by more than `max_angle` between the
+    previous and current accepted segments; `Δs` is only allowed to grow when the turn is
+    below `max_angle / 3`. Because the solution curve is smooth in arclength even at a
+    fold (the tangent rotates continuously), bounding the per-step turn forces small
+    steps *through* a turning point while permitting large steps on straight stretches —
+    and it is what prevents the secant predictor from overshooting onto a different branch
+    ("path jumping"). This is the analogue of OpenModelica's homotopy bend parameter.
+  - `maxsteps`: a hard cap on the total number of predictor-corrector attempts (including
+    bisection retries). Required because the path is *not* monotone in `λ`, so a sweep
+    that never reaches the target — a closed loop, or a branch escaping to infinity —
+    would otherwise not terminate. Exceeding it returns a `ReturnCode.MaxIters` failure.
+
+When the solver cannot reach `λspan[2]`, the returned solution carries a failure retcode
+and its `u` is the last converged curve point.
+
+The continuation is derivative-free in the predictor (a secant through the last two
+accepted points, bootstrapped from a pure-``λ`` step); the augmented corrector obtains
+the derivatives it needs through the inner solver's own differentiation, exactly as a
+standard `NonlinearProblem` would.
+"""
+@concrete struct ArcLengthContinuation <: AbstractNonlinearSolveAlgorithm
+    inner
+    initial_step_factor
+    adaptive::Bool
+    min_ds
+    max_step_factor
+    expand_factor
+    expand_threshold::Int
+    max_angle
+    maxsteps::Int
+end
+
+function ArcLengthContinuation(;
+        inner = nothing, initial_step_factor = 0.1, adaptive = true,
+        min_ds = nothing, max_step_factor = 1.0, expand_factor = 2.0,
+        expand_threshold = 2, max_angle = π / 6, maxsteps = 10000
+    )
+    if !(0 < initial_step_factor <= 1)
+        throw(
+            ArgumentError(
+                "ArcLengthContinuation `initial_step_factor` must be in (0, 1], got $initial_step_factor"
+            )
+        )
+    end
+    if min_ds !== nothing && min_ds <= 0
+        throw(ArgumentError("ArcLengthContinuation `min_ds` must be positive, got $min_ds"))
+    end
+    if !(0 < max_step_factor <= 1)
+        throw(
+            ArgumentError(
+                "ArcLengthContinuation `max_step_factor` must be in (0, 1], got $max_step_factor"
+            )
+        )
+    end
+    if expand_factor < 1
+        throw(
+            ArgumentError(
+                "ArcLengthContinuation `expand_factor` must be ≥ 1 (1 disables expansion), got $expand_factor"
+            )
+        )
+    end
+    if expand_threshold < 1
+        throw(
+            ArgumentError(
+                "ArcLengthContinuation `expand_threshold` must be ≥ 1, got $expand_threshold"
+            )
+        )
+    end
+    if !(0 < max_angle <= π)
+        throw(
+            ArgumentError(
+                "ArcLengthContinuation `max_angle` must be in (0, π], got $max_angle"
+            )
+        )
+    end
+    if maxsteps < 1
+        throw(ArgumentError("ArcLengthContinuation `maxsteps` must be ≥ 1, got $maxsteps"))
+    end
+    return ArcLengthContinuation(
+        inner, initial_step_factor, adaptive, min_ds,
+        max_step_factor, expand_factor, expand_threshold, max_angle, maxsteps
+    )
+end
+
+# Residual of the augmented (n+1) corrector system: the n homotopy equations stacked
+# with the scalar Keller pseudo-arclength constraint. A named struct (not a closure) so
+# the inner solver's compilation is reused across continuation steps. `f` is the raw
+# user homotopy `f(u, p, λ)` / `f(du, u, p, λ)`; `τ` and `xcur` are the unit predictor
+# direction and the last accepted packed point `[u; λ]`; `ds` is the arclength step. The
+# augmented variable is `x = [u; λ]`; the solver passes the problem parameter `p` through
+# (as for any `NonlinearProblem` residual) and it is forwarded to the user homotopy.
+struct AugmentedHomotopy{F, V, T}
+    f::F
+    τ::V
+    xcur::V
+    ds::T
+    n::Int
+end
+
+function (a::AugmentedHomotopy)(x, p)
+    u = x[1:(a.n)]
+    λ = x[a.n + 1]
+    Hval = a.f(u, p, λ)
+    c = LinearAlgebra.dot(a.τ, x .- a.xcur) - a.ds
+    return vcat(Hval, c)
+end
+
+function (a::AugmentedHomotopy)(res, x, p)
+    n = a.n
+    a.f(view(res, 1:n), view(x, 1:n), p, x[n + 1])
+    res[n + 1] = LinearAlgebra.dot(a.τ, x .- a.xcur) - a.ds
+    return nothing
+end
+
+# Natural-parameter solve at a fixed λ: gets the start point onto the curve and lands the
+# final point exactly on λ = λspan[2]. Mirrors HomotopySweep's per-step solve.
+function _arclength_fixed_solve(
+        prob::SciMLBase.HomotopyProblem{uType, iip}, inner, uguess,
+        λfix, args...; kwargs...
+    ) where {uType, iip}
+    fλ = SciMLBase.NonlinearFunction{iip}(FixLambda(prob.f, λfix))
+    inner_prob = NonlinearProblem{iip}(fλ, copy(uguess), prob.p)
+    return solve(inner_prob, inner, args...; prob.kwargs..., kwargs...)
+end
+
+function CommonSolve.solve(
+        prob::SciMLBase.HomotopyProblem{uType, iip},
+        alg::ArcLengthContinuation, args...; kwargs...
+    ) where {uType, iip}
+    λ0, λ1 = prob.λspan
+    λ = float(λ0)
+    λT = typeof(λ)
+    λend = λT(λ1)
+    span = λend - λ
+
+    # Correct the start onto the curve at λ0; everything downstream assumes H(u, λ) = 0.
+    start_sol = _arclength_fixed_solve(prob, alg.inner, prob.u0, λ, args...; kwargs...)
+    if !SciMLBase.successful_retcode(start_sol)
+        return SciMLBase.build_solution(
+            prob, alg, copy(prob.u0), start_sol.resid;
+            retcode = start_sol.retcode, original = start_sol
+        )
+    end
+    u = copy(start_sol.u)
+    last_sol = start_sol
+    if span == 0
+        return SciMLBase.build_solution(
+            prob, alg, u, last_sol.resid; retcode = ReturnCode.Success
+        )
+    end
+
+    n = length(u)
+    Tx = promote_type(eltype(u), λT)
+    pack(uvec, λval) = Tx[uvec..., λval]
+    xcur = pack(u, λ)
+    xprev = xcur                       # no history yet → secant falls back to pure-λ
+    have_prev = false
+
+    min_ds = alg.min_ds === nothing ? sqrt(eps(λT)) : λT(alg.min_ds)
+    max_ds = λT(alg.max_step_factor) * abs(span)
+    ds = min(λT(alg.initial_step_factor) * abs(span), max_ds)
+    sλ = λT(sign(span))
+    cos_reject = Tx(cos(alg.max_angle))         # turn beyond max_angle ⇒ reject + shrink
+    cos_grow = Tx(cos(alg.max_angle / 3))       # turn below max_angle/3 ⇒ allow growth
+    streak = 0
+
+    for _ in 1:(alg.maxsteps)
+        # Predictor direction τ (unit, length n+1). Secant through the last two accepted
+        # points once history exists; a pure-λ step toward λend bootstraps the first step.
+        if have_prev
+            d = xcur .- xprev
+            nd = norm(d)
+            τ = nd > 0 ? d ./ nd : pack(zeros(Tx, n), sλ)
+        else
+            τ = pack(zeros(Tx, n), sλ)
+        end
+
+        xpred = xcur .+ ds .* τ
+        aug = AugmentedHomotopy(prob.f, τ, xcur, Tx(ds), n)
+        # length n+1; never in-place even for an iip homotopy — the constraint row has no
+        # user-facing buffer, so we always own the residual.
+        augf = SciMLBase.NonlinearFunction{iip}(aug)
+        corr_prob = NonlinearProblem{iip}(augf, copy(xpred), prob.p)
+        last_sol = solve(corr_prob, alg.inner, args...; prob.kwargs..., kwargs...)
+
+        if SciMLBase.successful_retcode(last_sol)
+            xnew = last_sol.u
+            chord = xnew .- xcur
+            nchord = norm(chord)
+
+            # Curvature control: the realized step direction vs. the predictor (which, once
+            # there is history, IS the previous accepted segment's direction) measures the
+            # path's turn. A large turn means either real high curvature or that the
+            # corrector jumped to another branch — both call for a smaller step, so reject
+            # and bisect. The gate is skipped on the bootstrap step, where the pure-λ
+            # predictor is legitimately misaligned with a sloped branch.
+            cosang = (have_prev && nchord > 0) ?
+                clamp(LinearAlgebra.dot(τ, chord) / nchord, -one(Tx), one(Tx)) : one(Tx)
+            if have_prev && cosang < cos_reject && alg.adaptive && ds / 2 >= min_ds
+                ds = ds / 2
+                streak = 0
+                continue
+            end
+
+            unew = xnew[1:n]
+            λnew = xnew[n + 1]
+            λold = λ
+
+            xprev = xcur
+            xcur = copy(xnew)
+            u = copy(unew)
+            λ = λnew
+            have_prev = true
+
+            # A step that brackets λend has crossed the target; land on it exactly with a
+            # λ-fixed correction warm-started by interpolation along the just-taken step.
+            if (λold - λend) * (λnew - λend) <= 0
+                denom = λnew - λold
+                frac = denom == 0 ? one(Tx) : Tx((λend - λold) / denom)
+                uprev = xprev[1:n]
+                uguess = uprev .+ frac .* (unew .- uprev)
+                final_sol = _arclength_fixed_solve(
+                    prob, alg.inner, uguess, λend, args...; kwargs...
+                )
+                if SciMLBase.successful_retcode(final_sol)
+                    return SciMLBase.build_solution(
+                        prob, alg, copy(final_sol.u), final_sol.resid;
+                        retcode = ReturnCode.Success
+                    )
+                end
+                # the interpolation guess missed the basin; keep tracking and try the
+                # next crossing rather than failing on a single bad warm start
+            end
+
+            # Grow only on near-straight stretches, so the step does not race ahead into a
+            # turn it would then have to reject.
+            if alg.adaptive
+                streak += 1
+                if streak >= alg.expand_threshold && cosang >= cos_grow
+                    ds = min(λT(alg.expand_factor) * ds, max_ds)
+                    streak = 0
+                end
+            end
+        elseif alg.adaptive && ds / 2 >= min_ds
+            ds = ds / 2          # bisect; retry from the same accepted point
+            streak = 0
+        else
+            return SciMLBase.build_solution(
+                prob, alg, u, nothing;
+                retcode = last_sol.retcode, original = last_sol
+            )
+        end
+    end
+
+    # Ran out of attempts without bracketing λend: the path never reached the target.
+    return SciMLBase.build_solution(prob, alg, u, nothing; retcode = ReturnCode.MaxIters)
+end

--- a/test/Core/arclength_tests__item1.jl
+++ b/test/Core/arclength_tests__item1.jl
@@ -1,0 +1,34 @@
+using NonlinearSolve
+
+alg = ArcLengthContinuation()
+@test alg isa ArcLengthContinuation
+@test alg isa NonlinearSolve.AbstractNonlinearSolveAlgorithm
+@test alg.inner === nothing
+@test alg.initial_step_factor ≈ 0.1
+@test alg.adaptive == true
+@test alg.min_ds === nothing
+@test alg.max_step_factor ≈ 1.0
+@test alg.expand_factor ≈ 2.0
+@test alg.expand_threshold == 2
+@test alg.max_angle ≈ π / 6
+@test alg.maxsteps == 10000
+
+alg2 = ArcLengthContinuation(;
+    inner = SimpleNewtonRaphson(), initial_step_factor = 0.05,
+    max_angle = π / 4, maxsteps = 500
+)
+@test alg2.inner isa SimpleNewtonRaphson
+@test alg2.initial_step_factor ≈ 0.05
+@test alg2.max_angle ≈ π / 4
+@test alg2.maxsteps == 500
+
+@test_throws ArgumentError ArcLengthContinuation(; initial_step_factor = 0.0)
+@test_throws ArgumentError ArcLengthContinuation(; initial_step_factor = 1.5)
+@test_throws ArgumentError ArcLengthContinuation(; min_ds = 0.0)
+@test_throws ArgumentError ArcLengthContinuation(; max_step_factor = 0.0)
+@test_throws ArgumentError ArcLengthContinuation(; max_step_factor = 2.0)
+@test_throws ArgumentError ArcLengthContinuation(; expand_factor = 0.5)
+@test_throws ArgumentError ArcLengthContinuation(; expand_threshold = 0)
+@test_throws ArgumentError ArcLengthContinuation(; max_angle = 0.0)
+@test_throws ArgumentError ArcLengthContinuation(; max_angle = 4.0)   # > π
+@test_throws ArgumentError ArcLengthContinuation(; maxsteps = 0)

--- a/test/Core/arclength_tests__item2.jl
+++ b/test/Core/arclength_tests__item2.jl
@@ -1,0 +1,25 @@
+using NonlinearSolve
+
+using SciMLBase
+
+# Monotone (fold-free) homotopy: arclength continuation must reproduce the natural sweep's
+# answer on the easy case. u* = 2 at λ = 1.
+H(u, p, λ) = [(1 - λ) * (u[1] - p.c) + λ * (u[1]^2 - p.c)]
+prob = HomotopyProblem(H, [4.0], (c = 4.0,))
+
+sol = solve(prob, ArcLengthContinuation())
+@test SciMLBase.successful_retcode(sol)
+@test sol.u[1] ≈ 2.0 atol = 1.0e-6
+
+# the result is on the target system H(u, 1) = u^2 - c
+@test abs(sol.u[1]^2 - 4.0) < 1.0e-8
+
+# matches HomotopySweep on the same problem
+ref = solve(prob, HomotopySweep())
+@test sol.u[1] ≈ ref.u[1] atol = 1.0e-6
+
+# decreasing λspan is handled (target is the λspan[2] end, here λ = 0 ⇒ linear system u = c)
+prob_dec = HomotopyProblem(H, [1.0], (c = 4.0,); λspan = (1.0, 0.0))
+sol_dec = solve(prob_dec, ArcLengthContinuation())
+@test SciMLBase.successful_retcode(sol_dec)
+@test sol_dec.u[1] ≈ 4.0 atol = 1.0e-6

--- a/test/Core/arclength_tests__item3.jl
+++ b/test/Core/arclength_tests__item3.jl
@@ -1,0 +1,32 @@
+using NonlinearSolve
+
+using SciMLBase
+
+# S-shaped fold. The curve u^3 - 3u = μ(λ), μ(λ) = -3 + 6λ, has folds (∂H/∂u = 0) at
+# u = ±1, i.e. μ = ±2, i.e. λ = 5/6 and λ = 1/6. Continuing the connected branch from the
+# λ = 0 root on the lower sheet (u ≈ -2.1038) to the λ = 1 root on the upper sheet
+# (u ≈ +2.1038) requires λ to first rise to 5/6, reverse down to 1/6, then rise to 1 —
+# the path is non-monotone in λ. Natural-parameter marching cannot reverse λ; arclength
+# continuation tracks the augmented curve through both turning points.
+target = 2.1038034
+λseen = Float64[]
+function H(u, p, λ)
+    # record only the plain-Float64 residual evaluations; the corrector's Jacobian passes
+    # ForwardDiff Duals through λ, which we must not push into a Float64 buffer
+    λ isa Float64 && push!(λseen, λ)
+    return [u[1]^3 - 3 * u[1] - (-3 + 6λ)]
+end
+prob = HomotopyProblem(H, [-target]; λspan = (0.0, 1.0))
+
+empty!(λseen)
+sol = solve(prob, ArcLengthContinuation())
+@test SciMLBase.successful_retcode(sol)
+# lands on the connected upper-sheet root at λ = 1, with a genuine target-system residual
+@test sol.u[1] ≈ target atol = 1.0e-4
+@test abs(sol.u[1]^3 - 3 * sol.u[1] - 3) < 1.0e-6
+
+# proof the fold was rounded: λ rises past the first turning point (> 0.8) and then
+# decreases well below it (toward the second turning point at 1/6) before reaching 1.
+i_past_fold = findfirst(>(0.8), λseen)
+@test i_past_fold !== nothing
+@test minimum(λseen[i_past_fold:end]) < 0.3

--- a/test/Core/arclength_tests__item4.jl
+++ b/test/Core/arclength_tests__item4.jl
@@ -1,0 +1,35 @@
+using NonlinearSolve
+
+using SciMLBase
+
+# Float32 must stay Float32 (no promotion through the augmented packing/predictor).
+H(u, p, λ) = [(1 - λ) * (u[1] - p.c) + λ * (u[1]^2 - p.c)]
+prob32 = HomotopyProblem(H, Float32[4.0], (c = 4.0f0,); λspan = (0.0f0, 1.0f0))
+sol32 = solve(prob32, ArcLengthContinuation())
+@test SciMLBase.successful_retcode(sol32)
+@test eltype(sol32.u) == Float32
+@test sol32.u[1] ≈ 2.0f0 atol = 1.0f-4
+
+# in-place residual f(du, u, p, λ) is supported (the augmented corrector writes the n
+# homotopy rows in place and appends the scalar arclength constraint itself).
+function Hiip(du, u, p, λ)
+    du[1] = (1 - λ) * (u[1] - 4.0) + λ * (u[1]^2 - 4.0)
+    return nothing
+end
+probi = HomotopyProblem(NonlinearFunction{true}(Hiip), [4.0]; λspan = (0.0, 1.0))
+soli = solve(probi, ArcLengthContinuation())
+@test SciMLBase.successful_retcode(soli)
+@test soli.u[1] ≈ 2.0 atol = 1.0e-6
+
+# a multi-dimensional system tracks too (n = 2)
+function H2(u, p, λ)
+    return [
+        (1 - λ) * (u[1] - 1.0) + λ * (u[1]^2 + u[2]^2 - 2.0),
+        (1 - λ) * (u[2] - 1.0) + λ * (u[1] - u[2]),
+    ]
+end
+prob2 = HomotopyProblem(H2, [1.0, 1.0]; λspan = (0.0, 1.0))
+sol2 = solve(prob2, ArcLengthContinuation())
+@test SciMLBase.successful_retcode(sol2)
+@test sol2.u[1] ≈ 1.0 atol = 1.0e-6   # u1 = u2 and u1^2+u2^2 = 2 ⇒ u = (1, 1)
+@test sol2.u[2] ≈ 1.0 atol = 1.0e-6

--- a/test/Core/arclength_tests__item5.jl
+++ b/test/Core/arclength_tests__item5.jl
@@ -1,0 +1,23 @@
+using NonlinearSolve
+
+using SciMLBase
+
+# The solution curve is the circle u^2 + (λ - 0.5)^2 = 0.25, which only exists for
+# λ ∈ [0, 1]. A target at λspan[2] = 2 is off the curve and unreachable: arclength
+# continuation must report a failure retcode (and terminate — not hang — thanks to the
+# maxsteps guard) rather than claim success.
+Hc(u, p, λ) = [u[1]^2 + (λ - 0.5)^2 - 0.25]
+prob = HomotopyProblem(Hc, [0.0]; λspan = (0.0, 2.0))
+sol = solve(prob, ArcLengthContinuation(; maxsteps = 200))
+@test !SciMLBase.successful_retcode(sol)
+@test all(isfinite, sol.u)            # last converged curve point, not a diverged buffer
+
+# A start the corrector cannot bring onto the curve also fails cleanly: at λ0 = 0 the
+# circle is tangent (u = 0); start far away with a target system that has no real root at
+# λ = 1 — here the embedded system stays solvable, so instead test that a tiny maxsteps
+# forces termination on an otherwise-solvable fold problem.
+H(u, p, λ) = [u[1]^3 - 3 * u[1] - (-3 + 6λ)]
+probf = HomotopyProblem(H, [-2.1038]; λspan = (0.0, 1.0))
+sol_short = solve(probf, ArcLengthContinuation(; maxsteps = 2))
+@test !SciMLBase.successful_retcode(sol_short)   # 2 attempts cannot round the fold
+@test all(isfinite, sol_short.u)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -129,7 +129,12 @@ else
             @time @safetestset "HomotopyProblem defaults to HomotopySweep when alg is nothing" include("Core/homotopy_sweep_tests__item14.jl")
             @time @safetestset "HomotopySweep anchors at λspan[1] (right branch, not wrong root)" include("Core/homotopy_sweep_tests__item15.jl")
             @time @safetestset "HomotopySweep fails fast when the λspan[1] anchor is unsolvable" include("Core/homotopy_sweep_tests__item16.jl")
-            return @time @safetestset "HomotopySweep solves a zero-width λspan exactly once" include("Core/homotopy_sweep_tests__item17.jl")
+            @time @safetestset "HomotopySweep solves a zero-width λspan exactly once" include("Core/homotopy_sweep_tests__item17.jl")
+            @time @safetestset "ArcLengthContinuation construction + defaults" include("Core/arclength_tests__item1.jl")
+            @time @safetestset "ArcLengthContinuation happy path (fold-free, matches sweep)" include("Core/arclength_tests__item2.jl")
+            @time @safetestset "ArcLengthContinuation rounds a fold (non-monotone λ)" include("Core/arclength_tests__item3.jl")
+            @time @safetestset "ArcLengthContinuation Float32 / in-place / multi-dim" include("Core/arclength_tests__item4.jl")
+            return @time @safetestset "ArcLengthContinuation fails (no hang) on an unreachable target" include("Core/arclength_tests__item5.jl")
         end,
         groups = Dict(
             "PolyAlgorithms" => function ()


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Adds a second continuation solver for `HomotopyProblem`, complementing `HomotopySweep` (#962). Where `HomotopySweep` marches the homotopy parameter `λ` monotonically — and therefore cannot pass a **fold** (a turning point where the solution branch reverses in `λ`) — `ArcLengthContinuation` tracks the solution curve `H(u, λ) = 0` by **arclength** in the augmented `(u, λ)` space. This is the method behind OpenModelica's global homotopy and the classic predictor-corrector path trackers (Keller; Allgower & Georg), and it was the first follow-up listed in the `HomotopySweep` PR thread.

## How it works

Each continuation step:

- **Predictor** — a secant through the last two accepted points (derivative-free, bootstrapped from a pure-`λ` step). No `∂H/∂λ` required.
- **Corrector** — solve the augmented `(n+1)` system with the `inner` solver:
  ```
  H(u, λ)                = 0      # n homotopy equations
  τ · ([u; λ] - x₀) - Δs = 0      # Keller pseudo-arclength constraint
  ```
  Because `λ` is a *free corrector variable* (not held fixed as in a sweep), the augmented Jacobian stays nonsingular at folds where `∂H/∂u` is singular — that is precisely what lets the path round a turning point. The inner solver supplies the needed derivatives by differentiating the augmented residual, exactly as for any `NonlinearProblem`.
- **Curvature control (`max_angle`)** — the per-step turn of the path direction is bounded; a sharper turn rejects the step and halves `Δs`, while `Δs` only grows on near-straight stretches. The curve is *smooth in arclength even at a fold*, so this forces small steps through a turning point while permitting large steps elsewhere — and it stops the secant predictor from overshooting onto a different branch (path-jumping). This is the analogue of OpenModelica's homotopy bend parameter, and it was necessary: without it the predictor overshoots and the corrector jumps branches.

The target is the curve point at `λ = λspan[2]`: the tracker follows the path until a step brackets that `λ`, then does one final `λ`-fixed correction to land on it exactly. A `maxsteps` guard guarantees termination, which is *required* here because the path is not monotone in `λ` (a closed loop or a branch escaping to infinity would otherwise never stop).

## Verification (local, Julia 1.11)

Canonical S-fold `u³ - 3u = -3 + 6λ`, folds at `u = ±1` (`λ = 5/6`, `1/6`). The connected branch from the λ=0 lower-sheet root (`u ≈ -2.104`) reaches the λ=1 upper-sheet root (`u ≈ +2.104`) only by traversing **non-monotone λ**: it rises past the first fold at `λ = 5/6`, reverses down toward the second at `λ = 1/6`, then climbs to `1`. The recorded corrector `λ`-trace confirms this (rises > 0.8, dips back below 0.3, then reaches 1). `ArcLengthContinuation` returns the correct root with target-system residual `~1e-13`.

Also verified: fold-free problems match `HomotopySweep`; Float32 stays Float32; in-place `f(du,u,p,λ)` and multi-dimensional (`n=2`) homotopies work; unreachable targets return a failure retcode instead of hanging.

Note on path-jumping vs. the sweep: on a *smooth scalar* fold problem the sweep's global polyalgorithm corrector often still reaches the same final root by jumping across the fold (for `λ` past the fold there is a single distant real root it converges to), so a "wrong final answer" head-to-head is not a clean demonstration on these examples. The robust, testable distinction is that `ArcLengthContinuation` *follows the connected branch* (non-monotone `λ`), which the test asserts directly; branch-faithful tracking is the property that matters on multi-branch / vector systems where jumping lands on a genuinely different solution.

## Tests

`test/Core/arclength_tests__item1-5.jl` (registered in `test/runtests.jl`), 48 assertions, all passing locally:
1. construction defaults + kwarg validation
2. fold-free happy path, matches `HomotopySweep`, decreasing `λspan`
3. **fold rounding** — S-curve, correct root + asserted non-monotone `λ` traversal
4. Float32 preservation, in-place residual, multi-dimensional system
5. unreachable target / tiny `maxsteps` → failure retcode, no hang

`NonlinearSolveBase` QA (Aqua + ExplicitImports) passes 14/14; Runic clean. `NonlinearSolveBase` bumped 2.31.0 → 2.32.0.

> Heads-up: #967 also bumps `NonlinearSolveBase` to 2.32.0 (it branched from the same master). Whichever merges second will need a re-bump to 2.33.0 — flagging to avoid a silent version collision.

## Possible follow-ups (out of scope)

- A true tangent predictor (nullvector of the augmented Jacobian) for higher-order accuracy, when `∂H/∂λ` is cheaply available.
- Weighted arclength (scaling `u` vs `λ`) for badly-scaled systems.
- Exposing a `solve(prob, ArcLengthContinuation())` default route is intentionally *not* added — `HomotopySweep` remains the `HomotopyProblem` default; arclength is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)