### PR TITLE
Add InteractiveUtils to NonlinearSolveHomotopyContinuation test deps

### DIFF
--- a/lib/NonlinearSolveHomotopyContinuation/Project.toml
+++ b/lib/NonlinearSolveHomotopyContinuation/Project.toml
@@ -30,6 +30,7 @@ DifferentiationInterface = "0.7.3"
 DocStringExtensions = "0.9.3"
 Enzyme = "0.13.90"
 HomotopyContinuation = "2.12.0"
+InteractiveUtils = "<0.0.1, 1"
 LinearAlgebra = "1.10"
 NaNMath = "1.1"
 NonlinearSolve = "4.10"
@@ -44,6 +45,7 @@ SafeTestsets = "0.1"
 SciMLTesting = "1"
 [extras]
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
@@ -51,4 +53,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 [targets]
-test = ["Test", "NonlinearSolve", "Enzyme", "NaNMath", "SafeTestsets", "SciMLTesting"]
+test = ["Test", "NonlinearSolve", "Enzyme", "InteractiveUtils", "NaNMath", "SafeTestsets", "SciMLTesting"]


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem
`lib/NonlinearSolveHomotopyContinuation/test/runtests.jl` line 1 does `using SafeTestsets, Test, InteractiveUtils` and `@info sprint(InteractiveUtils.versioninfo)`, but `InteractiveUtils` is not declared in the sublibrary's `[compat]`, `[extras]`, or `[targets].test`. It is the only sublib in the monorepo missing this declaration (the other nine each declare it in all three places).

The test env therefore does not provide `InteractiveUtils`, and `runtests.jl:1` fails before any test runs:
```
ERROR: LoadError: ArgumentError: Package InteractiveUtils not found in current path.
```

This breaks three master lanes:
- Sublibrary CI: `lib/NonlinearSolveHomotopyContinuation` Core (Julia 1)
- Sublibrary CI: `lib/NonlinearSolveHomotopyContinuation` QA (Julia 1)
- Downgrade Sublibraries: `test (lib/NonlinearSolveHomotopyContinuation)`

## Fix
Declare `InteractiveUtils` in `[compat]` (`"<0.0.1, 1"`, matching the other sublibs), `[extras]`, and the `test` target.

## Verification (local, Julia 1.10)
`Pkg.test("NonlinearSolveHomotopyContinuation")`:
```
Testing NonlinearSolveHomotopyContinuation tests passed
AllRoots 169/169 | Single Root 50/50 | Code quality (Aqua.jl) 11/11
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)