### PR TITLE
Fix NonlinearSolveSciPy test env: drop undeclared Hwloc from test target

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.20.0"
+version = "4.20.1"
 authors = ["SciML"]
 
 [deps]

--- a/ext/NonlinearSolvePETScExt.jl
+++ b/ext/NonlinearSolvePETScExt.jl
@@ -126,19 +126,20 @@ function SciMLBase.__solve(
             PJ = PETSc.MatSeqDense(petsclib, J_init)
         end
 
-        # PETSc 0.4 callback signature: jac!(J, snes, x) returning PetscInt(0) for success
-        # Use J_init as intermediate storage for the Julia Jacobian
+        # PETSc 0.4 callback signature: jac!(J, snes, x) returning PetscInt(0) for success.
+        # `J_init` is closed over directly as intermediate storage for the Julia Jacobian.
+        # PETSc reconstructs a fresh `snes` wrapper for the callback whose `user_ctx` is
+        # `nothing`, so the Julia-side context cannot be recovered through `snes_arg`.
         function jac_fn!(J, snes_arg, cx)
             njac[] += 1
             PETSc.withlocalarray!(cx; read = true, write = false) do x_arr
-                jac!(snes_arg.user_ctx.jacobian, x_arr)
-                copy_to_petsc_mat!(J, snes_arg.user_ctx.jacobian)
+                jac!(J_init, x_arr)
+                copy_to_petsc_mat!(J, J_init)
                 PETSc.assemble!(J)
             end
             return PETSc.LibPETSc.PetscInt(0)
         end
         PETSc.setjacobian!(snes, jac_fn!, PJ, PJ)
-        snes.user_ctx = (; jacobian = J_init)
     end
 
     # Create PETSc vector for solution and solve

--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.31.0"
+version = "2.31.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -53,9 +53,15 @@ function construct_jacobian_cache(
         end
         autodiff = standardize_forwarddiff_tag(autodiff, prob)
         autodiff = construct_concrete_adtype(f, autodiff)
-        # Enzyme cannot differentiate through FunctionWrappers' llvmcall.
-        # Unwrap AutoSpecializeCallable so DI sees the raw user function.
-        if is_fw_wrapped(f.f) && _uses_enzyme_ad(autodiff)
+        # Unwrap AutoSpecializeCallable so DI sees the raw user function when:
+        # - Enzyme is used (it cannot differentiate through FunctionWrappers' llvmcall), or
+        # - a runtime sparsity detector is active. The detector runs its own AD pass with
+        #   a foreign tag (e.g. `DenseSparsityDetector` with `AutoForwardDiff`), producing
+        #   isbits dual element types that match no precompiled `NonlinearSolveTag` wrapper
+        #   signature and do not hit the non-isbits fallback, so the call would otherwise
+        #   throw `NoFunctionWrapperFoundError`.
+        if is_fw_wrapped(f.f) &&
+                (_uses_enzyme_ad(autodiff) || _has_runtime_sparsity_detector(f))
             f = @set f.f = get_raw_f(f.f)
         end
         di_extras = if SciMLBase.isinplace(f)
@@ -196,6 +202,11 @@ function (cache::JacobianCache{<:JacobianOperator})(u)
 end
 
 # Sparse Automatic Differentiation
+# True when `f` carries a runtime sparsity detector (`ADTypes.AbstractSparsityDetector`),
+# i.e. one whose detection pass evaluates the function with foreign element types rather
+# than reading a known prototype matrix.
+_has_runtime_sparsity_detector(f::NonlinearFunction) = f.sparsity isa ADTypes.AbstractSparsityDetector
+
 function construct_concrete_adtype(f::NonlinearFunction, ad::AbstractADType)
     return if f.sparsity === nothing
         if f.jac_prototype === nothing

--- a/lib/NonlinearSolveFirstOrder/test/sparsity_tests__item2.jl
+++ b/lib/NonlinearSolveFirstOrder/test/sparsity_tests__item2.jl
@@ -1,7 +1,8 @@
 using NonlinearSolveFirstOrder
 
 using SparseConnectivityTracer, BandedMatrices, LinearAlgebra, SparseArrays,
-    SparseMatrixColorings
+    SparseMatrixColorings, ADTypes
+using DifferentiationInterface: DenseSparsityDetector
 
 N = 16
 p = rand(N)
@@ -39,6 +40,23 @@ for nlf in (f, f!)
         )
 
         cache = init(nlprob_autosparse, NewtonRaphson(); abstol = 1.0e-9)
