### PR TITLE
Splat kwargs as NamedTuple's to avoid invalidations

### DIFF
--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -146,7 +146,8 @@ function solve_call(
         _prob.kwargs[:kwargshandle] : kwargshandle
 
     if has_kwargs(_prob)
-        kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
+        # `::NamedTuple` assert keeps dispatch off the invalidation-prone `merge(::Any, ::Pairs)` path
+        kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs)::NamedTuple, kwargs)
     end
 
     checkkwargs(kwargshandle; kwargs...)
@@ -268,7 +269,8 @@ function init_call(
     kwargshandle = has_kwargs(_prob) && haskey(_prob.kwargs, :kwargshandle) ?
         _prob.kwargs[:kwargshandle] : kwargshandle
     if has_kwargs(_prob)
-        kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
+        # `::NamedTuple` assert keeps dispatch off the invalidation-prone `merge(::Any, ::Pairs)` path
+        kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs)::NamedTuple, kwargs)
     end
 
     checkkwargs(kwargshandle; kwargs...)
@@ -752,7 +754,8 @@ function _solve_adjoint(
     end
 
     if has_kwargs(_prob)
-        kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
+        # `::NamedTuple` assert keeps dispatch off the invalidation-prone `merge(::Any, ::Pairs)` path
+        kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs)::NamedTuple, kwargs)
     end
 
     return if length(args) > 1
@@ -773,7 +776,8 @@ function _solve_forward(
     _prob = get_concrete_problem(prob; u0 = u0, p = p, kwargs...)
 
     if has_kwargs(_prob)
-        kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
+        # `::NamedTuple` assert keeps dispatch off the invalidation-prone `merge(::Any, ::Pairs)` path
+        kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs)::NamedTuple, kwargs)
     end
 
     return if length(args) > 1


### PR DESCRIPTION
The TL;DR for this and https://github.com/SciML/SciMLBase.jl/pull/1386 is that when other packages add `merge(::AbstractDict, ::AbstractDict)` methods a bunch of SciML functions get invalidated, so this converts the kwargs fields (always taken from function kwargs so always a `Base.Pairs`) into `NamedTuple`'s and adds type-asserts so the code isn't vulnerable to being invalidated from the new methods.

