### PR TITLE
Sweep drivers: consume jac/jac_prototype/sparsity/colorvec from the NonlinearFunction (#1020 item 2)

### DIFF
--- a/lib/NonlinearSolveBase/src/homotopy_sweep.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_sweep.jl
@@ -18,6 +18,16 @@ solver's workspace (Jacobian buffers, linear-solver storage) instead of reconstr
 the solver every step; the sweep's own per-step state lives in a fixed set of
 preallocated buffers.
 
+Optional derivative fields of the problem's `NonlinearFunction` (which
+[`SciMLBase.HomotopyProblem`](@ref) requires to follow the same λ-extended argument
+convention as the residual) are consumed by this solver: an analytic `jac(u, p, λ)` /
+`jac(J, u, p, λ)` is λ-fixed exactly like the residual and handed to the inner solver
+as a standard 2/3-argument Jacobian (so e.g. the default polyalgorithm selects its
+Jacobian-based members), and `jac_prototype`, `sparsity`, and `colorvec` are forwarded
+unchanged, enabling sparse Jacobian handling in every inner solve. The prototype is
+not eltype-promoted with λ: supply a prototype whose eltype matches the promoted
+residual eltype if λ's precision differs from `u0`'s.
+
 The step size is governed by the classic success/failure heuristic of
 predictor-corrector path tracking (see e.g. Timme, *Mixed precision path tracking for
 polynomial homotopy continuation*, Advances in Computational Mathematics 47, 2021): a
@@ -177,6 +187,35 @@ mutable struct FixLambda{F, T}
 end
 (fl::FixLambda)(args...) = fl.f(args..., fl.λ)
 
+# λ-fixing wrapper for the user's analytic Jacobian `jac(u, p, λ)` / `jac(J, u, p, λ)`,
+# exposing the standard 2/3-argument form to the inner solver. It reads λ from the
+# residual's own mutable `FixLambda` rather than carrying a copy, so advancing the
+# sweep remains a single field write and the Jacobian can never be evaluated at a
+# different λ than the residual.
+struct FixLambdaJac{FL <: FixLambda}
+    fl::FL
+end
+(fj::FixLambdaJac)(args...) = fj.fl.f.jac(args..., fj.fl.λ)
+
+# Builds the inner solver's NonlinearFunction around the λ-fixing wrapper, forwarding
+# the derivative fields of the problem's NonlinearFunction (`jac` λ-fixed through the
+# shared `FixLambda`; `jac_prototype`/`sparsity`/`colorvec` unchanged — the prototype
+# is NOT eltype-promoted with λ, so its eltype should match the promoted residual
+# eltype when λ's precision differs from `u0`'s). When no derivative field is present
+# the construction is exactly the bare positional one (the branch is decided by the
+# problem's type, so the unused arm is compiled away).
+function _sweep_nonlinear_function(::Val{iip}, f, fixλ::FixLambda) where {iip}
+    if f.jac === nothing && f.jac_prototype === nothing && f.sparsity === nothing &&
+            f.colorvec === nothing
+        return SciMLBase.NonlinearFunction{iip}(fixλ)
+    end
+    jac = f.jac === nothing ? nothing : FixLambdaJac(fixλ)
+    return SciMLBase.NonlinearFunction{iip}(
+        fixλ; jac, jac_prototype = f.jac_prototype,
+        sparsity = f.sparsity, colorvec = f.colorvec
+    )
+end
+
 # Secant/constant predictor `u + s*(u - u_prev)`, written into the reused `dst` buffer
 # for mutable arrays (no allocation) or returned fresh for immutable/StaticArray/scalar
 # `u` (stack, no heap). `Utils.can_setindex` is a compile-time trait, so the branch is