+        @test cache.jac_cache.J isa SparseMatrixCSC
+        sol = solve!(cache)
+        @test SciMLBase.successful_retcode(sol)
+    end
+
+    # The detector runs its own ForwardDiff pass with a foreign tag; under the default
+    # AutoSpecialize wrapping this used to throw `NoFunctionWrapperFoundError` because the
+    # isbits foreign-tag duals matched no precompiled wrapper signature.
+    @testset "Unstructured Sparse AD: DenseSparsityDetector" begin
+        nlprob_dense_detector = NonlinearProblem(
+            NonlinearFunction(
+                nlf; sparsity = DenseSparsityDetector(AutoForwardDiff(); atol = 1.0e-4)
+            ),
+            u0, p
+        )
+
+        cache = init(nlprob_dense_detector, NewtonRaphson(); abstol = 1.0e-9)
         @test cache.jac_cache.J isa SparseMatrixCSC
         sol = solve!(cache)
         @test SciMLBase.successful_retcode(sol)

--- a/lib/NonlinearSolveSciPy/Project.toml
+++ b/lib/NonlinearSolveSciPy/Project.toml
@@ -38,4 +38,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 [targets]
-test = ["InteractiveUtils", "SciMLTesting", "Test", "SafeTestsets", "Hwloc", "Pkg"]
+test = ["InteractiveUtils", "SciMLTesting", "Test", "SafeTestsets", "Pkg"]

--- a/lib/NonlinearSolveSciPy/test/runtests.jl
+++ b/lib/NonlinearSolveSciPy/test/runtests.jl
@@ -18,10 +18,11 @@ run_tests(;
         "Wrappers" => function ()
             return include("wrappers_tests.jl")
         end,
-        # QA (Aqua/JET): dep-adding group in its own isolated sub-env (test/qa).
-        "QA" => (;
-            env = joinpath(@__DIR__, "qa"),
-            body = joinpath(@__DIR__, "qa", "qa.jl"),
-        ),
+    ),
+    # QA (Aqua/JET) is a dep-adding group: it runs in its own isolated sub-env
+    # under test/qa (excluded from the base/Core/All run).
+    qa = (;
+        env = joinpath(@__DIR__, "qa"),
+        body = joinpath(@__DIR__, "qa", "qa.jl"),
     ),
 )


### PR DESCRIPTION
## Problem

Master CI is red on the SciPy sublibrary jobs (Core, QA, Wrappers) and the documentation build. All of them fail at the Pkg project-validation step with:

```
ERROR: LoadError: Dependency `Hwloc` in target `test` not listed in `deps`, `weakdeps` or `extras` section
 at ".../lib/NonlinearSolveSciPy/Project.toml".
```

## Root cause

PR #966 ("Add QA (Aqua/JET) group to NonlinearSolveSciPy") added `"Hwloc"` to the `test` target of `lib/NonlinearSolveSciPy/Project.toml` but never declared `Hwloc` in `[deps]`, `[weakdeps]`, or `[extras]` (nor added a `[compat]` entry). Pkg validates the target dependency list against the declared sections and errors before any test runs, which is why every SciPy job and the docs build (which resolves the SciPy sublibrary) fail at instantiate time.

`Hwloc` is not referenced anywhere in the SciPy sublibrary's sources or tests, and it appears in **no other** `Project.toml` in the repository (not the root, not any sibling sublibrary). The companion `Pkg` entry added in the same PR was declared correctly in `[extras]` and `[compat]`, so it is left untouched.

## Fix

Remove the stray `"Hwloc"` from the `test` target.

```diff
-test = ["InteractiveUtils", "SciMLTesting", "Test", "SafeTestsets", "Hwloc", "Pkg"]
+test = ["InteractiveUtils", "SciMLTesting", "Test", "SafeTestsets", "Pkg"]
```

## Local verification

