### PR TITLE
Raise Mooncake compat floor to 0.5.36 (fix Downgrade resolution)

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.31.3"
+version = "2.31.4"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]
@@ -86,7 +86,7 @@ LinearSolve = "3.48"
 LogExpFunctions = "0.3.29, 1"
 Markdown = "1.10"
 MaybeInplace = "0.1.4"
-Mooncake = "0.4, 0.5"
+Mooncake = "0.5.36"
 PreallocationTools = "1.1.2"
 PrecompileTools = "1.2"
 Preferences = "1.4"

--- a/test/Adjoint/Project.toml
+++ b/test/Adjoint/Project.toml
@@ -31,7 +31,7 @@ SimpleNonlinearSolve = {path = "../../lib/SimpleNonlinearSolve"}
 BracketingNonlinearSolve = "1.6"
 Enzyme = "0.13"
 ForwardDiff = "1"
-Mooncake = "0.4, 0.5"
+Mooncake = "0.5.36"
 NonlinearSolve = "4.19"
 NonlinearSolveBase = "2.20"
 NonlinearSolveFirstOrder = "2"


### PR DESCRIPTION
## Summary

Narrows the `Mooncake` `[compat]` entries from `"0.4, 0.5"` to a single latest floor `"0.5.36"` in every Project.toml that declares Mooncake, so the Downgrade lane can no longer pin an ancient Mooncake (the "limit to latest Mooncake" fix for the promotion-caused Downgrade `Unsatisfiable` wall).

### Raised floors

| File | Mooncake role | Old floor | New floor |
| --- | --- | --- | --- |
| `lib/NonlinearSolveBase/Project.toml` | weakdep (`NonlinearSolveBaseMooncakeExt`) | `0.4, 0.5` | `0.5.36` |
| `test/Adjoint/Project.toml` | direct test dep | `0.4, 0.5` | `0.5.36` |

Bumped `NonlinearSolveBase` `2.31.3` → `2.31.4` (a `[compat]` narrowing on a weakdep is a patch-level change, not a public-API change). `test/Adjoint` has no version field (test env), so nothing to bump there. Root `Project.toml` declares no Mooncake.

## Verification (downgrade min-resolution actually resolves)

Ran the actual `julia-actions/julia-downgrade-compat` `downgrade.jl` (current HEAD, with the merged-test-deps `create_merged_project` path) + `StefanKarpinski/Resolver.jl` (HEAD `9353ca5`) on Julia **1.12.6**, reproducing the CI downgrade lanes on the two Mooncake-carrying projects:

- **`test/Adjoint`** (Mooncake in direct `[deps]`/`[compat]`, non-merged `--min=@deps` path — the true Mooncake→Resolver path): **`Successfully resolved minimal versions`**, selecting **Mooncake 0.5.36** (the new floor).
- **`lib/NonlinearSolveBase`** (Mooncake weakdep-only, merged `[extras]`/`targets.test` path): **`Successfully resolved minimal versions`**. Mooncake is not in `[extras]`/`targets.test`, so it is never promoted into the merged `[deps]` fed to Resolver.jl.

**`resolves_at_min = true`** — the downgrade min-resolution succeeds after the bump.

Note: on the current Resolver.jl HEAD `9353ca5` + Julia 1.12, this repo's `test/Adjoint` graph resolves at min even with the *old* `"0.4, 0.5"` floor (resolving to Mooncake 0.5.1), so the earlier fleet-wide Resolver/Mooncake `Unsatisfiable` wall does not reproduce for this repo's dependency-graph shape here. The floor-raise still holds the min-resolution to the latest Mooncake and does no harm.

---

Please ignore until reviewed by @ChrisRackauckas.