@@ -232,7 +271,7 @@ function CommonSolve.solve(
     # buffer the inner solver never writes, so a FAILED attempt leaves the last
     # converged iterate intact for retries and the failure returns below.
     fixλ = FixLambda(prob.f, λ)
-    fλ = SciMLBase.NonlinearFunction{iip}(fixλ)
+    fλ = _sweep_nonlinear_function(Val(iip), prob.f, fixλ)
     guess = copy(u)
     cache = init(
         NonlinearProblem{iip}(fλ, guess, prob.p), alg.inner, args...;

--- a/lib/SimpleNonlinearSolve/src/simple_homotopy_sweep.jl
+++ b/lib/SimpleNonlinearSolve/src/simple_homotopy_sweep.jl
@@ -15,6 +15,15 @@ but the driver is written in the direct, value-oriented SimpleNonlinearSolve sty
 each step calls `solve` on a freshly constructed (stack-allocated) inner problem
 instead of maintaining an inner-solver cache, and all sweep state is plain values.
 
+Optional derivative fields of the problem's `NonlinearFunction` (which
+`SciMLBase.HomotopyProblem` requires to follow the same λ-extended argument convention
+as the residual) are consumed by this solver: an analytic `jac(u, p, λ)` /
+`jac(J, u, p, λ)` is λ-fixed exactly like the residual and handed to the inner solver
+as a standard 2/3-argument Jacobian, and `jac_prototype`, `sparsity`, and `colorvec`
+are forwarded unchanged. The prototype is not eltype-promoted with λ: supply a
+prototype whose eltype matches the promoted residual eltype if λ's precision differs
+from `u0`'s.
+
 With a `StaticArray` (or scalar) `u0` and a SimpleNonlinearSolve inner solver, the
 entire sweep is non-allocating, which also makes it the variant of choice inside hot
 loops, on GPUs, and for compilation-sensitive targets. For large mutable systems,
@@ -129,13 +138,35 @@ struct SimpleFixLambda{F, T}
 end
 (fl::SimpleFixLambda)(args...) = fl.f(args..., fl.λ)
 
+# Builds the inner NonlinearFunction for one step, forwarding the derivative fields of
+# the problem's NonlinearFunction: `jac` is λ-fixed through a second `SimpleFixLambda`
+# constructed here from the same `λfix` value as the residual's (both wrappers are
+# immutable and rebuilt together each step, so they cannot desynchronize);
+# `jac_prototype`/`sparsity`/`colorvec` pass through unchanged (the prototype is NOT
+# eltype-promoted with λ, so its eltype should match the promoted residual eltype when
+# λ's precision differs from `u0`'s). When no derivative field is present the
+# construction is exactly the bare positional one — the branch is decided by the
+# problem's type, so the unused arm is compiled away and the StaticArray/scalar path
+# stays allocation-free.
+function _simple_sweep_nonlinear_function(::Val{iip}, f, λfix) where {iip}
+    if f.jac === nothing && f.jac_prototype === nothing && f.sparsity === nothing &&
+            f.colorvec === nothing
+        return NonlinearFunction{iip}(SimpleFixLambda(f, λfix))
+    end
+    jac = f.jac === nothing ? nothing : SimpleFixLambda(f.jac, λfix)
+    return NonlinearFunction{iip}(
+        SimpleFixLambda(f, λfix); jac, jac_prototype = f.jac_prototype,
+        sparsity = f.sparsity, colorvec = f.colorvec
+    )
+end
+
 # One inner corrector solve at fixed λ. A fresh immutable problem per call: for
 # StaticArray/scalar `u` everything here lives on the stack.
 function _simple_sweep_solve(
         prob::SciMLBase.HomotopyProblem{uType, iip}, inner, guess, λfix,
         args...; kwargs...
     ) where {uType, iip}
-    fλ = NonlinearFunction{iip}(SimpleFixLambda(prob.f, λfix))
+    fλ = _simple_sweep_nonlinear_function(Val(iip), prob.f, λfix)
     inner_prob = NonlinearProblem{iip}(fλ, guess, prob.p)
     return solve(inner_prob, inner, args...; prob.kwargs..., kwargs...)
 end

--- a/test/Core/homotopy_jac_tests__item1.jl
+++ b/test/Core/homotopy_jac_tests__item1.jl
@@ -1,0 +1,150 @@
+using NonlinearSolve
+
+using SciMLBase
+using LinearAlgebra
+
+# Derivative-field passthrough: the sweep drivers must forward `jac` (λ-fixed to the
+# standard 2/3-argument form), `jac_prototype`, `sparsity`, and `colorvec` from the
+# problem's NonlinearFunction into the inner solver's NonlinearFunction instead of
+# dropping them.
+#
+# The extra λ-free jac methods below exist only so the user-side NonlinearFunction
+# constructor's arity-based iip conformance check accepts the λ-extended jac (MTK-style
+# generated functions carry both dispatches naturally); they error loudly because the
+# sweep must only ever call the λ-extended form through its own λ-fixing wrapper.
+
+# f(u,p,λ) = (1-λ)*(u-c) + λ*(u^3-c); λ=0 root u=c ; λ=1 root u=∛c.
+f_oop(u, p, λ) = [(1 - λ) * (u[1] - p) + λ * (u[1]^3 - p)]
+f_iip(du, u, p, λ) = (du[1] = (1 - λ) * (u[1] - p) + λ * (u[1]^3 - p); nothing)
+
+# --- Analytic oop jac is consumed (counting) ---
+oop_jac_calls = Ref(0)
+j_oop(u, p, λ) = (oop_jac_calls[] += 1; reshape([(1 - λ) + λ * 3 * u[1]^2;;], 1, 1))
+j_oop(u, p) = error("λ-free jac must never be called by the sweep")
+prob_oop = HomotopyProblem(NonlinearFunction{false}(f_oop; jac = j_oop), [2.0], 2.0)
+sol_oop = solve(prob_oop, HomotopySweep(; inner = NewtonRaphson()))
+@test SciMLBase.successful_retcode(sol_oop)
+@test sol_oop.u[1] ≈ cbrt(2.0) atol = 1.0e-8
+@test oop_jac_calls[] > 0
+
+# --- Analytic iip jac is consumed (counting) ---
+iip_jac_calls = Ref(0)
+function j_iip(J, u, p, λ)
+    iip_jac_calls[] += 1
+    J[1, 1] = (1 - λ) + λ * 3 * u[1]^2
+    return nothing
+end
+j_iip(J, u, p) = error("λ-free jac must never be called by the sweep")
+prob_iip = HomotopyProblem(NonlinearFunction{true}(f_iip; jac = j_iip), [2.0], 2.0)
+sol_iip = solve(prob_iip, HomotopySweep(; inner = NewtonRaphson()))
+@test SciMLBase.successful_retcode(sol_iip)
+@test sol_iip.u[1] ≈ cbrt(2.0) atol = 1.0e-8
+@test iip_jac_calls[] > 0
+
+# --- The default polyalgorithm sees the analytic jac (must_use_jacobian path) ---
+polyalg_jac_calls = Ref(0)
+j_poly(u, p, λ) = (polyalg_jac_calls[] += 1; reshape([(1 - λ) + λ * 3 * u[1]^2;;], 1, 1))
+j_poly(u, p) = error("λ-free jac must never be called by the sweep")
+prob_poly = HomotopyProblem(NonlinearFunction{false}(f_oop; jac = j_poly), [2.0], 2.0)
+sol_poly = solve(prob_poly, HomotopySweep())
+@test SciMLBase.successful_retcode(sol_poly)
+@test sol_poly.u[1] ≈ cbrt(2.0) atol = 1.0e-8
+@test polyalg_jac_calls[] > 0
+
+# --- jac correctness: analytic jac reproduces the AD solution ---
+prob_ad = HomotopyProblem(NonlinearFunction{false}(f_oop), [2.0], 2.0)
+sol_ad = solve(prob_ad, HomotopySweep(; inner = NewtonRaphson()))
+@test SciMLBase.successful_retcode(sol_ad)
+@test sol_oop.u[1] ≈ sol_ad.u[1] atol = 1.0e-12
+
+# --- SimpleHomotopySweep consumes an analytic jac (SimpleNewtonRaphson honors f.jac) ---
+simple_oop_jac_calls = Ref(0)
+function j_soop(u, p, λ)
+    simple_oop_jac_calls[] += 1
+    return reshape([(1 - λ) + λ * 3 * u[1]^2;;], 1, 1)
+end
+j_soop(u, p) = error("λ-free jac must never be called by the sweep")
+prob_soop = HomotopyProblem(NonlinearFunction{false}(f_oop; jac = j_soop), [2.0], 2.0)
+sol_soop = solve(prob_soop, SimpleHomotopySweep(; inner = SimpleNewtonRaphson()))
+@test SciMLBase.successful_retcode(sol_soop)
+@test sol_soop.u[1] ≈ cbrt(2.0) atol = 1.0e-8
+@test simple_oop_jac_calls[] > 0
+
+simple_iip_jac_calls = Ref(0)
+function j_siip(J, u, p, λ)
+    simple_iip_jac_calls[] += 1
+    J[1, 1] = (1 - λ) + λ * 3 * u[1]^2
+    return nothing
+end
+j_siip(J, u, p) = error("λ-free jac must never be called by the sweep")
+prob_siip = HomotopyProblem(NonlinearFunction{true}(f_iip; jac = j_siip), [2.0], 2.0)
+sol_siip = solve(prob_siip, SimpleHomotopySweep(; inner = SimpleNewtonRaphson()))
+@test SciMLBase.successful_retcode(sol_siip)
+@test sol_siip.u[1] ≈ cbrt(2.0) atol = 1.0e-8
+@test simple_iip_jac_calls[] > 0
+
+# --- Tridiagonal jac_prototype: the inner solver's J is the structured prototype ---
+# (1-λ)*(uᵢ-c) + λ*(3uᵢ - uᵢ₋₁ - uᵢ₊₁ + uᵢ³ - c) with zero boundary neighbors:
+# diagonally dominant, tridiagonal Jacobian.
+n = 50
+function f_band(du, u, p, λ)
+    for i in 1:length(u)
+        um = i == 1 ? zero(eltype(u)) : u[i - 1]
+        up = i == length(u) ? zero(eltype(u)) : u[i + 1]
+        du[i] = (1 - λ) * (u[i] - p) + λ * (3u[i] - um - up + u[i]^3 - p)
+    end
+    return nothing
+end
+band_J_type = Ref{Any}(nothing)
+function j_band(J, u, p, λ)
+    band_J_type[] = typeof(J)
+    for i in 1:length(u)
+        J[i, i] = (1 - λ) + λ * (3 + 3u[i]^2)
+        i > 1 && (J[i, i - 1] = -λ)
+        i < length(u) && (J[i, i + 1] = -λ)
+    end
+    return nothing
+end
+j_band(J, u, p) = error("λ-free jac must never be called by the sweep")
+proto = Tridiagonal(zeros(n - 1), ones(n), zeros(n - 1))
+nf_band = NonlinearFunction{true}(f_band; jac = j_band, jac_prototype = proto)
+prob_band = HomotopyProblem(nf_band, fill(1.0, n), 1.0)
+sol_band = solve(prob_band, HomotopySweep(; inner = NewtonRaphson()))
+@test SciMLBase.successful_retcode(sol_band)
+@test band_J_type[] <: Tridiagonal
+resid_band = zeros(n)
+f_band(resid_band, sol_band.u, 1.0, 1.0)
+@test maximum(abs, resid_band) < 1.0e-8
+
+# --- jac_prototype alone (no analytic jac) still passes through and solves ---
+nf_proto = NonlinearFunction{true}(
+    f_band; jac_prototype = Tridiagonal(zeros(n - 1), ones(n), zeros(n - 1))
+)
+prob_proto = HomotopyProblem(nf_proto, fill(1.0, n), 1.0)
+sol_proto = solve(prob_proto, HomotopySweep(; inner = NewtonRaphson()))
+@test SciMLBase.successful_retcode(sol_proto)
+resid_proto = zeros(n)
+f_band(resid_proto, sol_proto.u, 1.0, 1.0)
+@test maximum(abs, resid_proto) < 1.0e-8
+
+# --- No derivative fields: the inner function is constructed exactly as before ---
+import NonlinearSolveBase
+fixλ = NonlinearSolveBase.FixLambda(prob_ad.f, 0.0)
+fλ_plain = NonlinearSolveBase._sweep_nonlinear_function(Val(false), prob_ad.f, fixλ)
+@test typeof(fλ_plain) == typeof(SciMLBase.NonlinearFunction{false}(fixλ))
+@test fλ_plain.jac === nothing
+@test fλ_plain.jac_prototype === nothing
+
+# --- No-field problems solve identically (deterministic result + residual count) ---
+resid_calls = Ref(0)
+f_cnt(u, p, λ) = (resid_calls[] += 1; [(1 - λ) * (u[1] - p) + λ * (u[1]^3 - p)])
+prob_cnt = HomotopyProblem(NonlinearFunction{false}(f_cnt), [2.0], 2.0)
+sol_cnt1 = solve(prob_cnt, HomotopySweep(; inner = NewtonRaphson()))
+calls1 = resid_calls[]
+resid_calls[] = 0
+sol_cnt2 = solve(prob_cnt, HomotopySweep(; inner = NewtonRaphson()))
+@test SciMLBase.successful_retcode(sol_cnt1)
+@test sol_cnt1.u == sol_cnt2.u
+@test sol_cnt1.u == sol_ad.u
+@test calls1 == resid_calls[]
+@test calls1 > 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,7 @@ else
             @time @safetestset "ArcLengthContinuation Float32 / in-place / multi-dim" include("Core/arclength_tests__item4.jl")
             @time @safetestset "ArcLengthContinuation fails (no hang) on an unreachable target" include("Core/arclength_tests__item5.jl")
             @time @safetestset "ArcLengthContinuation tangent predictor" include("Core/arclength_tests__item6.jl")
+            @time @safetestset "Homotopy sweeps consume jac/jac_prototype/sparsity/colorvec" include("Core/homotopy_jac_tests__item1.jl")
             return @time @safetestset "HomotopyPolyAlgorithm stages, fallback, both-fail" include("Core/homotopy_polyalg_tests__item1.jl")
         end,
         groups = Dict(


### PR DESCRIPTION
> [!IMPORTANT]
> This PR should be ignored until reviewed by @ChrisRackauckas.

Implements roadmap item **Priority 2** of #1020 for the **sweep drivers**: `HomotopySweep` and `SimpleHomotopySweep` now consume the derivative fields of the problem's `NonlinearFunction` instead of silently dropping them.

## What changed

Both drivers previously built `SciMLBase.NonlinearFunction{iip}(FixLambda(prob.f, λ))`, discarding `jac`, `jac_prototype`, `sparsity`, and `colorvec` — so a user's analytic Jacobian was ignored (the default polyalgorithm's `must_use_jacobian` never fired) and sparse systems were differentiated dense at every Newton iteration of every step.

- **`lib/NonlinearSolveBase/src/homotopy_sweep.jl`** (`HomotopySweep`): new `FixLambdaJac` wrapper λ-fixes the user's `jac(u, p, λ)` / `jac(J, u, p, λ)` into the standard 2/3-argument form. It reads λ **from the residual's own mutable `FixLambda`** rather than carrying a copy, so advancing the sweep remains a single field write and the Jacobian can never be evaluated at a different λ than the residual (no second λ state to desynchronize). `jac_prototype`, `sparsity`, and `colorvec` are forwarded unchanged.
- **`lib/SimpleNonlinearSolve/src/simple_homotopy_sweep.jl`** (`SimpleHomotopySweep`): the immutable `SimpleFixLambda` is rebuilt per step, so the jac wrapper is a second `SimpleFixLambda(f.jac, λfix)` constructed at the same site from the same `λfix` value — rebuilt together, they cannot desynchronize.
- When **no derivative field is present**, both drivers construct the inner function exactly as before (`NonlinearFunction{iip}(wrapper)`, positional only). The branch is decided by the problem's *type*, so the unused arm is compiled away and the StaticArray/scalar `SimpleHomotopySweep` path stays AllocCheck-clean.
- The jac's iip-ness follows the residual's (`NonlinearFunction{iip}` governs both; the varargs wrappers serve either arity).
- **Eltype choice (documented in the docstrings):** `jac_prototype` is forwarded *unchanged* — it is not eltype-promoted with λ. Users whose λ precision differs from `u0`'s should supply a prototype whose eltype matches the promoted residual eltype.
- Docstrings of `HomotopySweep` and `SimpleHomotopySweep` now state the fields are consumed, mirroring the `SciMLBase.HomotopyProblem` docstring's λ-extended-convention wording (which currently ends with "continuation solvers do not consume them yet" — that phrase can be updated in SciMLBase once this merges).

## Verified locally (all run, outputs observed)

- **New test file** `test/Core/homotopy_jac_tests__item1.jl` (registered in `test/runtests.jl`'s core closure), covering: counting oop/iip analytic jacs consumed via `HomotopySweep(; inner = NewtonRaphson())` and via the default polyalgorithm; analytic jac reproduces the AD solution to 1e-12; `SimpleHomotopySweep(; inner = SimpleNewtonRaphson())` consumes oop and iip analytic jacs (verified empirically — SimpleNonlinearSolve's Newton honors `f.jac` through `SciMLBase.has_jac`); a 50-dim tridiagonal system with `jac_prototype = Tridiagonal(...)` where the inner solver's `J` is asserted to be `<: Tridiagonal`; prototype-only (no analytic jac) passthrough; unit check that field-free problems produce the exact pre-change inner-function type; and a residual-count determinism check for field-free problems.
- **Full homotopy/arclength/polyalg suite** (rerun after rebasing onto #1019's `HomotopyPolyAlgorithm` merge): new file + `homotopy_sweep_tests__item1–21.jl` + `arclength_tests__item1–6.jl` (**190/190 pass**) + `homotopy_polyalg_tests__item1.jl` (**25/25 pass**), all via `@safetestset` on this branch.
- **No-field parity vs unmodified master** (measured with a counting residual closure, identical script on both): `HomotopySweep` u=1.2599210498948732, 86 residual calls on master and on this branch; `SimpleHomotopySweep` u=1.2599210498948732, 73 calls on both — byte-identical behavior.
- **`NONLINEARSOLVE_TEST_GROUP=Core Pkg.test()` from `lib/SimpleNonlinearSolve`**: pass (totals in CI log below).
- **`lib/SimpleNonlinearSolve/test/alloc/allocation_tests__item2.jl`** in its own env: 2/2 pass — the field-free `SimpleHomotopySweep` path is still AllocCheck-clean.
- Runic `--inplace` then `--check` (exit 0) on all touched files.

## Interface note (upstream wrinkle, not addressed here)

SciMLBase's `NonlinearFunction` constructor arity-checks `jac` with the *standard* nonlinear convention (`isinplace(jac, 3, ...)`), so a bare λ-extended jac (`jac(u, p, λ)` = 3 args oop, `jac(J, u, p, λ)` = 4 args iip) is rejected at user-side construction (`NonconformingFunctionsError` / `TooManyArgumentsError`) unless the jac also carries a λ-free method — MTK-style generated functions with dual dispatches pass naturally, and the tests use loud-error λ-free dummy methods. Relaxing that check for `HomotopyProblem` use is a SciMLBase follow-up.

## Scope / coordination

- **`arclength.jl` is deliberately untouched**: derivative-field support for `ArcLengthContinuation` (which needs the bordered prototype `[J_proto col; rowᵀ 1]`) is a follow-up, and a sibling PR is working in that file.
- Sibling PRs are editing the controller regions of these same two sweep files; this diff is confined to the function-construction sites and docstrings, but sequential rebases may still be needed depending on merge order. (Already rebased once onto #1019; the full suite was rerun after the rebase.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