Reproduced and verified on Julia 1.10 (the package's `[compat]` julia floor) using the same validation Pkg performs:

```
=== ORIGINAL (broken) project ===
VALIDATION FAILED: Dependency `Hwloc` in target `test` not listed in `deps`, `weakdeps` or `extras` section
=== PATCHED project ===
VALIDATION PASSED
test target = ["InteractiveUtils", "SciMLTesting", "Test", "SafeTestsets", "Pkg"]
```

## Scope

This fixes only the SciPy/docs instantiate failure. The `downgrade-sublibraries`, `Trim`, and `BoundaryValueDiffEq` downstream failures on master are separate, pre-existing issues unrelated to this change.

Please ignore until reviewed by @ChrisRackauckas.

## Follow-up: SciPy QA harness fix (commit 06a13d1c4)

After the Hwloc fix unblocked instantiate, the SciPy QA jobs surfaced a second, pre-existing misconfiguration: `lib/NonlinearSolveSciPy/test/runtests.jl` declared its QA group as a `"QA"` entry **inside the `groups` Dict**. In SciMLTesting v1.2 `run_tests`, `GROUP=="QA"` is resolved against the dedicated `qa=` keyword (checked before the `groups` lookup), so a QA spec in `groups` is never reached and the job errored with `run_tests: GROUP="QA" was requested but no `qa` body was provided`.

Fix: move the QA spec out of `groups` into the `qa=` keyword, matching the sibling sublibraries (BracketingNonlinearSolve / NonlinearSolveFirstOrder / SimpleNonlinearSolve). The `test/qa` sub-env is unchanged.

Verified locally on Julia 1.10 (the SciPy compat floor): `NONLINEARSOLVE_TEST_GROUP=QA Pkg.test()` now runs the QA body (12/12 Aqua+JET tests pass) instead of throwing.

The Documentation, downgrade-sublibraries, BoundaryValueDiffEq and ModelingToolkit downstream reds remain pre-existing on master (`05b6bed0`) and are out of scope for this PR.

## Follow-up: docs `@example` source bugs (commit 9c1bdf55c)

With instantiate unblocked, the docs build surfaced two genuine source bugs (both reproduced on Julia 1.12, the current "1" channel), unrelated to the SciPy env:

1. **`snes_ex2.md` — `FieldError: type Nothing has no field jacobian`.** `NonlinearSolvePETScExt`'s Jacobian callback fetched the Julia-side intermediate matrix through `snes_arg.user_ctx.jacobian`. PETSc.jl 0.4.x reconstructs a *fresh* `PetscSNES` wrapper for the callback whose `user_ctx` defaults to `nothing` (the 3-arg `jac_fn!` means PETSc calls the no-`user_ctx` form), so `.jacobian` threw. Fix: close over `J_init` directly and drop the `snes.user_ctx` assignment.

2. **`large_systems.md` — `No matching function wrapper was found!`.** `DenseSparsityDetector(AutoForwardDiff())` runs its own ForwardDiff pass with a foreign tag; under the default AutoSpecialize wrapping those isbits foreign-tag duals match no precompiled `NonlinearSolveTag` wrapper signature and don't hit the non-isbits fallback (SCT tracers do, via their `BitSet`), so the wrapper threw. Fix: in `construct_jacobian_cache`, unwrap the `AutoSpecializeCallable` when a runtime sparsity detector is active (mirroring the existing Enzyme treatment).

Adds a `DenseSparsityDetector` regression case to NonlinearSolveFirstOrder's `sparsity_tests` (OOP + IIP AutoSpecialize-wrapped path). Patch-bumps `NonlinearSolveBase` 2.31.0→2.31.1 and `NonlinearSolve` 4.20.0→4.20.1.

**Local verification (Julia 1.12, the failing docs channel), against the exact failing doc-example code:**
- `snes_ex2`: dense and sparse `PETScSNES` solutions match `NewtonRaphson` to ~2e-15 (`retcode=Success`); the `FieldError` is gone.
- `large_systems`: `DenseSparsityDetector(AutoForwardDiff())` solve now returns `retcode=Success` (and `TracerSparsityDetector` still works).
- New `DenseSparsityDetector` testset passes 2/2 for both `f` and `f!`.

Please ignore until reviewed by @ChrisRackauckas.