### PR TITLE
Default polyalgorithms: replace the Bastin trust-region stage with Fan (forward-mode-only defaults)

### DIFF
--- a/lib/NonlinearSolveFirstOrder/src/poly_algs.jl
+++ b/lib/NonlinearSolveFirstOrder/src/poly_algs.jl
@@ -79,7 +79,7 @@ function FastShortcutNLLSPolyalg(
             TrustRegion(; common_kwargs..., concrete_jac),
             GaussNewton(; common_kwargs..., linesearch = BackTracking(), concrete_jac),
             TrustRegion(;
-                common_kwargs..., radius_update_scheme = RUS.Bastin, concrete_jac
+                common_kwargs..., radius_update_scheme = RUS.Fan, concrete_jac
             ),
             LevenbergMarquardt(; common_kwargs...),
         )

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests.jl
@@ -2,3 +2,4 @@
 @safetestset "Dual of BigFloat: Issue #512" include("misc_tests__item2.jl")
 @safetestset "TrustRegion reinit! resets trust_region" include("misc_tests__item3.jl")
 @safetestset "Line search uses forward-mode autodiff: Issue #837" include("misc_tests__item4.jl")
+@safetestset "Default NLLS polyalg is forward-mode only: Issue #837" include("misc_tests__item5.jl")

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests__item5.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests__item5.jl
@@ -1,0 +1,19 @@
+using NonlinearSolveFirstOrder
+using NonlinearSolveFirstOrder: RadiusUpdateSchemes
+
+# The Bastin and Yuan radius update schemes construct VJP operators, whose default
+# backend is selected from whichever reverse-mode AD packages happen to be loaded.
+# The default NLLS polyalgorithm must not contain such stages, so that loading a
+# reverse-mode AD package (e.g. Enzyme) can never change the behavior of a default
+# solve. See NonlinearSolve.jl#837. `RobustMultiNewton` intentionally keeps its
+# Bastin stage as an explicit opt-in robustness battery.
+function stage_needs_reverse_mode(stage)
+    hasproperty(stage, :trustregion) || return false
+    tr = stage.trustregion
+    (tr === missing || tr === nothing) && return false
+    hasproperty(tr, :method) || return false
+    return tr.method isa
+        Union{RadiusUpdateSchemes.__Bastin, RadiusUpdateSchemes.__Yuan}
+end
+
+@test all(!stage_needs_reverse_mode, FastShortcutNLLSPolyalg().algs)

