### PR TITLE
Add mass-matrix damping to PseudoTransient

### DIFF
--- a/lib/NonlinearSolveBase/src/descent/damped_newton.jl
+++ b/lib/NonlinearSolveBase/src/descent/damped_newton.jl
@@ -239,26 +239,42 @@ function InternalAPI.solve!(
 end
 
 dampen_jacobian!!(::Any, J::Union{AbstractSciMLOperator, Number}, D) = J + D
-function dampen_jacobian!!(J_cache, J::AbstractMatrix, D::Union{AbstractMatrix, Number})
+
+# Scalar damping (identity-style `(1/α) I` damping) only touches the diagonal of `J`.
+function dampen_jacobian!!(J_cache, J::AbstractMatrix, D::Number)
     ArrayInterface.can_setindex(J_cache) || return J .+ D
     J_cache !== J && copyto!(J_cache, J)
     if ArrayInterface.fast_scalar_indexing(J_cache)
-        if D isa Number
-            @simd ivdep for i in axes(J_cache, 1)
-                @inbounds J_cache[i, i] += D
-            end
-        else
-            @simd ivdep for i in axes(J_cache, 1)
-                @inbounds J_cache[i, i] += D[i, i]
-            end
+        @simd ivdep for i in axes(J_cache, 1)
+            @inbounds J_cache[i, i] += D
         end
     else
         idxs = diagind(J_cache)
-        if D isa Number
-            J_cache[idxs] .+= D
-        else
-            J_cache[idxs] .+= @view(D[idxs])
-        end
+        J_cache[idxs] .+= D
     end
+    return J_cache
+end
+
+# Diagonal damping (e.g. Levenberg-Marquardt's `Diagonal` `DᵀD`, or a diagonal mass matrix)
+# only touches the diagonal of `J`.
+function dampen_jacobian!!(J_cache, J::AbstractMatrix, D::Diagonal)
+    ArrayInterface.can_setindex(J_cache) || return J .+ D
+    J_cache !== J && copyto!(J_cache, J)
+    if ArrayInterface.fast_scalar_indexing(J_cache)
+        @simd ivdep for i in axes(J_cache, 1)
+            @inbounds J_cache[i, i] += D[i, i]
+        end
+    else
+        idxs = diagind(J_cache)
+        J_cache[idxs] .+= @view(D[idxs])
+    end
+    return J_cache
+end
+
+# General (e.g. non-diagonal mass-matrix) damping adds the full matrix `D` to `J`.
+function dampen_jacobian!!(J_cache, J::AbstractMatrix, D::AbstractMatrix)
+    ArrayInterface.can_setindex(J_cache) || return J .+ D
+    J_cache !== J && copyto!(J_cache, J)
+    @. J_cache += D
     return J_cache
 end

--- a/lib/NonlinearSolveBase/src/descent/damped_newton.jl
+++ b/lib/NonlinearSolveBase/src/descent/damped_newton.jl
@@ -110,8 +110,12 @@ function InternalAPI.init(
         damping_fn_cache = InternalAPI.init(
             prob, alg.damping_fn, alg.initial_damping, J, fu, u, Val(false); kwargs...
         )
-        J_cache = Utils.maybe_unaliased(J, alias_J)
         D = damping_fn_cache(nothing)
+        # A matrix-valued damping (e.g. a mass matrix) is added to every stored entry of the
+        # Jacobian and can grow a sparse Jacobian's sparsity pattern. Never alias the Jacobian
+        # cache's own storage in that case, or the next Jacobian recompute would decompress
+        # into a corrupted pattern.
+        J_cache = Utils.maybe_unaliased(J, alias_J && !(D isa AbstractMatrix))
 
         J_damped = dampen_jacobian!!(J_cache, J, D)
         J_cache = J_damped

--- a/lib/NonlinearSolveFirstOrder/src/pseudo_transient.jl
+++ b/lib/NonlinearSolveFirstOrder/src/pseudo_transient.jl
@@ -1,7 +1,7 @@
 """
     PseudoTransient(;
         concrete_jac = nothing, linesearch = missing, alpha_initial = 1e-3,
-        linsolve = nothing,
+        linsolve = nothing, mass_matrix = nothing,
         autodiff = nothing, jvp_autodiff = nothing, vjp_autodiff = nothing
     )
 
@@ -12,21 +12,36 @@ steady-state is achieved to switch over to Newton's method and gain a rapid conv
 This implementation specifically uses "switched evolution relaxation"
 [kelley1998convergence](@cite) SER method.
 
+The damped Newton step solves ``(J(u) + (1/α) M) δu = -F(u)``, i.e. one implicit-Euler step
+of the fictitious dynamics ``M u' = -F(u)`` with pseudo-timestep `α`. By default `M = I`,
+which recovers the classical pseudo-transient continuation. Supplying a mass matrix `M`
+generalizes this to differential-algebraic (DAE) steady-state problems
+[coffey2003pseudotransient](@cite), where `M` is the (possibly singular, structured) mass
+matrix of the underlying `M u' = -F(u)` system. This makes the continuation topology-aware:
+components with large `M` entries are damped less, algebraic components (zero rows of `M`)
+are treated consistently with the DAE structure.
+
 ### Keyword Arguments
 
   - `alpha_initial` : the initial pseudo time step. It defaults to `1e-3`. If it is small,
     you are going to need more iterations to converge but it can be more stable.
+  - `mass_matrix` : the mass matrix `M` used for damping, i.e. the descent solves
+    ``(J + (1/α) M) δu = -F``. Defaults to `nothing`, which uses `M = I` (identity damping,
+    bit-for-bit identical to the classical method). If `nothing` and the problem's
+    `NonlinearFunction` carries a non-identity `mass_matrix`, that mass matrix is used
+    automatically. A diagonal `M` (e.g. `Diagonal(...)`) uses an efficient diagonal update;
+    a general sparse/dense `M` is supported as well. Intended for square DAE-derived systems.
 """
 function PseudoTransient(;
         concrete_jac = nothing, linesearch = missing, alpha_initial = 1.0e-3,
-        linsolve = nothing,
+        linsolve = nothing, mass_matrix = nothing,
         autodiff = nothing, jvp_autodiff = nothing, vjp_autodiff = nothing
     )
     return GeneralizedFirstOrderAlgorithm(;
         linesearch,
         descent = DampedNewtonDescent(;
             linsolve, initial_damping = alpha_initial,
-            damping_fn = SwitchedEvolutionRelaxation()
+            damping_fn = SwitchedEvolutionRelaxation(mass_matrix)
         ),
         autodiff,
         jvp_autodiff,
@@ -37,12 +52,21 @@ function PseudoTransient(;
 end
 
 """
-    SwitchedEvolutionRelaxation()
+    SwitchedEvolutionRelaxation(mass_matrix = nothing)
 
 Method for updating the damping parameter in the [`PseudoTransient`](@ref) method based on
 "switched evolution relaxation" [kelley1998convergence](@cite) SER method.
+
+The optional `mass_matrix` generalizes the damping term from the identity `I` to a
+user-supplied (constant) matrix `M`, so that the damped Newton step becomes
+``(J + (1/α) M) δu = -F``. When `mass_matrix === nothing`, the damping is the scalar
+`1/α` applied to the diagonal, recovering the classical identity-damped method exactly.
 """
-struct SwitchedEvolutionRelaxation <: AbstractDampingFunction end
+@concrete struct SwitchedEvolutionRelaxation <: AbstractDampingFunction
+    mass_matrix
+end
+
+SwitchedEvolutionRelaxation() = SwitchedEvolutionRelaxation(nothing)
 
 """
     SwitchedEvolutionRelaxationCache <: AbstractDampingFunctionCache
@@ -53,6 +77,8 @@ Cache for the [`SwitchedEvolutionRelaxation`](@ref) method.
     res_norm
     α⁻¹
     internalnorm
+    mass_matrix
+    D
 end
 
 function NonlinearSolveBase.requires_normal_form_jacobian(
@@ -77,12 +103,26 @@ function InternalAPI.init(
         internalnorm::F = L2_NORM, kwargs...
     ) where {F}
     T = promote_type(eltype(u), eltype(fu))
-    return SwitchedEvolutionRelaxationCache(
-        internalnorm(fu), T(inv(initial_damping)), internalnorm
-    )
+    α⁻¹ = T(inv(initial_damping))
+    M = resolve_ser_mass_matrix(f.mass_matrix, prob)
+    D = M === nothing ? nothing : α⁻¹ .* M
+    return SwitchedEvolutionRelaxationCache(internalnorm(fu), α⁻¹, internalnorm, M, D)
 end
 
-(damping::SwitchedEvolutionRelaxationCache)(::Nothing) = damping.α⁻¹
+# Resolve the mass matrix used for damping: an explicit one always wins, otherwise fall
+# back to the problem's `NonlinearFunction` mass matrix if it is a genuine (non-identity)
+# matrix. `I` / `UniformScaling` / `nothing` all map back to scalar identity damping so the
+# classical behavior is preserved bit-for-bit.
+resolve_ser_mass_matrix(mass_matrix, ::AbstractNonlinearProblem) = mass_matrix
+function resolve_ser_mass_matrix(::Nothing, prob::AbstractNonlinearProblem)
+    hasproperty(prob.f, :mass_matrix) || return nothing
+    M = prob.f.mass_matrix
+    (M === nothing || M isa LinearAlgebra.UniformScaling) && return nothing
+    return M
+end
+
+(damping::SwitchedEvolutionRelaxationCache)(::Nothing) =
+    damping.mass_matrix === nothing ? damping.α⁻¹ : damping.D
 
 function InternalAPI.solve!(
         damping::SwitchedEvolutionRelaxationCache, J, fu, args...; kwargs...
@@ -90,5 +130,14 @@ function InternalAPI.solve!(
     res_norm = damping.internalnorm(fu)
     damping.α⁻¹ *= res_norm / damping.res_norm
     damping.res_norm = res_norm
-    return damping.α⁻¹
+    damping.mass_matrix === nothing && return damping.α⁻¹
+    damping.D = scale_mass_matrix!!(damping.D, damping.α⁻¹, damping.mass_matrix)
+    return damping.D
+end
+
+scale_mass_matrix!!(::Nothing, α⁻¹, M) = α⁻¹ .* M
+function scale_mass_matrix!!(D, α⁻¹, M)
+    ArrayInterface.can_setindex(D) || return α⁻¹ .* M
+    @. D = α⁻¹ * M
+    return D
 end

--- a/lib/NonlinearSolveFirstOrder/src/pseudo_transient.jl
+++ b/lib/NonlinearSolveFirstOrder/src/pseudo_transient.jl
@@ -104,21 +104,42 @@ function InternalAPI.init(
     ) where {F}
     T = promote_type(eltype(u), eltype(fu))
     α⁻¹ = T(inv(initial_damping))
-    M = resolve_ser_mass_matrix(f.mass_matrix, prob)
+    M = materialize_ser_mass_matrix(resolve_ser_mass_matrix(f.mass_matrix, prob), u)
+    if M isa AbstractMatrix
+        n = length(u)
+        size(M) == (n, n) || throw(
+            DimensionMismatch(
+                "mass matrix has size $(size(M)) but the problem has $n unknowns; a square \
+                 mass matrix of size ($n, $n) is required."
+            )
+        )
+    end
     D = M === nothing ? nothing : α⁻¹ .* M
     return SwitchedEvolutionRelaxationCache(internalnorm(fu), α⁻¹, internalnorm, M, D)
 end
 
 # Resolve the mass matrix used for damping: an explicit one always wins, otherwise fall
 # back to the problem's `NonlinearFunction` mass matrix if it is a genuine (non-identity)
-# matrix. `I` / `UniformScaling` / `nothing` all map back to scalar identity damping so the
-# classical behavior is preserved bit-for-bit.
+# matrix. `nothing` and the identity `I` both map back to scalar identity damping so the
+# classical behavior is preserved bit-for-bit; a scaled `λI` is kept and materialized into a
+# concrete `Diagonal` by `materialize_ser_mass_matrix`.
 resolve_ser_mass_matrix(mass_matrix, ::AbstractNonlinearProblem) = mass_matrix
+function resolve_ser_mass_matrix(M::LinearAlgebra.UniformScaling, ::AbstractNonlinearProblem)
+    return isone(M.λ) ? nothing : M
+end
 function resolve_ser_mass_matrix(::Nothing, prob::AbstractNonlinearProblem)
     hasproperty(prob.f, :mass_matrix) || return nothing
     M = prob.f.mass_matrix
     (M === nothing || M isa LinearAlgebra.UniformScaling) && return nothing
     return M
+end
+
+# A scaled identity `λI` carries no size, so materialize it into a concrete `Diagonal` of
+# the right size (the identity `I` has already been mapped to `nothing` above). Anything else
+# (a real matrix, or `nothing`) passes through unchanged.
+materialize_ser_mass_matrix(M, u) = M
+function materialize_ser_mass_matrix(M::LinearAlgebra.UniformScaling, u)
+    return Diagonal(fill(convert(eltype(u), M.λ), length(u)))
 end
 
 (damping::SwitchedEvolutionRelaxationCache)(::Nothing) =
@@ -135,7 +156,6 @@ function InternalAPI.solve!(
     return damping.D
 end
 
-scale_mass_matrix!!(::Nothing, α⁻¹, M) = α⁻¹ .* M
 function scale_mass_matrix!!(D, α⁻¹, M)
     ArrayInterface.can_setindex(D) || return α⁻¹ .* M
     @. D = α⁻¹ * M

--- a/lib/NonlinearSolveFirstOrder/test/rootfind_tests.jl
+++ b/lib/NonlinearSolveFirstOrder/test/rootfind_tests.jl
@@ -18,3 +18,4 @@
 @safetestset "LevenbergMarquardt: Kwargs" include("rootfind_tests__item18.jl")
 @safetestset "Simple Sparse AutoDiff" include("rootfind_tests__item19.jl")
 @safetestset "Custom JVP" include("rootfind_tests__item20.jl")
+@safetestset "PseudoTransient: Mass Matrix" include("rootfind_tests__item21.jl")

--- a/lib/NonlinearSolveFirstOrder/test/rootfind_tests__item21.jl
+++ b/lib/NonlinearSolveFirstOrder/test/rootfind_tests__item21.jl
@@ -1,7 +1,7 @@
 using NonlinearSolveFirstOrder
 include("setup_corerootfindtesting.jl")
 
-using LinearAlgebra, SciMLBase
+using LinearAlgebra, SparseArrays, SparseMatrixColorings, SciMLBase
 
 # The pseudo-transient damping term is (1/α) M. As the iteration converges α⁻¹ → 0, so the
 # damping vanishes and the method must land on the true root sqrt(p) regardless of which
@@ -77,4 +77,62 @@ end
         )
         @test sol_auto.u ≈ sol_explicit.u
     end
+end
+
+# Singular mass matrix: the headline use case (semi-explicit index-1 DAE steady state). The
+# algebraic component has zero mass, so its row is treated as pure Newton, the differential
+# component is damped. Must still converge.
+@testset "singular (DAE) mass matrix" begin
+    # u1 differential (mass 1), u2 algebraic (mass 0)
+    f(u, p) = [u[1]^2 - u[2] - 1.0, u[1] + u[2] - 3.0]
+    xstar = (-1 + sqrt(17)) / 2
+    ustar = [xstar, 3 - xstar]
+
+    prob = NonlinearProblem{false}(f, [3.0, -2.0], nothing)
+    for M in (Diagonal([1.0, 0.0]), [1.0 0.0; 0.0 0.0])
+        sol = solve(prob, PseudoTransient(; alpha_initial = 1.0e-2, mass_matrix = M); abstol = 1.0e-10)
+        @test SciMLBase.successful_retcode(sol)
+        @test sol.u ≈ ustar atol = 1.0e-7
+    end
+end
+
+# Explicit `mass_matrix = I` / `λI` must not error (regression for the UniformScaling path).
+@testset "UniformScaling mass matrix" begin
+    prob = NonlinearProblem{false}(quadratic_f, [1.0, 1.0], 2.0)
+
+    # `I` is identity damping: must match the default exactly.
+    s_default = solve(prob, PseudoTransient(; alpha_initial = 10.0); abstol = 1.0e-10)
+    s_I = solve(prob, PseudoTransient(; alpha_initial = 10.0, mass_matrix = I); abstol = 1.0e-10)
+    @test s_I.u == s_default.u
+    @test s_I.stats.nsteps == s_default.stats.nsteps
+
+    # A scaled identity must still converge.
+    s_2I = solve(prob, PseudoTransient(; alpha_initial = 10.0, mass_matrix = 2I); abstol = 1.0e-10)
+    @test SciMLBase.successful_retcode(s_2I)
+    @test s_2I.u ≈ [sqrt(2.0), sqrt(2.0)] atol = 1.0e-7
+end
+
+# Sparse in-place Jacobian must not have its sparsity pattern corrupted by the damping term.
+@testset "sparse Jacobian is not corrupted by mass-matrix damping" begin
+    quad!(du, u, p) = (du .= u .* u .- p)
+    jp = sparse(Diagonal(ones(2)))
+    nlf = NonlinearFunction{true}(quad!; jac_prototype = jp)
+    prob = NonlinearProblem(nlf, [1.0, 1.0], 2.0)
+
+    # Off-diagonal mass matrix entries lie outside the Jacobian pattern.
+    for M in (sparse([2.0 0.5; 0.5 3.0]), [2.0 0.5; 0.5 3.0])
+        sol = solve(prob, PseudoTransient(; alpha_initial = 10.0, mass_matrix = M); abstol = 1.0e-9)
+        @test SciMLBase.successful_retcode(sol)
+        @test sol.u ≈ [sqrt(2.0), sqrt(2.0)] atol = 1.0e-6
+    end
+end
+
+# A mass matrix whose size does not match the number of unknowns must error clearly rather
+# than reading out of bounds.
+@testset "size-mismatched mass matrix errors" begin
+    prob = NonlinearProblem{false}(quadratic_f, [1.0, 1.0, 1.0], 2.0)
+    @test_throws DimensionMismatch solve(
+        prob, PseudoTransient(; alpha_initial = 10.0, mass_matrix = Diagonal([1.0, 2.0]));
+        abstol = 1.0e-10
+    )
 end

--- a/lib/NonlinearSolveFirstOrder/test/rootfind_tests__item21.jl
+++ b/lib/NonlinearSolveFirstOrder/test/rootfind_tests__item21.jl
@@ -1,0 +1,80 @@
+using NonlinearSolveFirstOrder
+include("setup_corerootfindtesting.jl")
+
+using LinearAlgebra, SciMLBase
+
+# The pseudo-transient damping term is (1/α) M. As the iteration converges α⁻¹ → 0, so the
+# damping vanishes and the method must land on the true root sqrt(p) regardless of which
+# (SPD) mass matrix is used. This lets us check the mass-matrix machinery against the known
+# solution while also exercising the diagonal / general-matrix code paths.
+
+@testset "mass_matrix = nothing reproduces identity damping" begin
+    u0 = [1.0, 1.0]
+    prob = NonlinearProblem{false}(quadratic_f, u0, 2.0)
+
+    sol_default = solve(prob, PseudoTransient(; alpha_initial = 10.0); abstol = 1.0e-10)
+    sol_nothing = solve(
+        prob, PseudoTransient(; alpha_initial = 10.0, mass_matrix = nothing);
+        abstol = 1.0e-10
+    )
+
+    @test SciMLBase.successful_retcode(sol_default)
+    @test sol_default.u == sol_nothing.u
+    @test sol_default.stats.nsteps == sol_nothing.stats.nsteps
+end
+
+@testset "diagonal mass matrix" begin
+    u0 = [1.0, 1.0]
+    prob = NonlinearProblem{false}(quadratic_f, u0, 2.0)
+
+    for M in (Diagonal([1.0, 2.0]), Diagonal([0.5, 5.0]))
+        solver = PseudoTransient(; alpha_initial = 10.0, mass_matrix = M)
+        sol = solve(prob, solver; abstol = 1.0e-10)
+        @test SciMLBase.successful_retcode(sol)
+        @test sol.u ≈ [sqrt(2.0), sqrt(2.0)] atol = 1.0e-7
+    end
+end
+
+@testset "general (dense) mass matrix" begin
+    u0 = [1.0, 1.0]
+    prob = NonlinearProblem{false}(quadratic_f, u0, 2.0)
+
+    M = [2.0 0.5; 0.5 2.0]  # SPD, non-diagonal
+    solver = PseudoTransient(; alpha_initial = 10.0, mass_matrix = M)
+    sol = solve(prob, solver; abstol = 1.0e-10)
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u ≈ [sqrt(2.0), sqrt(2.0)] atol = 1.0e-7
+end
+
+@testset "in-place with mass matrix" begin
+    u0 = [1.0, 1.0]
+    prob = NonlinearProblem{true}(quadratic_f!, u0, 2.0)
+
+    solver = PseudoTransient(; alpha_initial = 10.0, mass_matrix = Diagonal([1.0, 3.0]))
+    sol = solve(prob, solver; abstol = 1.0e-10)
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u ≈ [sqrt(2.0), sqrt(2.0)] atol = 1.0e-7
+end
+
+# The mass matrix should also be picked up automatically from the problem's
+# `NonlinearFunction` when one is present, so DAE-derived `NonlinearProblem`s work with no
+# extra keyword.
+@testset "mass matrix from NonlinearFunction" begin
+    if hasproperty(NonlinearFunction(quadratic_f), :mass_matrix)
+        M = Diagonal([1.0, 2.0])
+        nlf = NonlinearFunction{false}(quadratic_f; mass_matrix = M)
+        prob = NonlinearProblem(nlf, [1.0, 1.0], 2.0)
+
+        # Explicit keyword omitted -> resolved from the function's mass matrix.
+        sol_auto = solve(prob, PseudoTransient(; alpha_initial = 10.0); abstol = 1.0e-10)
+        @test SciMLBase.successful_retcode(sol_auto)
+        @test sol_auto.u ≈ [sqrt(2.0), sqrt(2.0)] atol = 1.0e-7
+
+        # Explicit keyword should match the automatically-resolved behavior.
+        sol_explicit = solve(
+            NonlinearProblem{false}(quadratic_f, [1.0, 1.0], 2.0),
+            PseudoTransient(; alpha_initial = 10.0, mass_matrix = M); abstol = 1.0e-10
+        )
+        @test sol_auto.u ≈ sol_explicit.u
+    end
+end


### PR DESCRIPTION
Generalize the pseudo-transient continuation damping term from the identity `(1/α) I` to a user-supplied mass matrix `(1/α) M`, so the descent solves `(J + (1/α) M) δu = -F`. This extends ψtc to differential-algebraic (DAE) steady-state problems (Coffey, Kelley & Keyes, 2003), where `M` is the mass matrix of the underlying `M u' = -F(u)` dynamics — e.g. MNA circuit systems.

Changes:
- `PseudoTransient(; mass_matrix = nothing, ...)`: new keyword. When `nothing`, behavior is bit-for-bit identical to before; if the problem's `NonlinearFunction` carries a non-identity `mass_matrix`, it is picked up automatically.
- `SwitchedEvolutionRelaxation(mass_matrix)`: the SER damping function now returns `(1/α) M` when a mass matrix is supplied, keeping the SER step-growth rule unchanged.
- `dampen_jacobian!!`: split the diagonal (`Number`/`Diagonal`) fast paths from a new general `AbstractMatrix` path that adds the full damping matrix. A diagonal mass matrix keeps the efficient diagonal update; a general sparse/dense matrix is fully supported.
- Tests covering regression (nothing == identity), diagonal and dense mass matrices, in-place problems, and auto-resolution from the `NonlinearFunction` mass matrix.


Claude-Session: https://claude.ai/code/session_017zCWMioFzF3DVwXrVCkCk4

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
