### PR TITLE
Recompute trust-region radius on reinit

### DIFF
--- a/lib/NonlinearSolveFirstOrder/src/trust_region.jl
+++ b/lib/NonlinearSolveFirstOrder/src/trust_region.jl
@@ -293,6 +293,21 @@ function InternalAPI.reinit!(
     cache.p = p
     if u0 !== nothing
         u0_norm = cache.internalnorm(u0)
+        cache.fu_cache = Utils.evaluate_f!!(cache.f, cache.fu_cache, u0, p)
+        T = promote_type(eltype(u0), eltype(cache.fu_cache))
+        fu_norm = cache.internalnorm(cache.fu_cache)
+        cache.max_trust_radius = max_trust_radius(
+            cache.alg.max_trust_radius, T, cache.method, u0, fu_norm
+        )
+        cache.initial_trust_radius = initial_trust_radius(
+            cache.alg.initial_trust_radius, T, cache.method, cache.max_trust_radius,
+            u0_norm, fu_norm
+        )
+        if cache.method isa RUS.__Yuan
+            operator = StatefulJacobianOperator(cache.vjp_operator, u0, p)
+            @bb cache.Jᵀfu_cache = operator × vec(cache.fu_cache)
+            cache.initial_trust_radius = T(cache.p1 * cache.internalnorm(cache.Jᵀfu_cache))
+        end
     end
     cache.last_step_accepted = false
     cache.trust_region = cache.initial_trust_radius

--- a/lib/NonlinearSolveFirstOrder/src/trust_region.jl
+++ b/lib/NonlinearSolveFirstOrder/src/trust_region.jl
@@ -59,6 +59,8 @@ Simply put the desired scheme as follows:
 module RadiusUpdateSchemes
     # The weird definitions here are needed to main compatibility with the older enum variants
 
+    export Bastin, Fan, Hei, NLsolve, NocedalWright, Simple, Yuan
+
     abstract type AbstractRadiusUpdateScheme end
 
     function Base.show(io::IO, rus::AbstractRadiusUpdateScheme)

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests__item3.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests__item3.jl
@@ -18,3 +18,9 @@ sol = solve!(cache)
 # Reinitialize and check the trust region was reset
 reinit!(cache, [1.0, 1.0]; p = 2.0)
 @test tr_cache.trust_region == tr_cache.initial_trust_radius
+
+original_initial_trust_radius = tr_cache.initial_trust_radius
+reinit!(cache, [100.0, 1.0]; p = 2.0)
+@test tr_cache.initial_trust_radius != original_initial_trust_radius
+@test tr_cache.initial_trust_radius == tr_cache.max_trust_radius / 11
+@test tr_cache.trust_region == tr_cache.initial_trust_radius


### PR DESCRIPTION
Draft PR for #1004. Ignore until reviewed by @ChrisRackauckas.

## Summary
- Recompute trust-region max/initial radii from the current `u0` and residual during `GenericTrustRegionSchemeCache` reinit.
- Preserve the `Yuan` initialization behavior by recomputing its `J'fu`-based initial radius.
- Extend the existing trust-region reinit regression test to cover changed `u0` scaling.
- Mark documented `RadiusUpdateSchemes` constants public so root QA does not rely on non-public qualified access.

## Local verification
- `timeout 3600 julia --project=lib/NonlinearSolveFirstOrder --startup-file=no -e 'using Test; include("lib/NonlinearSolveFirstOrder/test/misc_tests__item3.jl")'` exited 0.
- `timeout 3600 julia --project=.runic-env --startup-file=no -m Runic --check lib/NonlinearSolveFirstOrder/src/trust_region.jl lib/NonlinearSolveFirstOrder/test/misc_tests__item3.jl` exited 0.
- `timeout 3600 julia --project=lib/NonlinearSolveFirstOrder -e 'using Pkg; Pkg.test(; test_args=["core"], julia_args=["--startup-file=no"])'` passed: `Testing NonlinearSolveFirstOrder tests passed`.
- `NONLINEARSOLVE_TEST_GROUP=QA timeout 3600 julia --project=lib/NonlinearSolveFirstOrder -e 'using Pkg; Pkg.test(; julia_args=["--startup-file=no"])'` passed: `Testing NonlinearSolveFirstOrder tests passed`.
- `GROUP=QA timeout 3600 julia --project=. -e 'using Pkg; Pkg.test(; julia_args=["--startup-file=no"])'` passed: `Testing NonlinearSolve tests passed`.

Closes #1004.