### PR TITLE
Line search: prefer forward-mode (JVP) backend for the directional derivative

### DIFF
--- a/lib/NonlinearSolveFirstOrder/src/solve.jl
+++ b/lib/NonlinearSolveFirstOrder/src/solve.jl
@@ -243,10 +243,21 @@ function SciMLBase.__init(
         if has_linesearch
             NonlinearSolveBase.supports_line_search(alg.descent) ||
                 error("Line Search not supported by $(alg.descent).")
-            _ls_ad = NonlinearSolveBase.standardize_forwarddiff_tag(
-                ifelse(provided_jvp_autodiff, alg.jvp_autodiff, alg.vjp_autodiff),
-                _ad_prob
-            )
+            # The line search only needs the directional derivative
+            # ϕ'(α) = ⟨fu, J⋅δu⟩, a single JVP, so prefer the forward-mode
+            # backend. Only use the reverse-mode backend when explicitly
+            # requested via `vjp_autodiff` or a reverse-mode `autodiff`, so
+            # that loading a reverse-mode AD package cannot change the
+            # behavior of an explicitly configured solver.
+            ls_ad = if provided_jvp_autodiff
+                alg.jvp_autodiff
+            elseif provided_vjp_autodiff ||
+                    ADTypes.mode(alg.autodiff) isa ADTypes.ReverseMode
+                alg.vjp_autodiff
+            else
+                alg.jvp_autodiff
+            end
+            _ls_ad = NonlinearSolveBase.standardize_forwarddiff_tag(ls_ad, _ad_prob)
             linesearch_cache = CommonSolve.init(
                 _ad_prob, alg.linesearch, fu, u; stats, internalnorm,
                 autodiff = _ls_ad, kwargs...

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests.jl
@@ -1,3 +1,4 @@
 @safetestset "Scalar Jacobians: Issue #451" include("misc_tests__item1.jl")
 @safetestset "Dual of BigFloat: Issue #512" include("misc_tests__item2.jl")
 @safetestset "TrustRegion reinit! resets trust_region" include("misc_tests__item3.jl")
+@safetestset "Line search uses forward-mode autodiff: Issue #837" include("misc_tests__item4.jl")

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests__item4.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests__item4.jl
@@ -1,0 +1,34 @@
+using NonlinearSolveFirstOrder, ADTypes, LineSearch
+
+# The residual writes to a Float64 scratch buffer on the primal path (like a
+# PreallocationTools.DiffCache), which ForwardDiff handles but Enzyme rejects
+# when the function is passed as `Const`. The line search must therefore use
+# the explicitly requested forward-mode backend, and loading Enzyme must not
+# switch it to a reverse-mode one.
+struct CachedResidual
+    cache::Vector{Float64}
+end
+function (f::CachedResidual)(res, u, p)
+    tmp = eltype(u) === Float64 ? f.cache : similar(u)
+    @. tmp = u^2 - p
+    @. res = tmp - u + 1.0
+    return nothing
+end
+
+n = 4
+u0 = ones(n)
+p = fill(2.0, n)
+prob = NonlinearLeastSquaresProblem(
+    NonlinearFunction(CachedResidual(zeros(n)); resid_prototype = zeros(n)), u0, p
+)
+
+alg = GaussNewton(; linesearch = BackTracking(), autodiff = AutoForwardDiff())
+sol = solve(prob, alg)
+@test SciMLBase.successful_retcode(sol)
+
+if isempty(VERSION.prerelease) && VERSION < v"1.12"
+    using Enzyme
+
+    sol = solve(prob, alg)
+    @test SciMLBase.successful_retcode(sol)
+end


### PR DESCRIPTION
### Summary

Fixes the line-search half of #837: `GaussNewton(; linesearch = BackTracking(), autodiff = AutoForwardDiff())` failing once Enzyme is loaded, despite the user explicitly choosing ForwardDiff.

The line search derivative is ϕ'(α) = ⟨fu, J⋅δu⟩ — a single directional derivative (JVP), which LineSearch.jl already computes with a `JacVecOperator` when handed a forward-mode backend. But `solve.jl` handed the line search `vjp_autodiff` unless `jvp_autodiff` was *explicitly* typed by the user — and the default `vjp_autodiff` is selected from whichever reverse-mode packages are loaded (Enzyme first). So `using Enzyme` anywhere in the session silently switched the line-search derivative backend of an explicitly-ForwardDiff solver to Enzyme.

New preference order for the line-search backend:
1. explicit `jvp_autodiff` (unchanged)
2. explicit `vjp_autodiff`, or a reverse-mode `autodiff` → VJP side (reverse intent is honored, no behavior change for those users)
3. otherwise → `jvp_autodiff` (which is the user's `autodiff` when forward-mode, or the shopped forward default)

Forward-mode is also the cheaper formulation here (one pushforward vs one pullback), so this is not a correctness/performance trade.

### Verified locally

On the issue MRE (DiffCache-carrying residual, ForwardDiff-compatible / Enzyme-incompatible), with Enzyme loaded:

| scenario | before | after |
|---|---|---|
| `autodiff = AutoForwardDiff()` + `BackTracking()` | ❌ EnzymeMutabilityException | ✅ Success |
| no `autodiff` given at all | ❌ | ✅ (line search defaults to forward JVP) |
| explicit reverse `autodiff = AutoEnzyme(mode=Reverse, function_annotation=Duplicated)` | ✅ | ✅ (still routes to VJP side) |

Adds a regression test (`misc_tests__item4.jl`) with a hand-rolled DiffCache-like residual (no new test deps): solves with `AutoForwardDiff()` before and after `using Enzyme`.

Full `NonlinearSolveFirstOrder` Core test group run locally: **all testsets pass** (incl. NLLS 472/472, NewtonRaphson 432/432, TrustRegion 1596/1596, new test 2/2).

Note: this does not address the `TrustRegion(radius_update_scheme = Bastin)` case of #837 — the Bastin scheme genuinely consumes VJPs; that needs the vjp-defaulting fix discussed in the issue and can be a follow-up PR.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mx15rEbvLviquZn9yk5mgL
