### PR TITLE
Limit StaticArray CUDA limited-memory Broyden smoke test

### DIFF
--- a/lib/SimpleNonlinearSolve/test/gpu/cuda_tests__item2.jl
+++ b/lib/SimpleNonlinearSolve/test/gpu/cuda_tests__item2.jl
@@ -13,7 +13,18 @@ if CUDA.functional()
         return nothing
     end
 
+    limited_memory_broyden_for_kernel(::Type{<:Number}; linesearch = nothing) =
+        SimpleLimitedMemoryBroyden(; linesearch)
+
+    function limited_memory_broyden_for_kernel(::Type{<:StaticArray}; linesearch = nothing)
+        # The StaticArray path unrolls one generated block per threshold. Keep the
+        # kernel smoke test small enough for 16 GiB CI GPUs; scalar coverage keeps
+        # the default threshold.
+        return SimpleLimitedMemoryBroyden(; threshold = Val(2), linesearch)
+    end
+
     @testset for u0 in (1.0f0, @SVector[1.0f0, 1.0f0])
+        u0_type = typeof(u0)
         prob = convert(ImmutableNonlinearProblem, NonlinearProblem{false}(f, u0, 2.0f0))
 
         # Note: SimpleHalley is excluded from kernel tests due to dynamic dispatch issues
@@ -26,11 +37,12 @@ if CUDA.functional()
                     nlsolve_update_rule = Val(true), autodiff = AutoForwardDiff()
                 ),
                 SimpleBroyden(),
-                SimpleLimitedMemoryBroyden(),
+                limited_memory_broyden_for_kernel(u0_type),
                 SimpleKlement(),
                 # SimpleHalley(; autodiff = AutoForwardDiff()),
                 SimpleBroyden(; linesearch = LiFukushimaLineSearch(; nan_maxiters = nothing)),
-                SimpleLimitedMemoryBroyden(;
+                limited_memory_broyden_for_kernel(
+                    u0_type;
                     linesearch = LiFukushimaLineSearch(; nan_maxiters = nothing)
                 ),
             )


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Keep scalar CUDA kernel-smoke coverage for `SimpleLimitedMemoryBroyden` at the default `threshold = Val(27)`.
- Use `threshold = Val(2)` only for StaticArray `SimpleLimitedMemoryBroyden` kernel-smoke variants, including the line-search variant.

## Context
The latest Sublibrary CI failure was `lib/SimpleNonlinearSolve [CUDA]`, where the self-hosted GPU runner OOMed while launching the `SVector{2,Float32}` kernel for `SimpleLimitedMemoryBroyden{..., Val{27}, ...}`. The log reported CUDA memory pool usage of 0 bytes, pointing to CUDA compile/module pressure rather than runtime array allocation.

## Validation
- `timeout 3600 env NONLINEARSOLVE_TEST_GROUP=CUDA ~/.juliaup/bin/julia +1 --project=. -e 'using Pkg; Pkg.test(; julia_args=["--check-bounds=auto"])'` from `lib/SimpleNonlinearSolve`\n  - Passed locally, but both CUDA testsets reported `Total 0` because this machine has `CUDA.functional() = false` and `CUDA.has_cuda() = false`.\n- `~/.juliaup/bin/julia +1 --startup-file=no -e 'Meta.parseall(read("lib/SimpleNonlinearSolve/test/gpu/cuda_tests__item2.jl", String)); println("parse ok")'`\n- `git diff --check`\n- `Runic.format_file(...; inplace=true)` on the changed file from a temporary Julia environment with Runic v1.7.0\n