### PR TITLE
Release 4 subpackage(s)

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.31.1"
+version = "2.31.2"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveHomotopyContinuation/Project.toml
+++ b/lib/NonlinearSolveHomotopyContinuation/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveHomotopyContinuation"
 uuid = "2ac3b008-d579-4536-8c91-a1a5998c2f8b"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com> and contributors"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/NonlinearSolveSciPy/Project.toml
+++ b/lib/NonlinearSolveSciPy/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveSciPy"
 uuid = "4827a3aa-8a82-4c61-8bd0-3c7d3e464ee5"
 authors = ["SciML"]
-version = "1.3.1"
+version = "1.3.2"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/SCCNonlinearSolve/Project.toml
+++ b/lib/SCCNonlinearSolve/Project.toml
@@ -1,6 +1,6 @@
 name = "SCCNonlinearSolve"
 uuid = "9dfe8606-65a1-4bb3-9748-cb89d1561431"
-version = "1.13.1"
+version = "1.13.2"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
Automated subpackage release bumps:
- NonlinearSolveBase v2.31.2
- NonlinearSolveHomotopyContinuation v0.1.9
- NonlinearSolveSciPy v1.3.2
- SCCNonlinearSolve v1.13.2