### PR TITLE
Add `SimpleHomotopySweep`: allocation-free homotopy continuation for StaticArrays

### DIFF
--- a/docs/src/native/simplenonlinearsolve.md
+++ b/docs/src/native/simplenonlinearsolve.md
@@ -20,6 +20,7 @@ These methods are suited for any general nonlinear root-finding problem, i.e.
 | [`SimpleTrustRegion`](@ref)          | ✔️       | ✔️           | ✔️                       | ✔️                        |
 | [`SimpleDFSane`](@ref)               | ✔️       | ✔️           | ✔️[^1]                   | ✔️                        |
 | [`SimpleLimitedMemoryBroyden`](@ref) | ✔️       | ✔️           | ✔️                       | ✔️[^2]                    |
+| [`SimpleHomotopySweep`](@ref)        | ✔️       | ✔️           | ✔️                       | ✔️                        |
 
 The algorithms which are non-allocating can be used directly inside GPU Kernels[^3].
 See [ParallelParticleSwarms.jl](https://github.com/SciML/ParallelParticleSwarms.jl) for more details.
@@ -32,6 +33,7 @@ SimpleKlement
 SimpleTrustRegion
 SimpleDFSane
 SimpleLimitedMemoryBroyden
+SimpleHomotopySweep
 ```
 
 `SimpleGaussNewton` is aliased to [`SimpleNewtonRaphson`](@ref) for solving Nonlinear Least

--- a/lib/SimpleNonlinearSolve/src/SimpleNonlinearSolve.jl
+++ b/lib/SimpleNonlinearSolve/src/SimpleNonlinearSolve.jl
@@ -53,6 +53,7 @@ include("klement.jl")
 include("lbroyden.jl")
 include("raphson.jl")
 include("trust_region.jl")
+include("simple_homotopy_sweep.jl")
 
 # By Pass the highlevel checks for NonlinearProblem for Simple Algorithms
 function CommonSolve.solve(
@@ -166,6 +167,7 @@ export SimpleBroyden, SimpleKlement, SimpleLimitedMemoryBroyden
 export SimpleDFSane
 export SimpleGaussNewton, SimpleNewtonRaphson, SimpleTrustRegion
 export SimpleHalley
+export SimpleHomotopySweep
 
 export solve
 

--- a/lib/SimpleNonlinearSolve/src/simple_homotopy_sweep.jl
+++ b/lib/SimpleNonlinearSolve/src/simple_homotopy_sweep.jl
@@ -1,0 +1,259 @@
+"""
+    SimpleHomotopySweep(; inner = SimpleNewtonRaphson(), nsteps = nothing,
+        adaptive = true, initial_step_factor = 0.1, min_dλ = nothing,
+        max_step_factor = 1.0, expand_factor = 2.0, expand_threshold = 2,
+        expand_quality = 0.25, predictor = :secant)
+
+Natural-parameter continuation solver for a `SciMLBase.HomotopyProblem`, the
+SimpleNonlinearSolve counterpart of `HomotopySweep`. The algorithm is the same —
+anchor solve at `λspan[1]`, then predictor-corrector λ-stepping with the classic
+success/failure step control (failure halves the increment; `expand_threshold`
+consecutive successes grow it by `expand_factor` up to `max_step_factor` of the span,
+gated on the `expand_quality` secant-prediction error estimate), with a
+trust-monitored `:secant` warm-start predictor (`:constant` disables extrapolation) —
+but the driver is written in the direct, value-oriented SimpleNonlinearSolve style:
+each step calls `solve` on a freshly constructed (stack-allocated) inner problem
+instead of maintaining an inner-solver cache, and all sweep state is plain values.
+
+With a `StaticArray` (or scalar) `u0` and a SimpleNonlinearSolve inner solver, the
+entire sweep is non-allocating, which also makes it the variant of choice inside hot
+loops, on GPUs, and for compilation-sensitive targets. For large mutable systems,
+prefer `HomotopySweep`, whose cached driver reuses the inner solver's workspace
+across steps.
+
+Keyword arguments are identical to `HomotopySweep` except that `inner` defaults to
+`SimpleNewtonRaphson()` (a SimpleNonlinearSolve corrector) rather than the
+NonlinearSolve polyalgorithm.
+
+When the sweep cannot reach the end of `λspan`, the returned solution carries a
+failure retcode: its `u` is the last converged iterate (at some ``λ`` short of
+`λspan[2]`, or `u0` itself if the initial `λspan[1]` anchor solve failed), while
+`resid` and `original` come from the most recent inner solve (unlike `HomotopySweep`,
+the `ReturnCode.Stalled` path reports the residual of the last *successful* step
+rather than `nothing`: every return path builds the same concrete solution type,
+which is part of what keeps the sweep allocation-free).
+"""
+@concrete struct SimpleHomotopySweep <: AbstractNonlinearSolveAlgorithm
+    inner
+    nsteps
+    adaptive::Bool
+    initial_step_factor
+    min_dλ
+    max_step_factor
+    expand_factor
+    expand_threshold::Int
+    expand_quality
+    predictor::Symbol
+end
+
+function SimpleHomotopySweep(;
+        inner = SimpleNewtonRaphson(), nsteps = nothing, adaptive = true,
+        initial_step_factor = 0.1, min_dλ = nothing, max_step_factor = 1.0,
+        expand_factor = 2.0, expand_threshold = 2, expand_quality = 0.25,
+        predictor = :secant
+    )
+    if nsteps !== nothing && nsteps < 1
+        throw(ArgumentError("SimpleHomotopySweep `nsteps` must be ≥ 1, got $nsteps"))
+    end
+    if !adaptive && nsteps === nothing
+        throw(
+            ArgumentError(
+                "SimpleHomotopySweep with `adaptive = false` takes fixed-size λ steps, " *
+                    "so an explicit `nsteps` is required."
+            )
+        )
+    end
+    if !(0 < initial_step_factor <= 1)
+        throw(
+            ArgumentError(
+                "SimpleHomotopySweep `initial_step_factor` must be in (0, 1], got $initial_step_factor"
+            )
+        )
+    end
+    if min_dλ !== nothing && min_dλ <= 0
+        throw(
+            ArgumentError(
+                "SimpleHomotopySweep `min_dλ` must be positive, got $min_dλ"
+            )
+        )
+    end
+    if !(0 < max_step_factor <= 1)
+        throw(
+            ArgumentError(
+                "SimpleHomotopySweep `max_step_factor` must be in (0, 1], got $max_step_factor"
+            )
+        )
+    end
+    if expand_factor < 1
+        throw(
+            ArgumentError(
+                "SimpleHomotopySweep `expand_factor` must be ≥ 1 (1 disables " *
+                    "expansion), got $expand_factor"
+            )
+        )
+    end
+    if expand_threshold < 1
+        throw(
+            ArgumentError(
+                "SimpleHomotopySweep `expand_threshold` must be ≥ 1, got $expand_threshold"
+            )
+        )
+    end
+    if !(expand_quality > 0)
+        throw(
+            ArgumentError(
+                "SimpleHomotopySweep `expand_quality` must be positive (Inf disables " *
+                    "the gate), got $expand_quality"
+            )
+        )
+    end
+    if predictor !== :secant && predictor !== :constant
+        throw(
+            ArgumentError(
+                "SimpleHomotopySweep `predictor` must be :secant or :constant, got :$predictor"
+            )
+        )
+    end
+    return SimpleHomotopySweep(
+        inner, nsteps, adaptive, initial_step_factor, min_dλ,
+        max_step_factor, expand_factor, expand_threshold, expand_quality, predictor
+    )
+end
+
+# Immutable λ-fixing wrapper (contrast NonlinearSolveBase's mutable `FixLambda`): the
+# sweep rebuilds it each step, which for isbits `f` is stack-allocated — the immutable
+# form is what keeps the StaticArray path heap-free.
+struct SimpleFixLambda{F, T}
+    f::F
+    λ::T
+end
+(fl::SimpleFixLambda)(args...) = fl.f(args..., fl.λ)
+
+# One inner corrector solve at fixed λ. A fresh immutable problem per call: for
+# StaticArray/scalar `u` everything here lives on the stack.
+function _simple_sweep_solve(
+        prob::SciMLBase.HomotopyProblem{uType, iip}, inner, guess, λfix,
+        args...; kwargs...
+    ) where {uType, iip}
+    fλ = NonlinearFunction{iip}(SimpleFixLambda(prob.f, λfix))
+    inner_prob = NonlinearProblem{iip}(fλ, guess, prob.p)
+    return solve(inner_prob, inner, args...; prob.kwargs..., kwargs...)
+end
+
+# The corrector may iterate in place in its u0 for mutable arrays, so hand it a copy;
+# immutable/StaticArray/scalar `u` cannot be mutated and passes through (stack).
+_simple_sweep_guess(u) = NLBUtils.can_setindex(u) ? copy(u) : u
+
+function CommonSolve.solve(
+        prob::SciMLBase.HomotopyProblem{uType, iip},
+        alg::SimpleHomotopySweep, args...; kwargs...
+    ) where {uType, iip}
+    λ0, λ1 = prob.λspan
+    λ = float(λ0)
+    λT = typeof(λ)
+    λend = λT(λ1)
+    span = λend - λ
+    dλ = alg.nsteps === nothing ? λT(alg.initial_step_factor) * span : span / alg.nsteps
+    min_dλ = alg.min_dλ === nothing ? sqrt(eps(λT)) : λT(alg.min_dλ)
+    max_dλ = λT(alg.max_step_factor) * span     # carries span's sign, like dλ
+    expand_factor = λT(alg.expand_factor)
+    abs(dλ) > abs(max_dλ) && (dλ = max_dλ)
+    u = _simple_sweep_guess(prob.u0)
+
+    # Anchor: solve the system at λ = λspan[1] from u0 before stepping (see
+    # `HomotopySweep` — same contract: a failed anchor means the homotopy premise is
+    # broken and no continuation is attempted).
+    last_sol = _simple_sweep_solve(
+        prob, alg.inner, _simple_sweep_guess(u), λ, args...; kwargs...
+    )
+    if !SciMLBase.successful_retcode(last_sol)
+        return SciMLBase.build_solution(
+            prob, alg, u, last_sol.resid;
+            retcode = last_sol.retcode, original = last_sol
+        )
+    end
+    u = _simple_sweep_guess(last_sol.u)
+    # Zero-width λspan (λ0 == λend): the anchor IS the single target solve.
+    λ == λend && return SciMLBase.build_solution(
+        prob, alg, u, last_sol.resid; retcode = ReturnCode.Success, original = last_sol
+    )
+
+    # λ_prev == λ means there is no secant history yet (constant warm start). The
+    # trust counter and quality gate mirror `HomotopySweep` exactly; see its docstring
+    # for the controller's rationale.
+    u_prev = u
+    λ_prev = λ
+    streak = 0
+    trust = 2
+    disp_prev = zero(λT)
+
+    while true
+        next_λ = abs(λend - λ) <= abs(dλ) ? λend : λ + dλ
+        if next_λ == λ && next_λ != λend
+            # dλ underflowed below eps(λ) mid-continuation: no further progress.
+            # `resid`/`original` come from the most recent inner solve (NOT `nothing`
+            # as in `HomotopySweep`): every return path builds the same concrete
+            # `NonlinearSolution` type, which is what lets the whole sweep stay
+            # allocation-free on StaticArrays.
+            return SciMLBase.build_solution(
+                prob, alg, u, last_sol.resid;
+                retcode = ReturnCode.Stalled, original = last_sol
+            )
+        end
+        used_secant = alg.predictor === :secant && trust >= 2 && λ_prev != λ
+        guess = if used_secant
+            s = (next_λ - λ) / (λ - λ_prev)
+            @. u + s * (u - u_prev)
+        else
+            _simple_sweep_guess(u)
+        end
+        last_sol = _simple_sweep_solve(prob, alg.inner, guess, next_λ, args...; kwargs...)
+
+        if SciMLBase.successful_retcode(last_sol)
+            θ = nothing
+            if λ_prev != λ
+                # measured against the prediction the secant WOULD have made, so trust
+                # can recover on constant-warm-started steps too
+                sv = (next_λ - λ) / (λ - λ_prev)
+                virtual = @. u + sv * (u - u_prev)
+                correction = L2_NORM(last_sol.u .- virtual)
+                disp = L2_NORM(last_sol.u .- u)
+                scale = max(disp, disp_prev, sqrt(eps(λT)) * (1 + L2_NORM(last_sol.u)))
+                θ = correction / scale
+                trust = θ < 1 / 2 ? trust + 1 : 0
+                disp_prev = disp
+            else
+                disp_prev = L2_NORM(last_sol.u .- u)
+            end
+            u_prev = u
+            λ_prev = λ
+            u = _simple_sweep_guess(last_sol.u)
+            λ = next_λ
+            λ == λend && break
+            if alg.adaptive
+                streak += 1
+                corrector_cheap = last_sol.stats !== nothing &&
+                    last_sol.stats.nsteps <= 2
+                if streak >= alg.expand_threshold &&
+                        (θ === nothing || θ <= λT(alg.expand_quality) || corrector_cheap)
+                    grown = expand_factor * dλ
+                    dλ = abs(grown) > abs(max_dλ) ? max_dλ : grown
+                    streak = 0
+                end
+            end
+        elseif alg.adaptive && abs(dλ) / 2 >= min_dλ
+            dλ = dλ / 2          # bisect; retry from the same λ (do not advance)
+            streak = 0
+            trust = 0
+        else
+            return SciMLBase.build_solution(
+                prob, alg, u, last_sol.resid;
+                retcode = last_sol.retcode, original = last_sol
+            )
+        end
+    end
+
+    return SciMLBase.build_solution(
+        prob, alg, u, last_sol.resid; retcode = ReturnCode.Success, original = last_sol
+    )
+end

--- a/lib/SimpleNonlinearSolve/test/alloc/allocation_tests.jl
+++ b/lib/SimpleNonlinearSolve/test/alloc/allocation_tests.jl
@@ -1,1 +1,2 @@
 @safetestset "Allocation Tests" include("allocation_tests__item1.jl")
+@safetestset "SimpleHomotopySweep Allocation Tests" include("allocation_tests__item2.jl")

--- a/lib/SimpleNonlinearSolve/test/alloc/allocation_tests__item2.jl
+++ b/lib/SimpleNonlinearSolve/test/alloc/allocation_tests__item2.jl
@@ -1,0 +1,25 @@
+using SimpleNonlinearSolve, StaticArrays, AllocCheck
+using SciMLBase
+
+# The whole continuation sweep — anchor, adaptive predictor-corrector loop, and the
+# returned solution — must be allocation-free for StaticArray and scalar states. Every
+# return path builds the same concrete NonlinearSolution type, which is what makes the
+# escaping return stack-allocatable.
+homotopy_f(u, p, λ) = @. (1 - λ) * (u - p) + λ * (u^2 - p)
+
+@check_allocs hsweep(prob, alg) = SciMLBase.solve(prob, alg)
+
+hprob_scalar = HomotopyProblem(homotopy_f, 4.0, 4.0)
+hprob_sa = HomotopyProblem(homotopy_f, @SVector[4.0], 4.0)
+
+@testset "SimpleHomotopySweep" begin
+    for prob in (hprob_scalar, hprob_sa)
+        try
+            sol = hsweep(prob, SimpleHomotopySweep())
+            @test SciMLBase.successful_retcode(sol)
+        catch e
+            @error e
+            @test false
+        end
+    end
+end

--- a/lib/SimpleNonlinearSolve/test/core/homotopy_sweep_tests.jl
+++ b/lib/SimpleNonlinearSolve/test/core/homotopy_sweep_tests.jl
@@ -1,0 +1,1 @@
+@safetestset "SimpleHomotopySweep" include("homotopy_sweep_tests__item1.jl")

--- a/lib/SimpleNonlinearSolve/test/core/homotopy_sweep_tests__item1.jl
+++ b/lib/SimpleNonlinearSolve/test/core/homotopy_sweep_tests__item1.jl
@@ -1,0 +1,80 @@
+using SimpleNonlinearSolve, StaticArrays, SciMLBase
+
+# ---- construction + validation ----
+alg = SimpleHomotopySweep()
+@test alg isa SimpleHomotopySweep
+@test alg.inner isa SimpleNewtonRaphson
+@test alg.adaptive
+@test alg.predictor === :secant
+
+@test_throws ArgumentError SimpleHomotopySweep(; nsteps = 0)
+@test_throws ArgumentError SimpleHomotopySweep(; adaptive = false)
+@test_throws ArgumentError SimpleHomotopySweep(; initial_step_factor = 0.0)
+@test_throws ArgumentError SimpleHomotopySweep(; min_dλ = 0.0)
+@test_throws ArgumentError SimpleHomotopySweep(; max_step_factor = 1.5)
+@test_throws ArgumentError SimpleHomotopySweep(; expand_factor = 0.5)
+@test_throws ArgumentError SimpleHomotopySweep(; expand_threshold = 0)
+@test_throws ArgumentError SimpleHomotopySweep(; expand_quality = 0.0)
+@test_throws ArgumentError SimpleHomotopySweep(; predictor = :tangent)
+
+# ---- correctness across container types ----
+# (1-λ)(u - p) + λ(u² - p): root path from u = p at λ = 0 to u = √p at λ = 1
+H(u, p, λ) = @. (1 - λ) * (u - p) + λ * (u^2 - p)
+
+sol_v = solve(HomotopyProblem(H, [4.0], 4.0), SimpleHomotopySweep())
+@test SciMLBase.successful_retcode(sol_v)
+@test sol_v.u[1] ≈ 2.0 atol = 1.0e-6
+
+sol_s = solve(HomotopyProblem(H, SA[4.0], 4.0), SimpleHomotopySweep())
+@test SciMLBase.successful_retcode(sol_s)
+@test sol_s.u isa SVector{1, Float64}
+@test sol_s.u[1] ≈ 2.0 atol = 1.0e-6
+
+sol_32 = solve(
+    HomotopyProblem(H, SA[4.0f0], 4.0f0; λspan = (0.0f0, 1.0f0)), SimpleHomotopySweep()
+)
+@test SciMLBase.successful_retcode(sol_32)
+@test eltype(sol_32.u) == Float32
+@test sol_32.u[1] ≈ 2.0f0 atol = 1.0f-4
+
+H!(du, u, p, λ) = (du .= (1 .- λ) .* (u .- p) .+ λ .* (u .^ 2 .- p); nothing)
+sol_i = solve(HomotopyProblem(NonlinearFunction{true}(H!), [4.0], 4.0), SimpleHomotopySweep())
+@test SciMLBase.successful_retcode(sol_i)
+@test sol_i.u[1] ≈ 2.0 atol = 1.0e-6
+
+# ---- decreasing λspan ----
+sol_dec = solve(
+    HomotopyProblem(H, SA[2.0], 4.0; λspan = (1.0, 0.0)), SimpleHomotopySweep()
+)
+@test SciMLBase.successful_retcode(sol_dec)
+@test sol_dec.u[1] ≈ 4.0 atol = 1.0e-6      # λ = 0 system is linear: u = p
+
+# ---- failure honesty: fold with no real root past λ = 1/3 must fail, not "succeed" ----
+Hfold(u, p, λ) = @. (1 - λ) * u + λ * (u^2 + 1)
+sol_f = solve(
+    HomotopyProblem(Hfold, SA[0.0]; λspan = (0.0, 1.0)),
+    SimpleHomotopySweep(; min_dλ = 1.0e-2)
+)
+@test !SciMLBase.successful_retcode(sol_f)
+@test all(isfinite, sol_f.u)                # last converged iterate, not diverged junk
+
+# ---- adaptive expansion takes fewer accepted steps than fixed increments ----
+λ_targets = Float64[]
+Hcount(u, p, λ) = (push!(λ_targets, λ); [u[1] - λ])
+prob_count = HomotopyProblem(Hcount, [0.0]; λspan = (0.0, 1.0))
+attempts(λs) = [λs[i] for i in eachindex(λs) if i == 1 || λs[i] != λs[i - 1]]
+
+empty!(λ_targets)
+solve(prob_count, SimpleHomotopySweep())
+n_grow = length(attempts(λ_targets))
+empty!(λ_targets)
+solve(prob_count, SimpleHomotopySweep(; expand_factor = 1))
+n_nogrow = length(attempts(λ_targets))
+@test n_grow < n_nogrow
+
+# ---- fixed-step mode ----
+sol_fix = solve(
+    HomotopyProblem(H, SA[4.0], 4.0), SimpleHomotopySweep(; adaptive = false, nsteps = 10)
+)
+@test SciMLBase.successful_retcode(sol_fix)
+@test sol_fix.u[1] ≈ 2.0 atol = 1.0e-6

--- a/lib/SimpleNonlinearSolve/test/runtests.jl
+++ b/lib/SimpleNonlinearSolve/test/runtests.jl
@@ -14,6 +14,7 @@ run_tests(;
         include("core/exotic_type_tests.jl")
         include("core/forward_diff_tests.jl")
         include("core/least_squares_tests.jl")
+        include("core/homotopy_sweep_tests.jl")
         include("core/matrix_resizing_tests.jl")
         return include("core/rootfind_tests.jl")
     end,


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

The companion to #967, per review direction: #967's `HomotopySweep` keeps the `init`/`reinit!`/`solve!` cache-reusing driver (right for loops over large mutable systems), and this PR splits out **`SimpleHomotopySweep`** in SimpleNonlinearSolve as the "no split" variant — direct per-step solves, designed to be **non-allocating on StaticArrays**.

## What it is

Same continuation algorithm as `HomotopySweep` (the `λspan[1]` anchor from #972; success/failure step control with streak expansion capped at `max_step_factor` and the `expand_quality` Deuflhard-style gate; trust-monitored `:secant` warm-start predictor), written in the direct, value-oriented SimpleNonlinearSolve style:

- Each step solves a **freshly constructed immutable inner problem** — an immutable `SimpleFixLambda` wrapper, no solver cache. For isbits `f` and StaticArray/scalar `u`, the wrapper, problem, and solve all live on the stack.
- All sweep state (λ, dλ, streak/trust counters, iterates) is plain values.
- `inner` defaults to `SimpleNewtonRaphson()`.

The key trick for zero allocations: **every return path builds the same concrete `NonlinearSolution` type** (`resid`/`original` always from the most recent inner solve — including the `Stalled` path, a documented deliberate difference from `HomotopySweep`'s `nothing`). With a Union return type the escaping solution must be heap-boxed; with one concrete type Julia stack-allocates it, and the whole sweep — anchor, adaptive loop, and return — passes AllocCheck with **0 allocation sites** for both scalar and `SVector` states. That makes it usable inside hot loops and GPU kernels, matching the SimpleNonlinearSolve contract.

## Verification (local, Julia 1.11)

- **AllocCheck**: `check_allocs(solve, (HomotopyProblem{SVector}, SimpleHomotopySweep))` → 0 sites; the new alloc-group test (scalar + `SVector`) passes 2/2 in the `test/alloc` environment.
- **Correctness**: Vector / SVector / scalar / in-place / Float32 / decreasing `λspan` / fixed-step mode; the no-real-root fold problem reports a failure retcode with a finite last-converged iterate; adaptive expansion takes strictly fewer accepted steps than fixed increments.
- **SimpleNonlinearSolve Core group**: `Pkg.test` exit 0 with the new tests registered.
- Honesty note: the full Alloc *group* run aborts on the **pre-existing** `SimpleHalley` scalar-allocation failure under Julia 1.11 codegen — the exact version sensitivity already documented in `test_groups.toml` (CI pins Alloc to the current release) — before reaching the new item; the new item was therefore verified standalone in the same environment.
- Runic clean; docstring + `@docs` entry + solver-table row added (public and documented together). No version bump (leaving versioning to the release process per 90b090cd).

## Relationship to #967

Independent of #967's branch (this touches only SimpleNonlinearSolve + docs; #967 touches only NonlinearSolveBase). Mergeable in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)