### PR TITLE
CI: drop prerelease (1.13) channel from the Trim test group

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -38,9 +38,12 @@ os = ["ubuntu-latest", "macos-latest"]
 [QA]
 versions = ["lts", "1"]
 
-# Trimming was introduced in Julia 1.12; skip lts (1.10).
+# Trimming was introduced in Julia 1.12; skip lts (1.10). The prerelease channel
+# (1.13) is also skipped: JET's `report_opt`/`test_opt` mis-analyzes on 1.13-rc1
+# (spurious dynamic-dispatch reports inside Base's printing code plus a fatal crash
+# in error display), which is an upstream JET/Julia issue, not a NonlinearSolve one.
 [Trim]
-versions = ["1", "pre"]
+versions = ["1"]
 os = ["ubuntu-latest", "macos-latest"]
 
 # GPU group: CUDA sub-env on a self-hosted GPU runner (ubuntu only).


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

The `Trim` job is red on the `pre` channel (Julia 1.13.0-rc1) because of an upstream **JET / Julia 1.13** incompatibility, not a NonlinearSolve bug:

- `test_opt(minimize, (Float64,))` returns **zero** reports and passes on Julia 1.12.6.
- On 1.13.0-rc1 it returns ~233 spurious `RuntimeDispatchReport`s, almost all located inside Base's own printing code (`show_unquoted`, `Printf.fmt`) after JET/Revise tracks Base, then crashes fatally in `display_error` → `IOContext`/`ImmutableDict` `MethodError` in a stale `@world` world age.

This drops `pre` from the `[Trim]` group in `test/test_groups.toml`, mirroring the existing `[Bounds]` and `[Adjoint]` groups that already exclude the prerelease channel for upstream-compat reasons. The `VERSION >= v"1.12"` gate in `test/runtests.jl` is unchanged, so Trim still runs on the `1` (stable) channel.

Reproduced locally on Julia 1.13.0-rc1 (fails) vs 1.12.6 (passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)