### PR TITLE
specify the module for the bindings in `safe_getproperty`

### DIFF
--- a/lib/NonlinearSolveBase/src/utils.jl
+++ b/lib/NonlinearSolveBase/src/utils.jl
@@ -129,8 +129,8 @@ safe_reshape(x::Number, args...) = x
 safe_reshape(x, args...) = reshape(x, args...)
 
 @generated function safe_getproperty(s::S, ::Val{X}) where {S, X}
-    hasfield(S, X) && return :(getproperty(s, $(Meta.quot(X))))
-    return :(missing)
+    hasfield(S, X) && return :(Base.getproperty(s, $(Meta.quot(X))))
+    return :(Base.missing)
 end
 
 @generated function safe_vec(v)


### PR DESCRIPTION
without this I get a huge output from SnoopCompile about bindind replacements. I am not sure if it actually matters in practice but this at least removes a bunch of noise. The noise looks like

```
, rebinding Core.Binding(:(NonlinearSolveBase.Utils.getproperty), #undef, #undef, #undef, 0x08) invalidated:
   mt_backedges:   1: signature NonlinearSolveBase.Utils.getproperty triggered MethodInstance for NonlinearSolveBase.Utils.safe_getproperty(::NonlinearSolveBase.NewtonDescent{Nothing}, ::Val{:linsolve}) (0 children)
                   2: signature NonlinearSolveBase.Utils.getproperty triggered MethodInstance for NonlinearSolveBase.Utils.safe_getproperty(::NonlinearSolveBase.NewtonDescentCache{Float64, Nothing, Nothing, Nothing, Nothing, Nothing, Val{true}, Val{false}}, ::Val{:preinverted_jacobian}) (0 children)
                   3: signature NonlinearSolveBase.Utils.getproperty triggered MethodInstance for NonlinearSolveBase.Utils.safe_getproperty(::NonlinearSolveBase.NewtonDescentCache{Float64, Nothing, Nothing, Nothing, Nothing, Nothing, Val{true}, Val{false}}, ::Val{:normal_form}) (0 children)
...
```

with hundreds of lines of huge signatures. 

