### PR TITLE
Re-enable end-to-end Enzyme reverse-mode IIP NonlinearProblem adjoint test (#939)

### DIFF
--- a/test/Adjoint/adjoint_tests__item2.jl
+++ b/test/Adjoint/adjoint_tests__item2.jl
@@ -10,12 +10,10 @@ using NonlinearSolve
 #
 # End-to-end gradient correctness (the full
 # `Enzyme.autodiff(Reverse, simple_loss, Active, Duplicated(p, dp))`
-# over `solve(::NonlinearProblem)`) is not verified here because compiling
-# the `solve_up` Enzyme augmented_primal rule for an IIP problem triggers
-# a "GC error (probable corruption)" abort on macOS LTS in Enzyme v0.13.150
-# — a separate Enzyme/Julia 1.10 GC issue, not a NonlinearSolveBase bug.
-# Has been manually verified to return `dp ≈ [1.0, -1.0]` on Julia 1.11.9
-# and 1.12.6 with the patch + SciMLSensitivity loaded.
+# over `solve(::NonlinearProblem)`) lives in `adjoint_tests__item3.jl`. That
+# path used to abort with a "GC error (probable corruption)" on macOS LTS in
+# Enzyme v0.13.150 (EnzymeAD/Enzyme.jl#3130) and is re-enabled now that the
+# GC issue is fixed.
 using NonlinearSolveBase, SciMLBase, Enzyme
 
 resid!(du, u, p) = (du .= u .- p; nothing)

--- a/test/Adjoint/adjoint_tests__item3.jl
+++ b/test/Adjoint/adjoint_tests__item3.jl
@@ -1,0 +1,28 @@
+using NonlinearSolve
+
+# End-to-end regression for SciML/NonlinearSolve.jl#939 and
+# EnzymeAD/Enzyme.jl#3130. This drives a full reverse-mode
+# `Enzyme.autodiff` pass through `solve(::NonlinearProblem, NewtonRaphson())`
+# on the in-place (IIP) path, exercising the `solve_up` Enzyme
+# augmented_primal rule whose deeply nested `Tape{NamedTuple{...}}` type used
+# to abort the worker with "GC error (probable corruption)" on macOS LTS
+# (Julia 1.10) under Enzyme v0.13.150 (Enzyme.jl#3130). The probe in
+# `adjoint_tests__item2.jl` only checks the `maybe_wrap_nonlinear_f`
+# short-circuit; this item is the actual gradient the user cares about, and
+# is restored here so CI (including macOS LTS) verifies the GC issue stays
+# fixed on current Enzyme.
+using SciMLSensitivity, Enzyme
+
+function simple_loss(p)
+    prob = NonlinearProblem((du, u, p) -> du[1] = u[1] - p[1] + p[2], [0.0], p)
+    sol = solve(prob, NewtonRaphson())
+    return sum(sol.u)
+end
+
+p = [2.0, 1.0]
+dp = Enzyme.make_zero(p)
+Enzyme.autodiff(
+    Enzyme.Reverse, simple_loss, Enzyme.Active, Enzyme.Duplicated(p, dp)
+)
+
+@test dp ≈ [1.0, -1.0]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -159,7 +159,8 @@ else
                 env = joinpath(@__DIR__, "Adjoint"),
                 body = function ()
                     @time @safetestset "Adjoint Tests" include("Adjoint/adjoint_tests__item1.jl")
-                    return @time @safetestset "maybe_wrap_nonlinear_f skips wrapping inside Enzyme.autodiff (#939)" include("Adjoint/adjoint_tests__item2.jl")
+                    @time @safetestset "maybe_wrap_nonlinear_f skips wrapping inside Enzyme.autodiff (#939)" include("Adjoint/adjoint_tests__item2.jl")
+                    return @time @safetestset "Enzyme reverse-mode over IIP NonlinearProblem (#939)" include("Adjoint/adjoint_tests__item3.jl")
                 end,
             ),
             "Wrappers" => (;


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

## Summary

Re-enables the full end-to-end Enzyme reverse-mode adjoint test over `solve(::NonlinearProblem, NewtonRaphson())` on the **in-place (IIP)** path, as requested by @wsmoses in [EnzymeAD/Enzyme.jl#3130 (comment)](https://github.com/EnzymeAD/Enzyme.jl/issues/3130#issuecomment-4785751039):

> can you try to re-enable the ci test which otherwise was failing linked here?

## Background

In #940 the regression test for #939 was originally the full
`Enzyme.autodiff(Reverse, simple_loss, Active, Duplicated(p, dp))` over an IIP
`NonlinearProblem`. That path aborted the worker with `GC error (probable
corruption)` on **macOS LTS (Julia 1.10) under Enzyme v0.13.150** — tracked as
EnzymeAD/Enzyme.jl#3130. To keep CI green at the time, #940 downgraded the test
to a lightweight probe of `maybe_wrap_nonlinear_f`'s `EnzymeCore.within_autodiff()`
short-circuit (`adjoint_tests__item2.jl`), which never exercises the heavy
`solve_up` augmented_primal tape.

Enzyme has since advanced (v0.13.150 → v0.13.169) and the GC abort no longer
reproduces. This PR restores the actual end-to-end gradient test so CI verifies
the fix and guards against regression.

## Change

- Add `test/Adjoint/adjoint_tests__item3.jl`: the full
  `Enzyme.autodiff(Reverse, simple_loss, ...)` over `solve(::NonlinearProblem)`
  asserting `dp ≈ [1.0, -1.0]`.
- Register it in the `Adjoint` group in `test/runtests.jl`.
- Update the now-stale note in `adjoint_tests__item2.jl` to point at item3.

The `Adjoint` group is configured `versions = ["lts", "1"]`, `os = ["ubuntu-latest", "macos-latest"]` in `test/test_groups.toml`, so the `lts × macos-latest` cell re-exercises the **exact macOS-LTS combination that originally crashed**.

## Verification

Ran locally on **Linux, Julia 1.10.11 (LTS)** with the current released stack (Enzyme v0.13.169, NonlinearSolve v4.20.0, NonlinearSolveBase v2.31.1, SciMLSensitivity v7.112.1):

```
dp = [1.0, -1.0]
END-TO-END OK
```

No GC error. macOS LTS itself is unavailable to me locally — confirming the GC fix on that platform is precisely what this PR hands to CI.

## Related

- EnzymeAD/Enzyme.jl#3130
- #939, #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)