### PR TITLE
Fix reinit! resetting LinearSolveParameters to a Missing p-type

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.34.0"
+version = "2.34.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseLinearSolveExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseLinearSolveExt.jl
@@ -87,14 +87,22 @@ function LinearSolve.update_tolerances!(cache::LinearSolveJLCache; kwargs...)
 end
 
 function InternalAPI.reinit!(cache::LinearSolveJLCache, args...; u = missing, p = missing, kwargs...)
-    if u !== missing
+    # `u`/`p` left as `missing` mean "unchanged" — preserve the current values rather than
+    # overwriting them with `missing`. Otherwise a `reinit!` that only updates `u` (the
+    # usual case in a continuation loop, parameters fixed) would rebuild the parameters as
+    # `LinearSolveParameters(u_fixed, missing)`, whose `Missing` p-type mismatches the
+    # concretely-typed `p` (e.g. `NullParameters`) the LinearSolve cache was built with,
+    # throwing a `setfield!` type error.
+    cur = cache.lincache.p
+    u_fixed = if u !== missing
         u_vec = Utils.safe_vec(u)
         (; A, b) = cache.lincache
-        u_fixed = NonlinearSolveBase.fix_incompatible_linsolve_arguments(A, b, u_vec)
-        return SciMLBase.reinit!(cache.lincache; p = LinearSolveParameters(u_fixed, p))
+        NonlinearSolveBase.fix_incompatible_linsolve_arguments(A, b, u_vec)
     else
-        return SciMLBase.reinit!(cache.lincache; p = LinearSolveParameters(u, p))
+        cur.u
     end
+    p_new = p === missing ? cur.p : p
+    return SciMLBase.reinit!(cache.lincache; p = LinearSolveParameters(u_fixed, p_new))
 end
 
 end

--- a/test/Core/reinit_tests__item1.jl
+++ b/test/Core/reinit_tests__item1.jl
@@ -1,0 +1,33 @@
+using NonlinearSolve
+
+using SciMLBase
+
+# Regression: `reinit!` with only a new `u0` (parameters unchanged) must preserve the
+# cache's parameter *type*, not reset it to `missing`. Rebuilding the internal
+# `LinearSolveParameters` with a `Missing` p-field mismatched the concretely-typed `p`
+# (e.g. `NullParameters`) the LinearSolve-backed cache was built with, throwing a
+# `setfield!` type error for every solver that uses that linear cache (NewtonRaphson,
+# TrustRegion, and the default polyalgorithm) — so a continuation-style loop that inits
+# once and `reinit!`s each step could not be built.
+n = 5
+f(u, p) = u .^ 2 .- p
+prob = NonlinearProblem(f, ones(n), fill(4.0, n))
+
+for alg in (NewtonRaphson(), TrustRegion(), nothing)
+    cache = init(prob, alg)
+    s1 = solve!(cache)
+    @test SciMLBase.successful_retcode(s1)
+    @test s1.u ≈ fill(2.0, n) atol = 1.0e-6
+
+    # only a new warm start, parameters left unchanged — must not throw, root unchanged
+    SciMLBase.reinit!(cache, fill(0.5, n))
+    s2 = solve!(cache)
+    @test SciMLBase.successful_retcode(s2)
+    @test s2.u ≈ fill(2.0, n) atol = 1.0e-6
+
+    # an explicit new `p` must still be applied (root moves to sqrt(9) = 3)
+    SciMLBase.reinit!(cache, ones(n); p = fill(9.0, n))
+    s3 = solve!(cache)
+    @test SciMLBase.successful_retcode(s3)
+    @test s3.u ≈ fill(3.0, n) atol = 1.0e-6
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,6 +107,7 @@ else
             @time @safetestset "Default Algorithm for AbstractSteadyStateProblem" include("Core/default_alg_tests__item1.jl")
             @time @safetestset "NLLS Hessian SciML/NonlinearSolve.jl#445" include("Core/forward_ad_tests__item2.jl")
             @time @safetestset "reinit! on ForwardDiff cache SciML/NonlinearSolve.jl#391" include("Core/forward_ad_tests__item3.jl")
+            @time @safetestset "reinit! preserves parameters (LinearSolveParameters type stability)" include("Core/reinit_tests__item1.jl")
             @time @safetestset "Correct Best Solution: #565" include("Core/issue_tests__item1.jl")
             @time @safetestset "Polyalgorithm Fallback Path: CurveFit.jl#76" include("Core/issue_tests__item2.jl")
             @time @safetestset "Polyalgorithm Cache solve!: Issue #779" include("Core/issue_tests__item3.jl")


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Prerequisite for making the homotopy-continuation solvers reuse an inner-solver cache in their step loop (`init` once, `reinit!` + `solve!` each step) instead of rebuilding the solver every step.

## The bug

`InternalAPI.reinit!(cache::LinearSolveJLCache; u = missing, p = missing)` rebuilt the internal `LinearSolveParameters` from the passed `p` **even when `p` was `missing`** — i.e. the ordinary case of reinit!-ing with only a new `u0`, parameters unchanged:

```julia
return SciMLBase.reinit!(cache.lincache; p = LinearSolveParameters(u_fixed, p))  # p === missing here
```

That builds `LinearSolveParameters(u_fixed, missing)`, whose `Missing` p-field type mismatches the concretely-typed `p` (e.g. `NullParameters`) the LinearSolve cache was constructed with, so `reinit!` throws:

```
setfield!: expected LinearSolveParameters{Vector{Float64}, NullParameters},
           got a value of type LinearSolveParameters{Vector{Float64}, Missing}
```

This fires for **every** solver that uses the LinearSolve-backed linear cache — `NewtonRaphson`, `TrustRegion`, and the default polyalgorithm — so the standard "init once, `reinit!` each step" reuse pattern was unusable with them.

## The fix

Treat `missing` `u`/`p` as *"unchanged"* — read them from the cache's current `LinearSolveParameters` rather than overwriting with `missing`. An explicit `p` is still applied as before.

## Verification (local, Julia 1.11)

- `NewtonRaphson`, `TrustRegion`, and the polyalgorithm now `init` once and `reinit!`+`solve!` in a loop **without error** and with correct roots (previously all threw).
- Passing a new `p` to `reinit!` still moves the solution to the new root (`sqrt(9) = 3`).
- The reinit!-exercising suite (ForwardDiff-cache #391, NoInit caching, LinearSolve preconditioner, polyalg cache `solve!` #779) still passes — 106 assertions.
- New regression test `test/Core/reinit_tests__item1.jl` (18 assertions) covering init → `p`-less `reinit!` → explicit-`p` `reinit!` across the three solver families.

`NonlinearSolveBase` bumped 2.34.0 → 2.34.1 (bug-fix).

> Note: there is a separate, deeper gap where a `p`-less `reinit!` *after* an explicit `p`-change does not always retain the changed `p` for one solver family (the outer cache's `p` persistence, not this linear-cache path); left out of scope here and not asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)