### PR TITLE
Box Enzyme solve_up tape closure

### DIFF
--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseEnzymeExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseEnzymeExt.jl
@@ -152,9 +152,10 @@ function Enzyme.EnzymeRules.augmented_primal(
     end
     primal = EnzymeRules.needs_primal(config) ? res[1] : nothing
     shadow = EnzymeRules.needs_shadow(config) ? dres : nothing
-    tup = (dres, res[2])
+    # Keep SciMLSensitivity's pullback closure out of the concrete Enzyme tape type.
+    tape = Any[dres, res[2]]
     RetType = Enzyme.EnzymeRules.augmented_rule_return_type(config, RT)
-    return RetType(primal, shadow, tup::Any)
+    return RetType(primal, shadow, tape)
 end
 
 function Enzyme.EnzymeRules.reverse(


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Box the `solve_up` Enzyme custom-rule tape in `Any[...]` so the SciMLSensitivity pullback closure does not become part of the concrete Enzyme tape type.
- Keep the same primal, shadow, and reverse pullback behavior; this only reduces compiler/tape type pressure on the macOS Julia 1.10 Enzyme reverse-mode path.

## Context
The latest master root CI failed intermittently in `tests / Adjoint (julia lts, macos-latest)` with a Julia signal 11 in `test/Adjoint/adjoint_tests__item3.jl`. Recent runs show the same job/file/line can pass with identical Enzyme/SciMLSensitivity versions, so this targets robustness rather than changing the tested behavior.

## Validation
- `timeout 3600 env NONLINEARSOLVE_TEST_GROUP=Adjoint ~/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test(; julia_args=["--check-bounds=auto"])'`\n- `timeout 3600 ~/.juliaup/bin/julia +1 --project=. -e 'using Pkg; Pkg.test(; julia_args=["--check-bounds=auto"])'` from `lib/NonlinearSolveBase`\n- `git diff --check`\n- `Runic.format_file(...; inplace=true)` on the changed file from a temporary Julia environment with Runic v1.7.0\n