### PR TITLE
Allow CUDA.jl v6 in GPU test environments

### DIFF
--- a/lib/SimpleNonlinearSolve/test/gpu/Project.toml
+++ b/lib/SimpleNonlinearSolve/test/gpu/Project.toml
@@ -16,7 +16,7 @@ SimpleNonlinearSolve = {path = "../.."}
 [compat]
 ADTypes = "1.2"
 BracketingNonlinearSolve = "1.6"
-CUDA = "5"
+CUDA = "6"
 LineSearch = "0.1.9"
 NonlinearSolveBase = "2.20"
 SimpleNonlinearSolve = "2.10"

--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -27,7 +27,7 @@ SimpleNonlinearSolve = {path = "../../lib/SimpleNonlinearSolve"}
 [compat]
 ADTypes = "1.9"
 BracketingNonlinearSolve = "1.6"
-CUDA = "5"
+CUDA = "6"
 LinearAlgebra = "1.10"
 LinearSolve = "3.48"
 NonlinearSolve = "4.19"


### PR DESCRIPTION
## Summary

The GPU test environments pin CUDA.jl to `"5"`. The V100 GPU CI runners now run nvidia driver 580, which requires CUDA.jl **v6.2+** — versions below 6.2 select the CUDA runtime based on the driver version and pick an incompatible runtime, causing GPU CI to fail. The fix landed in [JuliaGPU/CUDA.jl#3134](https://github.com/JuliaGPU/CUDA.jl/pull/3134) (see also [issue #3079](https://github.com/JuliaGPU/CUDA.jl/issues/3079)).

This widens the CUDA compat in the GPU test environments to `"6"` so the resolver picks the latest 6.x (currently ≥6.2), which contains the runtime-selection fix.

## Changes

- Bump `CUDA` compat from `"5"` to `"6"` in `test/gpu/Project.toml` and `lib/SimpleNonlinearSolve/test/gpu/Project.toml`.

Test-environment-only; no package compat or version is affected.
