### PR TITLE
Fix update_A! dispatch so reuse_A_if_factorization actually works

### DIFF
--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseLinearSolveExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseLinearSolveExt.jl
@@ -38,7 +38,14 @@ end
 
 update_A!(cache::LinearSolveJLCache, ::Nothing, reuse) = cache
 function update_A!(cache::LinearSolveJLCache, A, reuse)
-    return update_A!(cache, Utils.safe_getproperty(cache.linsolve, Val(:alg)), A, reuse)
+    # Dispatch on the *resolved* algorithm stored in the LinearSolve cache.
+    # `cache.linsolve` is the user-passed object (e.g. `KLUFactorization()`), which has
+    # no `alg` field, so the old `safe_getproperty(cache.linsolve, Val(:alg))` returned
+    # `missing` and always fell through to the non-factorization method below. That
+    # method re-sets `A` unconditionally, marking the LinearSolve cache fresh, so
+    # factorization algorithms refactorized on every call even when the caller asked
+    # for reuse via `reuse_A_if_factorization` (and `nfactors` was never incremented).
+    return update_A!(cache, cache.lincache.alg, A, reuse)
 end
 
 function update_A!(cache::LinearSolveJLCache, alg, A, reuse)

--- a/lib/NonlinearSolveBase/test/linear_solver_routing.jl
+++ b/lib/NonlinearSolveBase/test/linear_solver_routing.jl
@@ -36,3 +36,26 @@ lc_dense = NonlinearSolveBase.construct_linear_solver(
     nothing, nothing, rand(4, 4) + 5I, b, u, nothing; stats
 )
 @test lc_dense isa NonlinearSolveBase.LinearSolveJLCache
+
+# `update_A!` must dispatch on the *resolved* algorithm (`lincache.alg`), not the
+# user-passed `linsolve` object (which has no `alg` field). With the old dispatch every
+# call re-set `A` — factorization algorithms refactorized on every solve even when the
+# caller requested reuse via `reuse_A_if_factorization`, and `nfactors` never moved.
+stats_reuse = SciMLBase.NLStats(0, 0, 0, 0, 0)
+A_fact = rand(4, 4) + 5I
+lc_fact = NonlinearSolveBase.construct_linear_solver(
+    nothing, LUFactorization(), copy(A_fact), copy(b), copy(u), nothing;
+    stats = stats_reuse
+)
+@test lc_fact isa NonlinearSolveBase.LinearSolveJLCache
+res = lc_fact(; A = A_fact, b, linu = u, reuse_A_if_factorization = false)
+@test res.u ≈ A_fact \ b
+@test stats_reuse.nfactors == 1
+# reuse: the factorization must not be redone and nfactors must not move
+res = lc_fact(; A = A_fact, b, linu = u, reuse_A_if_factorization = true)
+@test res.u ≈ A_fact \ b
+@test stats_reuse.nfactors == 1
+# fresh A with reuse off refactorizes exactly once more
+res = lc_fact(; A = 2 .* A_fact, b, linu = u, reuse_A_if_factorization = false)
+@test res.u ≈ (2 .* A_fact) \ b
+@test stats_reuse.nfactors == 2


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft opened by an agent.

## Bug

`update_A!` in `NonlinearSolveBaseLinearSolveExt` dispatches on `Utils.safe_getproperty(cache.linsolve, Val(:alg))`. But `cache.linsolve` is the **user-passed LinearSolve algorithm** (e.g. `KLUFactorization()`, `LUFactorization()`), which has no `alg` field — so the lookup returns `missing` and every call falls through to the generic non-factorization method, which re-sets `A` unconditionally (marking the LinearSolve cache fresh).

Consequences:

1. **`reuse_A_if_factorization` was a no-op** — factorization algorithms refactorized on **every** linear solve. Plain `solve` hides this (each Newton iteration has a new J anyway, so a refactorization is due regardless), but any driver that holds J fixed across iterations pays a full refactorization per iteration. The big consumer is OrdinaryDiffEq's `NonlinearSolveAlg` modified-Newton path (`step!(cache; recompute_jacobian = false)`): profiling `FBDF(linsolve = KLUFactorization(), nlsolve = NonlinearSolveAlg(NewtonRaphson()))` on a sparse 512-dim 2D brusselator showed **79% of total runtime inside `klu_l_refactor`** (~890 numeric refactorizations per solve vs ~218 actual W updates).
2. **`stats.nfactors` was never incremented** for factorization algorithms (always 0), so the problem was invisible in stats.

## Fix

Dispatch on the **resolved** algorithm `cache.lincache.alg` instead. This preserves the existing `DefaultLinearSolver` special case (forced reset for default GMRES): when `linsolve === nothing`, `lincache.alg` is exactly the `DefaultLinearSolver` that method matches.

## Verification (run locally)

Before → after on a 200-dim sparse tridiagonal nonlinear system:

```
NR+KLU       iters=27 njacs=27 nfactors=0  (before)   nfactors=27  (after)
NR+LU        iters=27 njacs=27 nfactors=0  (before)   nfactors=27  (after)
NR+default   iters=27 njacs=27 nfactors=0  (before)   nfactors=27  (after)
NR+GMRES     iters=27 njacs=0  nfactors=0  (unchanged, correct — matrix-free)
```

Modified-Newton pattern: `step!` once with `recompute_jacobian = true` then 5× with `recompute_jacobian = false` → `nfactors` stays at 1 (before: refactorized each step).

Added a regression test in `linear_solver_routing.jl` asserting `nfactors` moves exactly once per fresh `A` and not at all under reuse. `NonlinearSolveBase` test suite passes locally on Julia 1.12 (exit 0), amended routing testset 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)