--- a/src/poly_algs.jl
+++ b/src/poly_algs.jl
@@ -42,7 +42,7 @@ function FastShortcutNonlinearPolyalg(
             algs = (
                 NewtonRaphson(; common_kwargs...),
                 TrustRegion(; common_kwargs...),
-                TrustRegion(; common_kwargs..., radius_update_scheme = RUS.Bastin),
+                TrustRegion(; common_kwargs..., radius_update_scheme = RUS.Fan),
                 LevenbergMarquardt(; common_kwargs_nocj...),
             )
         end
@@ -63,7 +63,7 @@ function FastShortcutNonlinearPolyalg(
                     SimpleKlement(),
                     NewtonRaphson(; common_kwargs...),
                     TrustRegion(; common_kwargs...),
-                    TrustRegion(; common_kwargs..., radius_update_scheme = RUS.Bastin),
+                    TrustRegion(; common_kwargs..., radius_update_scheme = RUS.Fan),
                     LevenbergMarquardt(; common_kwargs_nocj...),
                 )
             end
@@ -82,7 +82,7 @@ function FastShortcutNonlinearPolyalg(
                     Klement(; linsolve, autodiff),
                     NewtonRaphson(; common_kwargs...),
                     TrustRegion(; common_kwargs...),
-                    TrustRegion(; common_kwargs..., radius_update_scheme = RUS.Bastin),
+                    TrustRegion(; common_kwargs..., radius_update_scheme = RUS.Fan),
                     LevenbergMarquardt(; common_kwargs_nocj...),
                 )
             end

--- a/test/PolyAlgorithms/core_tests__item20.jl
+++ b/test/PolyAlgorithms/core_tests__item20.jl
@@ -1,0 +1,26 @@
+using NonlinearSolve
+using NonlinearSolve: RadiusUpdateSchemes
+
+# The Bastin and Yuan radius update schemes construct VJP operators, whose default
+# backend is selected from whichever reverse-mode AD packages happen to be loaded.
+# The default polyalgorithms must not contain such stages, so that loading a
+# reverse-mode AD package (e.g. Enzyme) can never change the behavior of a default
+# solve. See #837.
+function stage_needs_reverse_mode(stage)
+    hasproperty(stage, :trustregion) || return false
+    tr = stage.trustregion
+    (tr === missing || tr === nothing) && return false
+    hasproperty(tr, :method) || return false
+    return tr.method isa
+        Union{RadiusUpdateSchemes.__Bastin, RadiusUpdateSchemes.__Yuan}
+end
+
+# `FastShortcutNLLSPolyalg` is asserted in NonlinearSolveFirstOrder's own tests,
+# since this environment resolves that package from the registry.
+for poly in (
+        FastShortcutNonlinearPolyalg(),
+        FastShortcutNonlinearPolyalg(; must_use_jacobian = Val(true)),
+        FastShortcutNonlinearPolyalg(; prefer_simplenonlinearsolve = Val(true)),
+    )
+    @test all(!stage_needs_reverse_mode, poly.algs)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -139,6 +139,7 @@ else
                 @time @safetestset "Out-of-place Matrix Resizing" include("PolyAlgorithms/core_tests__item14.jl")
                 @time @safetestset "Inplace Matrix Resizing" include("PolyAlgorithms/core_tests__item15.jl")
                 @time @safetestset "Default Algorithm Singular Handling" include("PolyAlgorithms/core_tests__item19.jl")
+                @time @safetestset "Default polyalgs are forward-mode only: Issue #837" include("PolyAlgorithms/core_tests__item20.jl")
                 return @time @safetestset "23 Test Problems: PolyAlgorithms" include("PolyAlgorithms/23_test_problems_tests__item1.jl")
             end,
             "Verbosity" => function ()


### PR DESCRIPTION
### Summary

Follow-up to #837 and #1005: replace the `TrustRegion(radius_update_scheme = RUS.Bastin)` stage in the **default** polyalgorithms (`FastShortcutNonlinearPolyalg` ×3 branches, `FastShortcutNLLSPolyalg`) with `RUS.Fan`, so that **the default solver paths never construct a reverse-mode (VJP) operator**. Combined with #1005 (line search now uses the forward/JVP side), loading Enzyme (or any reverse-mode AD package) can no longer change — or break — the behavior of a default `solve`.

`RobustMultiNewton` intentionally keeps its Bastin stage: it is an explicit opt-in "maximum robustness battery", not a default. `RadiusUpdateSchemes.Bastin` remains fully available for explicit use.

### Why Bastin was in the defaults, and why Fan is a safe swap (all measured locally)

Robustness on the 23 test problems (NonlinearProblemLibrary, the benchmark's own success criterion — `abstol=reltol=1e-8`, `‖resid‖∞ < 1e-6`):

| scheme | solved | fails |
|---|---|---|
| Bastin | 22/23 | Freudenstein-Roth |
| Simple / NLsolve / NocedalWright / Hei / Fan | 21/23 | Trigonometric, Freudenstein-Roth |
| Yuan | 20/23 | Brown almost linear, Trigonometric, Freudenstein-Roth |

Bastin is the strongest **standalone** scheme. But in the polyalg its marginal value is zero on this suite: its one unique win (Trigonometric) is already solved by the `NewtonRaphson` stage, and Freudenstein-Roth (which Bastin also fails) is caught by `NewtonRaphson`/`Broyden`/`Klement`. Composed-polyalg coverage, verified end-to-end:

| variant | 23 test problems |
|---|---|
| default `solve(prob)` (current, Bastin) | 23/23 |
| polyalg with Fan | 23/23 |
| polyalg with NocedalWright | 23/23 |

Why `Fan` and not `Hei`/`NocedalWright`: per-problem timing shows Hei is the slowest of the candidates on the hard (Hammarling) problems (30,928 iterations vs Fan 12,547–26,927), and NocedalWright tracks `Simple` almost iteration-for-iteration — a fallback stage that mimics the `TrustRegion()` stage right before it adds no diversity. Fan takes genuinely different trajectories at the same aggregate cost.

Honest trade-off note: Bastin's curvature-aware update is dramatically better on the singular Hammarling problems (53 iterations vs ~17k–31k for every AD-free scheme). That advantage is not realized in the polyalg — the plain `TrustRegion()` stage sits *before* the Bastin stage and already succeeds on those problems, so the fall-through never happens there. Users who want Bastin explicitly can still use it (with a working reverse-mode backend, e.g. `AutoEnzyme(mode=Enzyme.Reverse, function_annotation=Enzyme.Duplicated)` for `DiffCache`-carrying residuals).

### Tests

- New invariant test (`test/PolyAlgorithms/core_tests__item20.jl`): no stage of any default polyalg uses a VJP-consuming radius update scheme (Bastin/Yuan).
- Existing gate `23_test_problems_tests__item1.jl` (asserts `FastShortcutNonlinearPolyalg` and `RobustMultiNewton` solve all 23 problems with no broken entries) passes with the swap.
- Full `PolyAlgorithms` test group and `NonlinearSolveFirstOrder` Core group run locally: pass.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mx15rEbvLviquZn9yk5mgL
