### PR TITLE
NonlinearSolveBase: declare documented API public (downstream ExplicitImports)

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.31.2"
+version = "2.31.3"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
+++ b/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
@@ -83,10 +83,6 @@ include("forward_diff.jl")
 # Unexported Public API
 @compat(public, (L2_NORM, Linf_NORM, NAN_CHECK, UNITLESS_ABS2, get_tolerance))
 
-# Documented cache/termination author interface (so downstream packages can drop their
-# `NonlinearSolveBase.X` non-public ExplicitImports ignores). `get_abstol`/`get_reltol`
-# are part of the documented `AbstractNonlinearSolveCache` interface; the termination-mode
-# abstract supertypes are the documented hierarchy the concrete modes extend.
 @compat(public, (get_abstol, get_reltol))
 @compat(public, (AbstractNonlinearTerminationMode, AbstractSafeNonlinearTerminationMode))
 @compat(public, (nonlinearsolve_forwarddiff_solve, nonlinearsolve_dual_solution))

--- a/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
+++ b/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
@@ -82,6 +82,13 @@ include("forward_diff.jl")
 
 # Unexported Public API
 @compat(public, (L2_NORM, Linf_NORM, NAN_CHECK, UNITLESS_ABS2, get_tolerance))
+
+# Documented cache/termination author interface (so downstream packages can drop their
+# `NonlinearSolveBase.X` non-public ExplicitImports ignores). `get_abstol`/`get_reltol`
+# are part of the documented `AbstractNonlinearSolveCache` interface; the termination-mode
+# abstract supertypes are the documented hierarchy the concrete modes extend.
+@compat(public, (get_abstol, get_reltol))
+@compat(public, (AbstractNonlinearTerminationMode, AbstractSafeNonlinearTerminationMode))
 @compat(public, (nonlinearsolve_forwarddiff_solve, nonlinearsolve_dual_solution))
 @compat(
     public,


### PR DESCRIPTION
Declare NonlinearSolveBase-owned, documented public-API names `public` so downstream packages can drop their `NonlinearSolveBase.X` non-public ExplicitImports ignores.

## Made public (NonlinearSolveBase-owned + documented)

- **`get_abstol`, `get_reltol`** — part of the documented `AbstractNonlinearSolveCache` interface. That interface's docstring lists `get_abstol(cache)` / `get_reltol(cache)` as required methods, and it is rendered in `docs/src/devdocs/internal_interfaces.md`.
- **`AbstractNonlinearTerminationMode`, `AbstractSafeNonlinearTerminationMode`** — the documented termination-mode supertype hierarchy. Every concrete, exported termination mode (`AbsTerminationMode`, `RelNormSafeBestTerminationMode`, …) renders its supertype (`<: AbstractNonlinearTerminationMode` / `<: AbstractSafeNonlinearTerminationMode`) in its docstring, and downstream packages dispatch on these supertypes. They live in `src/public.jl`.

## Skipped (with reason)

- **`get_maxiters`** — not defined anywhere in `lib/NonlinearSolveBase/src/` (no such symbol); nothing to publicize.
- **`AbstractSafeBestNonlinearTerminationMode`** and internals (`AutoSpecializeCallable`, `Utils`, …) — outside the requested documented subset / clearly internal.

## Rationale

These are stable, documented author-interface names that downstream SciML packages reference as `NonlinearSolveBase.X`. Declaring them `public` lets those downstreams drop the corresponding non-public-access ignores from their ExplicitImports QA configuration. Uses the package's established `@compat(public, (...))` (Compat.jl) style, which already gates the `public` keyword for the Julia 1.10 floor. Bumps `NonlinearSolveBase` 2.31.2 -> 2.31.3 (public-API addition).

This PR should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)