### PR TITLE
Make radius update schemes public

### DIFF
--- a/lib/NonlinearSolveFirstOrder/src/trust_region.jl
+++ b/lib/NonlinearSolveFirstOrder/src/trust_region.jl
@@ -59,6 +59,8 @@ Simply put the desired scheme as follows:
 module RadiusUpdateSchemes
     # The weird definitions here are needed to main compatibility with the older enum variants
 
+    export Simple, NLsolve, NocedalWright, Hei, Yuan, Bastin, Fan
+
     abstract type AbstractRadiusUpdateScheme end
 
     function Base.show(io::IO, rus::AbstractRadiusUpdateScheme)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -34,11 +34,10 @@ run_qa(
         #   NonlinearSolveBase(.Utils): Utils, evaluate_f, initialization_alg, nodual_value,
         #     safe_vec
         #   ForwardDiff: partials;  LeastSquaresOptim: Cholesky, LSMR, QR
-        #   NonlinearSolveFirstOrder.RadiusUpdateSchemes: Bastin
         all_qualified_accesses_are_public = (;
             ignore = (
                 :Utils, :evaluate_f, :initialization_alg, :nodual_value, :safe_vec,
-                :partials, :Cholesky, :LSMR, :QR, :Bastin,
+                :partials, :Cholesky, :LSMR, :QR,
             ),
         ),
         # Still non-public in their owning packages after the make-public round:


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Exports the documented `RadiusUpdateSchemes` constants from the submodule so qualified accesses like `RadiusUpdateSchemes.Fan` are public.
- Removes the stale root QA ignore for `RadiusUpdateSchemes.Bastin` now that the documented schemes are public.

## Investigation

Root QA fails on current `origin/master` at `99517497` with ExplicitImports:

```text
NonPublicQualifiedAccessException
- `Fan` is not public in `NonlinearSolveFirstOrder.RadiusUpdateSchemes` but it was imported from `NonlinearSolveFirstOrder.RadiusUpdateSchemes` at `src/poly_algs.jl:45:76`
```

The parent of `1479e367` (`c25a6a76`) passes root QA. The introducing commit is:

```text
1479e367 Default polyalgorithms: replace the Bastin trust-region stage with Fan (#1006)
```

## Local verification

```text
GROUP=QA timeout 3600 julia --project=. -e 'using Pkg; Pkg.test(; julia_args=["--startup-file=no"])'
Test Summary: | Pass  Total   Time
QA            |   16     16  52.6s
     Testing NonlinearSolve tests passed
```

```text
julia --project=. -m Runic -c .
# passed with exit code 0
```
