### PR TITLE
Fix Spell Check CI: reword "mis-analyzes" in test/test_groups.toml

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -39,7 +39,7 @@ os = ["ubuntu-latest", "macos-latest"]
 versions = ["lts", "1"]
 
 # Trimming was introduced in Julia 1.12; skip lts (1.10). The prerelease channel
-# (1.13) is also skipped: JET's `report_opt`/`test_opt` mis-analyzes on 1.13-rc1
+# (1.13) is also skipped: JET's `report_opt`/`test_opt` analyzes incorrectly on 1.13-rc1
 # (spurious dynamic-dispatch reports inside Base's printing code plus a fatal crash
 # in error display), which is an upstream JET/Julia issue, not a NonlinearSolve one.
 [Trim]


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Master failure

The "Spell Check with Typos" workflow fails on master (e.g. the 2026-07-02/03 master runs) with:

```
error: `mis` should be `miss`, `mist`
  --> ./test/test_groups.toml:42:57
line: `# (1.13) is also skipped: JET's report_opt/test_opt mis-analyzes on 1.13-rc1`
```

typos splits `mis-analyzes` at the hyphen and flags `mis` as a typo. The line was introduced by bb02a2d86 ("CI: drop the prerelease (1.13) channel from the Trim test group", #991), found via `git log -S "mis-analyzes" -- test/test_groups.toml`.

## Fix

Reword the comment to "analyzes incorrectly on 1.13-rc1" (comment-only change, no behavior change). Rewording is simpler and cleaner than adding an exception to `.typos.toml`.

## Local verification

- Reproduced the failure on an unmodified master checkout with typos.
- Downloaded the exact CI binary (typos v1.47.2 from the crate-ci release used by the workflow) and ran `typos .` at the repo root after the fix: exit code 0, zero errors reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)