### PR TITLE
Fix Trim CI hang: drain juliac output pipes while the process runs

### DIFF
--- a/test/trim/runtests.jl
+++ b/test/trim/runtests.jl
@@ -28,14 +28,20 @@ end
     function _execute(cmd::Cmd)
         out = Pipe()
         err = Pipe()
-        process = run(pipeline(ignorestatus(cmd); stdout = out, stderr = err))
+        # The pipes must be drained while the process runs: with `--trim=unsafe-warn`
+        # juliac can emit far more than the 64KiB pipe buffer, and a full pipe blocks
+        # the child while `run(...; wait = true)` blocks the parent — a deadlock that
+        # hung CI until the 2h job timeout.
+        process = run(pipeline(ignorestatus(cmd); stdout = out, stderr = err); wait = false)
         close(out.in)
         close(err.in)
-        out = (
-            stdout = String(read(out)), stderr = String(read(err)),
+        stdout_task = @async read(out, String)
+        stderr_task = @async read(err, String)
+        wait(process)
+        return (
+            stdout = fetch(stdout_task), stderr = fetch(stderr_task),
             exitcode = process.exitcode,
         )
-        return out
     end
 
     JULIAC = normpath(


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Problem

The `tests / Trim (julia 1, ubuntu-latest)` job in the "CI (NonlinearSolve)" workflow has been hanging and getting killed at the 2-hour GitHub Actions timeout on every run since ~2026-06-20 (e.g. [this run](https://github.com/SciML/NonlinearSolve.jl/actions/runs/28652107900/job/84973091420)). The log always stops right after the "Trimmable implementation" testset passes; the "Run trim" testset then produces no output until the kill, and job cleanup terminates several orphaned `julia` processes.

## Timeline

- **Last green:** master run [27148997352](https://github.com/SciML/NonlinearSolve.jl/actions/runs/27148997352) (sha `45c88b9`, 2026-06-08/09). The trim env then resolved SciMLBase v2.155.1 / DiffEqBase v6.218.0 and "Run trim" passed in 26s.
- **2026-06-11 – ~06-16:** Trim failed fast with a Pkg resolver error (unsatisfiable DiffEqBase) — sha `633d93a`, run [27316871371](https://github.com/SciML/NonlinearSolve.jl/actions/runs/27316871371).
- **~2026-06-20 onward:** once compat floors were fixed and the trim env started resolving the new stack (SciMLBase v3, DiffEqBase v7), every Trim (julia 1) job hangs for exactly 2h and is cancelled.

## Root cause

`_execute` in `test/trim/runtests.jl` ran the `juliac` subprocess to completion (`run` defaults to `wait = true`) **before** reading its stdout/stderr `Pipe`s. With the new dependency stack, `juliac --trim=unsafe-warn` emits **129,772 bytes** of trim-verifier warnings on stdout — double the 64KiB Linux pipe buffer. The child blocks writing to the full pipe, the parent blocks in `run` waiting for the child to exit: a deadlock that only ends when GitHub kills the job.

Verified locally on Julia 1.12.6 (same as CI's `julia 1`):
- Running the same `juliac` command with output streamed to a file **succeeds** (exit code 0) and produces 129,772 bytes on stdout.
- Running it through the old `_execute` deadlocks; a SIGTERM backtrace shows the parent blocked in `wait` inside `run` at the `_execute` `run(...)` line.
- A minimal child that just writes 129,772 bytes to stdout deadlocks the old `_execute` the same way, proving the mechanism.

So this is not a `juliac` hang — trimming still works; the test harness deadlocked on its own output capture. It regressed via upstream dependency releases (more verifier warnings), not via a commit in this repo, which is why the hang appeared without any change to the trim tests.

## Fix

Spawn the process with `wait = false`, drain both pipes concurrently with `@async read(...)` tasks, and only then `wait(process)` — the pipes can never fill up regardless of how much output `juliac` emits.

## Testing

Ran the full Trim group locally on Julia 1.12.6 with the fix (`NONLINEARSOLVE_TEST_GROUP=Trim Pkg.test(julia_args = ["--check-bounds=auto"])`):

```
Test Summary:                        | Pass  Total  Time
Clean implementation (non-trimmable) |    2      2  ...
Test Summary:            | Pass  Total  Time
Trimmable implementation |    2      2  ...
Test Summary: | Pass  Broken  Total   Time
Run trim      |    4       3      7  33.0s
     Testing NonlinearSolve tests passed
```

The 3 broken tests are the pre-existing expected-broken `main_segfault.jl` cases, matching the last-green run exactly. Runic check on the changed file passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)