In combination with https://github.com/SciML/SciMLBase.jl/pull/1386 it fixes these invalidations on Julia 1.13 when loading CurveFit:
```julia
 inserting merge(d1::OrderedCollections.LittleDict, others::AbstractDict...) @ OrderedCollections ~/.julia/packages/OrderedCollections/MglBA/src/little_dict.jl:165 invalidated:                                                               
   mt_backedges:  1: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for SciMLBase.var"#remake#913"(::Missing, ::Any, ::Any, ::Missing, ::Missing, ::Bool, ::Bool, ::Missing, ::Nothing, ::Type{Val{true}}, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(SciMLBase.remake), ::SciMLBase.NonlinearLeastSquaresProblem{<:Union{Number, var"#s34"} where var"#s34"<:AbstractArray, iip, <:Union{var"#s33", var"#s31"} where {var"#s33"<:ForwardDiff.Dual{T, V, P}, var"#s31"<:(AbstractArray{<:ForwardDiff.Dual{T, V, P}})}} where {iip, T, V, P}) (0 children)                                                                                                                                                                                                                           
                  2: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for SciMLBase.var"#remake#911"(::Missing, ::Any, ::Any, ::Missing, ::Missing, ::Missing, ::Missing, ::Bool, ::Bool, ::Nothing, ::Type{Val{true}}, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(SciMLBase.remake), ::SciMLBase.NonlinearProblem{<:Union{Number, var"#s34"} where var"#s34"<:AbstractArray, iip, <:Union{var"#s33", var"#s31"} where {var"#s33"<:ForwardDiff.Dual{T, V, P}, var"#s31"<:(AbstractArray{<:ForwardDiff.Dual{T, V, P}})}} where {iip, T, V, P}) (0 children)                                                                                                                                                                                                                            
                  3: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}}triggered MethodInstance for SciMLBase.var"#remake#913"(::Missing, ::Any, ::Any, ::Missing, ::Missing, ::Bool, ::Bool, ::Missing, ::Nothing, ::Type{Val{true}}, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(SciMLBase.remake), ::SciMLBase.NonlinearLeastSquaresProblem) (0 children)
                  4: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for SciMLBase.var"#remake#911"(::Missing, ::Any, ::Any, ::Missing, ::Missing, ::Missing, ::Missing, ::Bool, ::Bool, ::Nothing, ::Type{Val{true}}, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(SciMLBase.remake), ::SciMLBase.NonlinearProblem) (0 children)
                  5: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveBase.NonlinearSolvePolyAlgorithm{Val{3}, Tuple{NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}}, Val{false}}, ::Nothing) (0 children)                                                                        
                  6: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveBase.NonlinearSolvePolyAlgorithm{Val{3}, Tuple{NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}}, Val{false}}, ::Nothing) (0 children)
                  7: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveBase.NonlinearSolvePolyAlgorithm{Val{6}, Tuple{NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{LineSearch.BackTracking{Nothing, Float64, Float64, Float64, Val{3}, Float64, Bool}, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Bastin, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}}, Val{false}}, ::Nothing) (0 children)                                                                                                                                                                                                                                                                                                                                                                       
                  8: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveBase.NonlinearSolvePolyAlgorithm{Val{6}, Tuple{NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{LineSearch.BackTracking{Nothing, Float64, Float64, Float64, Val{3}, Float64, Bool}, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Bastin, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}}, Val{false}}, ::Nothing) (0 children)                                                                                                                                                                                                                                                                                                                                                          
                  9: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, ::Vararg{Nothing}) (0 children)                                                                                                                                                                                                                                                                                                                                                                            
                 10: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, ::Vararg{Nothing}) (0 children)                                                                                                                                                                                                                                                                                                                                                               
                 11: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}, ::Vararg{Nothing}) (0 children)               
                 12: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}, ::Vararg{Nothing}) (0 children)  
                 13: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}) (0 children)                                                                                  
                 14: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}) (0 children)                                                                     
                 15: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}, ::Vararg{Nothing}) (0 children)    
                 16: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}, ::Vararg{Nothing}) (0 children)                                                                                                                                                                                                                                       
                 17: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, ::Vararg{Nothing}) (0 children)
                 18: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, ::Vararg{Nothing}) (0 children)
                 19: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{LineSearch.BackTracking{Nothing, Float64, Float64, Float64, Val{3}, Float64, Bool}, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, ::Vararg{Nothing}) (0 children)                         
                 20: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{LineSearch.BackTracking{Nothing, Float64, Float64, Float64, Val{3}, Float64, Bool}, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, ::Vararg{Nothing}) (0 children)            
                 21: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{LineSearch.BackTracking{Nothing, Float64, Float64, Float64, Val{3}, Float64, Bool}, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}) (0 children)                                            
                 22: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{LineSearch.BackTracking{Nothing, Float64, Float64, Float64, Val{3}, Float64, Bool}, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}) (0 children)                               
                 23: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Bastin, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, ::Vararg{Nothing}) (0 children)
                 24: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Bastin, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, ::Vararg{Nothing}) (0 children)
                 25: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Bastin, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}) (0 children)
                 26: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Bastin, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}) (0 children)
                 27: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveBase.NonlinearSolvePolyAlgorithm{Val{3}, Tuple{NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}}, Val{false}}, ::Vararg{Nothing}) (0 children)
                 28: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveBase.NonlinearSolvePolyAlgorithm{Val{3}, Tuple{NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}}, Val{false}}, ::Vararg{Nothing}) (0 children)
                 29: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveBase.NonlinearSolvePolyAlgorithm{Val{6}, Tuple{NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{LineSearch.BackTracking{Nothing, Float64, Float64, Float64, Val{3}, Float64, Bool}, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Bastin, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}}, Val{false}}, ::Vararg{Nothing}) (0 children)                                                                                       
                 30: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::NonlinearSolveBase.NonlinearSolvePolyAlgorithm{Val{6}, Tuple{NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{LineSearch.BackTracking{Nothing, Float64, Float64, Float64, Val{3}, Float64, Bool}, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Bastin, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}}, Val{false}}, ::Vararg{Nothing}) (0 children)                                                                          
                 31: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::Nothing, ::Nothing) (0 children)                                                                                                                                                  
                 32: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::Nothing, ::Nothing) (0 children)                                                                                                                                     
                 33: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::SciMLBase.AbstractNonlinearAlgorithm, ::Nothing) (0 children)                                                                                                                     
                 34: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::SciMLBase.AbstractNonlinearAlgorithm, ::Nothing) (0 children)                                                                                                        
                 35: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::Nothing) (0 children)                                                                                                                                                             
                 36: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::Nothing) (0 children)                                                                                                                                                
                 37: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Bool, ::Nothing, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::SciMLBase.AbstractNonlinearAlgorithm) (0 children)                                                                                                                                
                 38: signature Tuple{typeof(merge), Any, Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}} triggered MethodInstance for NonlinearSolveBase.var"#init_call#161"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.init_call), ::Any, ::SciMLBase.AbstractNonlinearAlgorithm) (0 children)                                                                                                                   
   backedges: 1: superseding merge(d::AbstractDict, others::AbstractDict...) @ Base abstractdict.jl:361 with MethodInstance for merge(::AbstractDict, ::Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}) (21 children)
              2: superseding merge(d::AbstractDict, others::AbstractDict...) @ Base abstractdict.jl:361 with MethodInstance for merge(::AbstractDict, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}) (2489 children)
```

Written with help from Claude :robot: 

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API