### PR TITLE
Bump version to 4.20.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.20.2"
+version = "4.20.3"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (4.20.2 -> 4.20.3) to release unreleased commits on `master` via JuliaRegistrator.