### PR TITLE
Fix docs build: unwrap AutoSpecialize for AD-based sparsity detection

### DIFF
--- a/lib/NonlinearSolveBase/src/autospecialize.jl
+++ b/lib/NonlinearSolveBase/src/autospecialize.jl
@@ -73,6 +73,17 @@ _uses_enzyme_ad(ad::AutoSparse) = _uses_enzyme_ad(ADTypes.dense_ad(ad))
 _uses_enzyme_ad(_) = false
 
 """
+    _uses_ad_sparsity_detector(ad) -> Bool
+
+Return `true` if `ad` is an `AutoSparse` whose sparsity detector differentiates the
+function (`DenseSparsityDetector`). Such detectors call the function with their own AD
+tag, which `AutoSpecializeCallable`'s FunctionWrapper does not have an entry for, so the
+raw user function must be used. Tracer-based detectors do not differentiate and are fine.
+"""
+_uses_ad_sparsity_detector(ad::AutoSparse) = ADTypes.sparsity_detector(ad) isa DI.DenseSparsityDetector
+_uses_ad_sparsity_detector(_) = false
+
+"""
     maybe_unwrap_prob_for_enzyme(prob, autodiffs...)
 
 If the problem function is wrapped by AutoSpecialize and any of the given AD backends

--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -53,9 +53,12 @@ function construct_jacobian_cache(
         end
         autodiff = standardize_forwarddiff_tag(autodiff, prob)
         autodiff = construct_concrete_adtype(f, autodiff)
-        # Enzyme cannot differentiate through FunctionWrappers' llvmcall.
-        # Unwrap AutoSpecializeCallable so DI sees the raw user function.
-        if is_fw_wrapped(f.f) && _uses_enzyme_ad(autodiff)
+        # Enzyme cannot differentiate through FunctionWrappers' llvmcall, and AD-based
+        # sparsity detection (DenseSparsityDetector) differentiates with a foreign tag the
+        # wrapper has no entry for. In both cases unwrap AutoSpecializeCallable so DI sees
+        # the raw user function.
+        if is_fw_wrapped(f.f) &&
+                (_uses_enzyme_ad(autodiff) || _uses_ad_sparsity_detector(autodiff))
             f = @set f.f = get_raw_f(f.f)
         end
         di_extras = if SciMLBase.isinplace(f)

--- a/lib/NonlinearSolveFirstOrder/test/sparsity_tests__item1.jl
+++ b/lib/NonlinearSolveFirstOrder/test/sparsity_tests__item1.jl
@@ -2,6 +2,7 @@ using NonlinearSolveFirstOrder
 
 using LinearAlgebra, SparseArrays, SparseConnectivityTracer, ADTypes,
     SparseMatrixColorings
+using DifferentiationInterface: DenseSparsityDetector
 
 const N = 32
 const xyd_brusselator = range(0, stop = 1, length = N)
@@ -58,6 +59,21 @@ prob_brusselator_2d_sparse = NonlinearProblem(
     u0, p
 )
 sol = solve(prob_brusselator_2d_sparse, NewtonRaphson(); abstol = 1.0e-8)
+@test norm(sol.resid, Inf) < 1.0e-8
+
+# AD-based sparsity detection (DenseSparsityDetector) differentiates the function with its
+# own tag. Combined with the default AutoSpecialize FunctionWrapper this used to throw
+# "No matching function wrapper was found!"; the Jacobian cache must unwrap to the raw
+# function for the detector. (SparseMatrixColorings is loaded above, so the sparse
+# coloring path is active.)
+prob_brusselator_2d_dense_di = NonlinearProblem(
+    NonlinearFunction(
+        brusselator_2d_loop;
+        sparsity = DenseSparsityDetector(AutoForwardDiff(); atol = 1.0e-4)
+    ),
+    u0, p
+)
+sol = solve(prob_brusselator_2d_dense_di, NewtonRaphson(); abstol = 1.0e-8)
 @test norm(sol.resid, Inf) < 1.0e-8
 
 f! = (du, u) -> brusselator_2d_loop(du, u, p)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

Follow-up to #989. That PR fixed two of the three `Documentation` build failures, but was merged before its third commit synced, so master's `Documentation` job is still red:

```
failed to run `@example` block in docs/src/tutorials/large_systems.md:324-338
  exception = No matching function wrapper was found!
```

(Confirmed on master commit `5cf15ef4`, run 28322141470 — only this block remains; the PETSc and `HomotopyProblem` `@ref` failures from #989 are gone.)

## Cause

With `SparseMatrixColorings` loaded (the sparse-coloring path), a problem built with
`sparsity = DenseSparsityDetector(AutoForwardDiff())` and the default `AutoSpecialize`
fails. `DenseSparsityDetector` differentiates the function with its own ForwardDiff tag
(`DifferentiationInterface.FixTail{…}`), but `AutoSpecializeCallable`'s FunctionWrapper
only has entries for `NonlinearSolveTag` duals, so no wrapper matches.

## Fix

This is the same class of problem the Jacobian cache already handles for Enzyme (which
also can't go through the FunctionWrapper): unwrap `AutoSpecializeCallable` to the raw
user function. Extend the existing unwrap condition in
`lib/NonlinearSolveBase/src/jacobian.jl` to also fire when the autodiff is an `AutoSparse`
whose detector is a `DenseSparsityDetector` (new `_uses_ad_sparsity_detector` helper).
Tracer-based detectors don't differentiate and are unaffected.

## Test

Regression test added to NonlinearSolveFirstOrder's `sparsity_tests__item1.jl` (it already
loads `SparseMatrixColorings`): solving the Brusselator with a `DenseSparsityDetector` and
the default specialization. Before the fix it throws `No matching function wrapper`; after,
it converges.

Verified locally (Julia 1.12.6, in the `docs/` environment): the previously-failing
`large_systems.md` block now runs (`retcode = Success`), and the updated `sparsity_tests`
file passes 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)