### PR TITLE
Fix NonlinearSolveSciPy test target: drop undeclared Hwloc dep

### DIFF
--- a/lib/NonlinearSolveSciPy/Project.toml
+++ b/lib/NonlinearSolveSciPy/Project.toml
@@ -24,18 +24,18 @@ Pkg = "1.10"
 PrecompileTools = "1.2"
 PythonCall = "0.9"
 Reexport = "1.2.2"
+SafeTestsets = "0.1"
 SciMLBase = "2.153, 3"
 SciMLTesting = "1"
 Test = "1.10"
 julia = "1.10"
 
-SafeTestsets = "0.1"
 [extras]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 [targets]
-test = ["InteractiveUtils", "SciMLTesting", "Test", "SafeTestsets", "Hwloc", "Pkg"]
+test = ["InteractiveUtils", "SciMLTesting", "Test", "SafeTestsets", "Pkg"]

--- a/lib/NonlinearSolveSciPy/test/runtests.jl
+++ b/lib/NonlinearSolveSciPy/test/runtests.jl
@@ -18,10 +18,13 @@ run_tests(;
         "Wrappers" => function ()
             return include("wrappers_tests.jl")
         end,
-        # QA (Aqua/JET): dep-adding group in its own isolated sub-env (test/qa).
-        "QA" => (;
-            env = joinpath(@__DIR__, "qa"),
-            body = joinpath(@__DIR__, "qa", "qa.jl"),
-        ),
+    ),
+    # QA (Aqua/JET) is a dep-adding group: it runs in its own isolated sub-env
+    # under test/qa (excluded from the base/Core/All run).
+    qa = (;
+        env = joinpath(@__DIR__, "qa"),
+        body = function ()
+            return include("qa/qa.jl")
+        end,
     ),
 )


### PR DESCRIPTION
## Problem

Master CI is red on the SciPy sublibrary jobs (Core, QA, Wrappers), the SciPy downgrade job, and the Documentation build. All of them fail at the Pkg project-validation step with:

```
ERROR: Dependency `Hwloc` in target `test` not listed in `deps`, `weakdeps` or `extras` section
 at ".../lib/NonlinearSolveSciPy/Project.toml".
```

## Root cause

PR #966 ("Add QA (Aqua/JET) group to NonlinearSolveSciPy") added `"Hwloc"` to the `test` target of `lib/NonlinearSolveSciPy/Project.toml` but never declared `Hwloc` in `[deps]`, `[weakdeps]`, or `[extras]` (only the companion `Pkg` entry was added correctly). Pkg validates that every name in a target is declared, so reading the project errors out. This fires on every consumer that instantiates the sublibrary's Project.toml — the Documentation build (which `dev`s the umbrella), the SciPy Core/QA/Wrappers CI groups, and the SciPy downgrade job.

`Hwloc` is not referenced by any NonlinearSolveSciPy test (`basic_tests`, `wrappers_tests`, `qa`) and is absent from every other sublibrary's and the root package's test target, so the entry is dead.

## Fix

Remove `"Hwloc"` from the test target. Also tidy the previously orphaned `SafeTestsets` keys into their proper `[compat]`/`[extras]` tables (they sat after blank lines — valid TOML, but misleading).

This supersedes the closed #977.

## Local verification

On Julia 1.12.6 (the "1" CI channel), `Pkg.Types.read_project` on `lib/NonlinearSolveSciPy/Project.toml` errored with the exact CI message before the change and parses cleanly after. A sweep over all `lib/*/Project.toml` confirms every test-target name is now declared.

Please ignore until reviewed by @ChrisRackauckas

## Update: also fix the QA group wiring

With Hwloc removed, both SciPy QA jobs (Julia 1 and lts) were still red with `ArgumentError: GROUP="QA" was requested but no `qa` body was provided`. PR #966 registered the QA group inside the `groups` dict (with `body` as a file-path string), but SciMLTesting v1.2.0 only runs GROUP="QA" through the dedicated `qa=` keyword. Switched `lib/NonlinearSolveSciPy/test/runtests.jl` to the canonical `qa = (; env=..., body = function() ... end)` form used by every other sublibrary. Verified against SciMLTesting v1.2.0's run_tests dispatch on Julia 1.10.