### PR TITLE
Fix docs build: PETScSNES Jacobian callback + HomotopyProblem @ref

### DIFF
--- a/docs/src/basics/nonlinear_problem.md
+++ b/docs/src/basics/nonlinear_problem.md
@@ -52,4 +52,5 @@ IntervalNonlinearProblem
 NonlinearProblem
 SteadyStateProblem
 NonlinearLeastSquaresProblem
+SciMLBase.HomotopyProblem
 ```

--- a/ext/NonlinearSolvePETScExt.jl
+++ b/ext/NonlinearSolvePETScExt.jl
@@ -126,19 +126,20 @@ function SciMLBase.__solve(
             PJ = PETSc.MatSeqDense(petsclib, J_init)
         end
 
-        # PETSc 0.4 callback signature: jac!(J, snes, x) returning PetscInt(0) for success
-        # Use J_init as intermediate storage for the Julia Jacobian
+        # PETSc 0.4 callback signature: jac!(J, snes, x) returning PetscInt(0) for success.
+        # `J_init` (captured in the closure) is the Julia-side scratch Jacobian; PETSc does
+        # not round-trip `snes.user_ctx` back to the callback (it arrives as `nothing`), so
+        # we use the captured buffer directly rather than `snes_arg.user_ctx`.
         function jac_fn!(J, snes_arg, cx)
             njac[] += 1
             PETSc.withlocalarray!(cx; read = true, write = false) do x_arr
-                jac!(snes_arg.user_ctx.jacobian, x_arr)
-                copy_to_petsc_mat!(J, snes_arg.user_ctx.jacobian)
+                jac!(J_init, x_arr)
+                copy_to_petsc_mat!(J, J_init)
                 PETSc.assemble!(J)
             end
             return PETSc.LibPETSc.PetscInt(0)
         end
         PETSc.setjacobian!(snes, jac_fn!, PJ, PJ)
-        snes.user_ctx = (; jacobian = J_init)
     end
 
     # Create PETSc vector for solution and solve


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

## What's broken

The `Documentation` CI job on `master` has been red since at least 2026-06-23. `makedocs` terminates with `[:cross_references, :example_block]` — two independent errors:

1. **`docs/src/tutorials/snes_ex2.md`** — every `PETScSNES` `@example` block (lines 57-61, 74-76, 84-86) throws:
   ```
   FieldError: type Nothing has no field `jacobian`; Nothing has no fields at all.
   ```
   from the Jacobian callback in `ext/NonlinearSolvePETScExt.jl`. With PETSc 0.4.x the callback receives a `snes_arg` whose `user_ctx` is `nothing` — PETSc does not round-trip the Julia-side `snes.user_ctx` back into the callback — so `snes_arg.user_ctx.jacobian` errors.

2. **`docs/src/native/solvers.md`** — `[`SciMLBase.HomotopyProblem`](@ref)` in the `HomotopySweep` docstring cannot resolve:
   ```
   Cannot resolve @ref for md"[`SciMLBase.HomotopyProblem`](@ref)" ...
   - No docstring found in doc for binding `SciMLBase.HomotopyProblem`.
   ```
   `SciMLBase.HomotopyProblem` has a docstring but it is never rendered anywhere in the manual, so Documenter has no anchor to link to.

## Fixes

1. Use the closure-captured `J_init` as the Julia-side scratch Jacobian directly (it is already in scope in `jac_fn!`), and drop the now-unused `snes.user_ctx` assignment.
2. Render `SciMLBase.HomotopyProblem` in the `@docs` block of `docs/src/basics/nonlinear_problem.md` so the cross-reference resolves.

## Verification (run locally)

Julia 1.12.6, PETSc 0.4.10 / PETSc_jll 3.22.1, in the actual `docs/` environment:

- Before: `solve(nlprob_dense, PETScSNES())` throws the `FieldError` above (reproduced).
- After: dense **and** sparse `PETScSNES` both return `retcode = Success` with `resid ≈ 1.1e-9`, matching `NewtonRaphson`, no exception.
- A scoped Documenter build resolves the `@ref` with `cross_references` kept as a hard error; the same build reproduces the exact CI `[:cross_references]` error when the `HomotopyProblem` docstring is removed (negative control).

## Not addressed here

- **`Trim` job on `julia pre` (1.13.0-rc1)** is also red on `master`, but it is an upstream **JET / Julia 1.13-rc1** incompatibility, not a NonlinearSolve bug: `test_opt` on 1.13-rc1 returns 233 spurious `RuntimeDispatchReport`s located in Base's own `show_unquoted`/`Printf.fmt` printing code, then crashes fatally in `display_error` (`IOContext`/`ImmutableDict` `MethodError` in a stale world age after JET tracks Base). The same `test_opt` returns zero reports and passes on Julia 1.12. Left out of this PR since fixing it would require disabling a real test; worth a separate upstream JET issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)