### PR TITLE
ArcLengthContinuation: consume jac/jac_prototype/sparsity/colorvec (#1020 item 2 follow-up, stacked on #1021)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -117,6 +117,7 @@ Setfield = "1.1.2"
 SciMLLogging = "1.10.1, 2"
 SimpleNonlinearSolve = "2.10"
 SparseArrays = "1.10"
+SparseMatrixColorings = "0.4.5"
 SpeedMapping = "0.4"
 StableRNGs = "1"
 StaticArrays = "1.9"
@@ -136,9 +137,11 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLLogging = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["InteractiveUtils", "NaNMath", "NonlinearProblemLibrary", "Pkg", "PolyesterForwardDiff", "Random", "SafeTestsets", "SciMLLogging", "SciMLTesting", "StableRNGs", "StaticArrays", "Test"]
+test = ["InteractiveUtils", "NaNMath", "NonlinearProblemLibrary", "Pkg", "PolyesterForwardDiff", "Random", "SafeTestsets", "SciMLLogging", "SciMLTesting", "SparseArrays", "SparseMatrixColorings", "StableRNGs", "StaticArrays", "Test"]

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseSparseArraysExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseSparseArraysExt.jl
@@ -8,6 +8,28 @@ using NonlinearSolveBase: NonlinearSolveBase, Utils
 # SparseArrays-specific implementations for NonlinearSolveBase
 # =============================================================================
 
+Utils.is_extension_loaded(::Val{:SparseArrays}) = true
+
+"""
+    structural_sparse(x::AbstractMatrix)
+
+`SparseMatrixCSC` carrying the STRUCTURAL nonzero pattern of `x`, with `one(eltype(x))`
+stored at every structural entry. Unlike `sparse(x)`, which keeps only value-nonzero
+entries, this preserves structural entries whose values happen to be zero — a
+`Tridiagonal` prototype with zero-valued bands must not lose its bands when converted
+for pattern purposes.
+"""
+function Utils.structural_sparse(x::AbstractMatrix)
+    rows, cols = NonlinearSolveBase.ArrayInterface.findstructralnz(x)
+    # indexed comprehensions, not collect: the structured-matrix index iterators
+    # (e.g. ArrayInterface.TridiagonalIndex) advertise eltype Any and fail collect
+    I = Int[rows[k] for k in 1:length(rows)]
+    J = Int[cols[k] for k in 1:length(cols)]
+    return sparse(I, J, fill(one(eltype(x)), length(I)), size(x, 1), size(x, 2))
+end
+
+Utils.structural_sparse(x::AbstractSparseMatrixCSC) = x
+
 """
     NAN_CHECK(x::AbstractSparseMatrixCSC)
 

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseSparseArraysExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseSparseArraysExt.jl
@@ -14,10 +14,12 @@ Utils.is_extension_loaded(::Val{:SparseArrays}) = true
     structural_sparse(x::AbstractMatrix)
 
 `SparseMatrixCSC` carrying the STRUCTURAL nonzero pattern of `x`, with `one(eltype(x))`
-stored at every structural entry. Unlike `sparse(x)`, which keeps only value-nonzero
-entries, this preserves structural entries whose values happen to be zero — a
-`Tridiagonal` prototype with zero-valued bands must not lose its bands when converted
-for pattern purposes.
+stored at every structural entry. Whether plain `sparse(x)` preserves zero-valued
+structural entries depends on which specialized constructor exists: the band-copying
+ones do (`sparse(Tridiagonal(zeros(4), zeros(5), zeros(4)))` keeps all 13 entries), but
+`sparse(Diagonal(zeros(5)))` has no stored entries at all — so a prototype whose values
+happen to be zero can silently lose pattern entries that sparse AD coloring needs.
+Going through `findstructralnz` makes the conversion value-independent for every type.
 """
 function Utils.structural_sparse(x::AbstractMatrix)
     rows, cols = NonlinearSolveBase.ArrayInterface.findstructralnz(x)

--- a/lib/NonlinearSolveBase/src/arclength.jl
+++ b/lib/NonlinearSolveBase/src/arclength.jl
@@ -27,6 +27,30 @@ The target is the point on the curve where ``λ = λspan[2]``: the solver follow
 until a step brackets that ``λ``, then performs one final ``λ``-fixed correction to land
 on it exactly.
 
+Optional derivative fields of the problem's `NonlinearFunction` (which follow the same
+λ-extended argument convention as the residual) are consumed. An analytic
+`jac(u, p, λ)` / `jac(J, u, p, λ)` supplies the ``∂H/∂u`` block of the augmented path
+Jacobian ``[∂H/∂u | ∂H/∂λ]``; the missing ``∂H/∂λ`` column is a *scalar-parameter*
+derivative, obtained as one forward-mode derivative of the residual in ``λ`` at fixed
+`u` (through `autodiff`) — the packed system is never differentiated wholesale. The
+assembled path Jacobian drives the `:tangent` predictor and, extended by the
+analytically known θ-weighted Keller constraint row, gives every augmented corrector
+solve a full analytic ``(n+1)×(n+1)`` Jacobian; the λ-fixed anchor and landing solves
+consume the jac exactly as [`HomotopySweep`](@ref) does. A `jac_prototype` (or matrix
+`sparsity`) is extended to the augmented shapes: one structurally dense ``∂H/∂λ``
+column for the predictor's ``n×(n+1)`` system, plus the structurally dense constraint
+row for the corrector's bordered ``(n+1)×(n+1)`` system. Sparse and structured
+prototypes are promoted to `SparseMatrixCSC` — a bordered `Tridiagonal` is no longer
+tridiagonal, and CSC is the general container the coloring and sparse linear-solve
+machinery handle; this requires `SparseArrays` to be loaded (structured prototypes
+fall back to a dense bordered prototype otherwise), and the prototype is not
+eltype-promoted with λ. A sparsity *detector* is forwarded unchanged (it detects the
+augmented pattern from the augmented residual itself). A user `colorvec` is forwarded
+to the predictor's system extended by one fresh color for the dense λ column; it is
+not forwarded to the corrector, whose dense constraint row admits no nontrivial column
+coloring — there the bordered prototype's value is chiefly the sparse linear solve.
+When no derivative fields are present, construction is identical to before.
+
 !!! note "The arclength metric is θ-weighted"
 
     All of the solver's path geometry — the Keller constraint row, the predictor
@@ -90,8 +114,10 @@ Keyword arguments:
     `autodiff`). This is the Euler tangent predictor of the classic path trackers and of
     OpenModelica's global homotopy.
   - `autodiff`: the automatic-differentiation backend (an `ADTypes.AbstractADType`) used
-    to form the augmented Jacobian for the `:tangent` predictor; `nothing` (default)
-    selects `AutoForwardDiff()`. Unused by the `:secant` predictor.
+    to form the augmented Jacobian for the `:tangent` predictor and, when the problem
+    supplies an analytic `jac`, to take the single ``∂H/∂λ`` scalar derivative that
+    completes it; `nothing` (default) selects `AutoForwardDiff()`. Unused by the
+    `:secant` predictor on problems without an analytic `jac`.
   - `linsolve`: the LinearSolve.jl algorithm for the `:tangent` predictor's bordered
     solve (the same knob the Newton descent methods expose); `nothing` (default) selects
     LinearSolve's default. Unused by the `:secant` predictor.
@@ -277,13 +303,212 @@ function (a::HomotopyResidual)(res, x, p)
     return nothing
 end
 
+# The homotopy with λ moved into the differentiated-argument slot and (u, p) as DI
+# `Constant` contexts: the ∂H/∂λ column of the augmented Jacobian is the derivative of
+# this in its first (scalar) argument — one forward-mode directional derivative, not a
+# Jacobian of the packed system.
+struct LambdaShifted{F}
+    f::F
+end
+
+(ls::LambdaShifted)(λ, u, p) = ls.f(u, p, λ)
+
+function (ls::LambdaShifted)(res, λ, u, p)
+    ls.f(res, u, p, λ)
+    return nothing
+end
+
+# Analytic n×(n+1) path Jacobian `[∂H/∂u | ∂H/∂λ]` of the packed variable `x = [u; λ]`,
+# assembled from the user's λ-extended `jac` (which supplies only the n×n ∂H/∂u block)
+# plus the ∂H/∂λ column as a single scalar derivative in λ (prepared once at solve
+# start, reused every call). Standard 2/3-argument Jacobian calling convention, so
+# `construct_jacobian_cache` consumes it through its ordinary `has_jac` path and the
+# augmented corrector's Jacobian can embed it as its top block.
+struct AugmentedPathJac{J, L, B, P, R}
+    jac::J           # the user's λ-extended jac(u, p, λ) / jac(J, u, p, λ)
+    lres::L          # LambdaShifted residual for the ∂H/∂λ column
+    backend::B
+    prep::P
+    rescratch::R     # iip: primal residual buffer for DI.derivative!; oop: nothing
+    n::Int
+end
+
+function (apj::AugmentedPathJac)(J, x, p)
+    n = apj.n
+    u = view(x, 1:n)
+    λ = x[n + 1]
+    apj.jac(view(J, 1:n, 1:n), u, p, λ)
+    DI.derivative!(
+        apj.lres, apj.rescratch, view(J, 1:n, n + 1),
+        apj.prep, apj.backend, λ, Constant(u), Constant(p)
+    )
+    return nothing
+end
+
+function (apj::AugmentedPathJac)(x, p)
+    n = apj.n
+    u = view(x, 1:n)
+    λ = x[n + 1]
+    Ju = apj.jac(u, p, λ)
+    col = DI.derivative(apj.lres, apj.prep, apj.backend, λ, Constant(u), Constant(p))
+    return hcat(Ju, col)
+end
+
+# Full analytic (n+1)×(n+1) Jacobian of `AugmentedHomotopy`: the path Jacobian as the
+# top n rows and the Keller constraint row — analytically known, it is the θ-weighted
+# τ — as the bottom row. Aliases the driver's in-place-updated τ buffer (the same
+# object the per-step `AugmentedHomotopy` residual reads), so the Jacobian's constraint
+# row can never desynchronize from the residual's; `ds`/`xcur` do not appear because
+# the constraint is affine in `x` (its gradient is independent of both).
+struct AugmentedHomotopyJac{PJ, V, T}
+    pathjac::PJ
+    τ::V
+    n::Int
+    wu::T
+    wλ::T
+end
+
+function (aj::AugmentedHomotopyJac)(J, x, p)
+    n = aj.n
+    aj.pathjac(view(J, 1:n, :), x, p)
+    @views J[n + 1, 1:n] .= aj.wu .* aj.τ[1:n]
+    J[n + 1, n + 1] = aj.wλ * aj.τ[n + 1]
+    return nothing
+end
+
+function (aj::AugmentedHomotopyJac)(x, p)
+    n = aj.n
+    Jtop = aj.pathjac(x, p)
+    row = vcat(aj.wu .* view(aj.τ, 1:n), aj.wλ * aj.τ[n + 1])
+    return vcat(Jtop, transpose(row))
+end
+
+# The user's n×n ∂H/∂u prototype extended to the packed path system's n×(n+1) shape by
+# appending the structurally dense ∂H/∂λ column. Sparse/structured prototypes become
+# `SparseMatrixCSC` — a bordered `Tridiagonal` (or any banded/structured type) no longer
+# fits its own structure, and CSC is the general sparse container every downstream
+# consumer (coloring, sparse LU) handles — via the STRUCTURAL nonzero pattern
+# (`Utils.structural_sparse`), so band entries whose prototype values happen to be zero
+# survive as pattern. The sparse route needs the SparseArrays extension; without it (a
+# session that cannot construct CSC matrices anyway) structured prototypes fall back to
+# dense. Dense prototypes stay dense. As in the sweep, the prototype is NOT
+# eltype-promoted with λ.
+function _augmented_prototype(proto::AbstractMatrix, n)
+    T = eltype(proto)
+    if sparse_or_structured_prototype(proto) &&
+            Utils.is_extension_loaded(Val(:SparseArrays))
+        S = Utils.structural_sparse(proto)
+        return hcat(S, Utils.make_sparse(fill(one(T), n, 1)))
+    end
+    B = fill(one(T), n, n + 1)
+    copyto!(view(B, 1:n, 1:n), proto)
+    return B
+end
+
+# The (n+1)×(n+1) bordered prototype of the augmented corrector system: the augmented
+# path prototype with the structurally dense Keller constraint row appended,
+# `[∂H/∂u  ∂H/∂λ; wᵀ  1]`.
+function _bordered_prototype(proto::AbstractMatrix, n)
+    T = eltype(proto)
+    top = _augmented_prototype(proto, n)
+    row = fill(one(T), 1, n + 1)
+    if sparse_or_structured_prototype(top)
+        return vcat(top, Utils.make_sparse(row))
+    end
+    return vcat(top, row)
+end
+
+# Builds the shared analytic path Jacobian (or `nothing` when the user supplied no
+# analytic jac; the branch is decided by the problem's type). The DI preparation for
+# the ∂H/∂λ scalar derivative is done once here — with `(u, p)` as `Constant` contexts
+# whose values change call to call — and reused by both consumers (the `:tangent`
+# predictor's Jacobian cache and every corrector Jacobian evaluation).
+function _arclength_path_jac(
+        prob::SciMLBase.HomotopyProblem{uType, iip}, alg, x, n
+    ) where {uType, iip}
+    prob.f.jac === nothing && return nothing
+    gf = SciMLBase.NonlinearFunction{iip}(HomotopyResidual(prob.f, n))
+    gprob = NonlinearProblem{iip}(gf, x, prob.p)
+    backend = select_jacobian_autodiff(gprob, alg.autodiff)
+    lres = LambdaShifted(prob.f.f)
+    u = view(x, 1:n)
+    λ = x[n + 1]
+    if iip
+        rescratch = Utils.safe_similar(x, n)
+        prep = DI.prepare_derivative(
+            lres, rescratch, backend, λ, Constant(u), Constant(prob.p);
+            strict = Val(false)
+        )
+        return AugmentedPathJac(prob.f.jac, lres, backend, prep, rescratch, n)
+    else
+        prep = DI.prepare_derivative(
+            lres, backend, λ, Constant(u), Constant(prob.p); strict = Val(false)
+        )
+        return AugmentedPathJac(prob.f.jac, lres, backend, prep, nothing, n)
+    end
+end
+
+# The packed path function for the `:tangent` predictor, carrying the derivative fields
+# of the problem's NonlinearFunction translated to the packed n×(n+1) shapes: the
+# analytic path Jacobian, the augmented prototype/matrix-sparsity, and the user
+# colorvec extended by one fresh color for the structurally dense ∂H/∂λ column (valid
+# for forward-mode column coloring, which is what the packed n×(n+1) system uses). A
+# sparsity DETECTOR is forwarded unchanged — it detects the augmented pattern from the
+# packed residual itself. With no derivative fields the construction is exactly the
+# bare one (the branch is decided by the problem's type, so the unused arm is compiled
+# away).
+function _arclength_path_function(::Val{iip}, f, path_jac, n) where {iip}
+    g = HomotopyResidual(f, n)
+    if f.jac === nothing && f.jac_prototype === nothing && f.sparsity === nothing &&
+            f.colorvec === nothing
+        return SciMLBase.NonlinearFunction{iip}(g)
+    end
+    jac_prototype = f.jac_prototype === nothing ? nothing :
+        _augmented_prototype(f.jac_prototype, n)
+    # the NonlinearFunction constructor defaults `sparsity` to the SAME object as
+    # `jac_prototype`, and construct_concrete_adtype rejects a matrix sparsity that is
+    # a distinct object from a sparse/structured prototype — preserve the identity
+    sparsity = if f.sparsity === nothing
+        nothing
+    elseif f.sparsity === f.jac_prototype
+        jac_prototype
+    elseif f.sparsity isa AbstractMatrix
+        _augmented_prototype(f.sparsity, n)
+    else
+        f.sparsity
+    end
+    colorvec = f.colorvec === nothing ? nothing :
+        vcat(f.colorvec, maximum(f.colorvec) + 1)
+    return SciMLBase.NonlinearFunction{iip}(
+        g; jac = path_jac, jac_prototype, sparsity, colorvec
+    )
+end
+
+# The corrector's NonlinearFunction around the per-step `AugmentedHomotopy` residual,
+# carrying the (n+1)×(n+1) bordered derivative fields. The user colorvec is NOT
+# forwarded: the structurally dense constraint row makes every pair of columns share a
+# row, so no nontrivial column coloring is valid for the bordered pattern — when sparse
+# AD applies (no analytic jac), the coloring is recomputed, and the bordered
+# prototype's value is chiefly the sparse linear solve. With no derivative fields the
+# construction is exactly the bare one.
+function _arclength_augmented_function(
+        ::Val{iip}, f, aug, jac, jac_prototype, sparsity
+    ) where {iip}
+    if f.jac === nothing && f.jac_prototype === nothing && f.sparsity === nothing &&
+            f.colorvec === nothing
+        return SciMLBase.NonlinearFunction{iip}(aug)
+    end
+    return SciMLBase.NonlinearFunction{iip}(aug; jac, jac_prototype, sparsity)
+end
+
 # Natural-parameter solve at a fixed λ: gets the start point onto the curve and lands the
-# final point exactly on λ = λspan[2]. Mirrors HomotopySweep's per-step solve.
+# final point exactly on λ = λspan[2]. Mirrors HomotopySweep's per-step solve, including
+# its derivative-field forwarding (λ-fixed jac, prototype/sparsity/colorvec unchanged).
 function _arclength_fixed_solve(
         prob::SciMLBase.HomotopyProblem{uType, iip}, inner, uguess,
         λfix, args...; kwargs...
     ) where {uType, iip}
-    fλ = SciMLBase.NonlinearFunction{iip}(FixLambda(prob.f, λfix))
+    fλ = _sweep_nonlinear_function(Val(iip), prob.f, FixLambda(prob.f, λfix))
     inner_prob = NonlinearProblem{iip}(fλ, copy(uguess), prob.p)
     return solve(inner_prob, inner, args...; prob.kwargs..., kwargs...)
 end
@@ -294,10 +519,10 @@ end
 # `alg` carries no `concrete_jac`, so the cache holds a concrete J the bordered solve can
 # factorize.
 function _arclength_jac_cache(
-        prob::SciMLBase.HomotopyProblem{uType, iip}, alg, x,
+        prob::SciMLBase.HomotopyProblem{uType, iip}, alg, path_jac, x,
         n, stats
     ) where {uType, iip}
-    gf = SciMLBase.NonlinearFunction{iip}(HomotopyResidual(prob.f, n))
+    gf = _arclength_path_function(Val(iip), prob.f, path_jac, n)
     gprob = NonlinearProblem{iip}(gf, x, prob.p)
     fu = if iip
         res = Utils.safe_similar(x, n)
@@ -469,10 +694,14 @@ function CommonSolve.solve(
     τseed = pack(zeros(Tx, n), sλ / sqrt(wλ))
 
     use_tangent = alg.predictor === :tangent
+    # Analytic path Jacobian assembled from the user's jac (nothing without one),
+    # shared by the tangent predictor's Jacobian cache and the corrector's Jacobian.
+    path_jac = _arclength_path_jac(prob, alg, xcur, n)
     # one reusable Jacobian cache (via NonlinearSolve's own tooling) for the tangent
     # predictor; nothing for the derivative-free secant.
     stats = NLStats(0, 0, 0, 0, 0)
-    jac_cache = use_tangent ? _arclength_jac_cache(prob, alg, xcur, n, stats) : nothing
+    jac_cache = use_tangent ? _arclength_jac_cache(prob, alg, path_jac, xcur, n, stats) :
+        nothing
     # Reused by every predictor step: the bordered-tangent workspace (matrix, rhs,
     # solution, and the shared linear-solver cache) for the tangent, and `tscratch` for
     # the secant chord. Allocated once here so the loop only reuses memory.
@@ -482,6 +711,24 @@ function CommonSolve.solve(
     # tangent continues into the span (pure-λ direction picks the correct sign). A
     # stable buffer, written in place by every predictor branch below.
     τ = copy(τseed)
+    # Derivative fields of the per-step corrector function, built once: the Jacobian
+    # aliases the τ buffer (kept in sync with the residual by construction) and the
+    # bordered prototypes depend only on the user prototype and n.
+    aug_jac = path_jac === nothing ? nothing :
+        AugmentedHomotopyJac(path_jac, τ, n, wu, wλ)
+    aug_proto = prob.f.jac_prototype === nothing ? nothing :
+        _bordered_prototype(prob.f.jac_prototype, n)
+    # preserve the constructor-established `sparsity === jac_prototype` identity (see
+    # `_arclength_path_function`)
+    aug_sparsity = if prob.f.sparsity === nothing
+        nothing
+    elseif prob.f.sparsity === prob.f.jac_prototype
+        aug_proto
+    elseif prob.f.sparsity isa AbstractMatrix
+        _bordered_prototype(prob.f.sparsity, n)
+    else
+        prob.f.sparsity
+    end
 
     for _ in 1:(alg.maxsteps)
         # Predictor direction τ (θ-metric unit, length n+1).
@@ -508,7 +755,9 @@ function CommonSolve.solve(
         aug = AugmentedHomotopy(prob.f, τ, xcur, Tx(ds), n, wu, wλ)
         # length n+1; never in-place even for an iip homotopy — the constraint row has no
         # user-facing buffer, so we always own the residual.
-        augf = SciMLBase.NonlinearFunction{iip}(aug)
+        augf = _arclength_augmented_function(
+            Val(iip), prob.f, aug, aug_jac, aug_proto, aug_sparsity
+        )
         corr_prob = NonlinearProblem{iip}(augf, copy(xpred), prob.p)
         # The cap is spliced BEFORE the user kwargs so an explicit `maxiters` always
         # wins (and `cap_active` is false in that case anyway).

--- a/lib/NonlinearSolveBase/src/utils.jl
+++ b/lib/NonlinearSolveBase/src/utils.jl
@@ -208,6 +208,13 @@ end
 # When SparseArrays is not loaded, this function should not be called
 function make_sparse end
 
+# SparseMatrixCSC carrying the STRUCTURAL nonzero pattern of a prototype (ones at every
+# structural entry) — unlike `sparse(x)`, which drops stored zeros, so a prototype band
+# whose values happen to be zero would silently vanish from the pattern.
+# Implementation provided by the SparseArrays extension; gate calls on
+# `is_extension_loaded(Val(:SparseArrays))`.
+function structural_sparse end
+
 condition_number(J::AbstractMatrix) = cond(J)
 function condition_number(J::AbstractVector)
     if !ArrayInterface.can_setindex(J)

--- a/test/Core/arclength_jac_tests__item1.jl
+++ b/test/Core/arclength_jac_tests__item1.jl
@@ -1,0 +1,193 @@
+using NonlinearSolve
+
+using SciMLBase
+using LinearAlgebra
+using SparseArrays
+using SparseMatrixColorings
+
+# Derivative-field support for ArcLengthContinuation (issue #1020 item 2, the follow-up
+# left out of the sweep-driver PR): the user's λ-extended jac supplies only the n×n
+# ∂H/∂u block, so the driver completes the augmented path Jacobian [∂H/∂u | ∂H/∂λ] with
+# the ∂H/∂λ column as one scalar forward derivative, borders it with the analytically
+# known θ-weighted Keller constraint row for the corrector, and extends
+# jac_prototype/sparsity/colorvec to the augmented/bordered shapes.
+#
+# The extra λ-free jac methods below exist only so the user-side NonlinearFunction
+# constructor's arity-based iip conformance check accepts the λ-extended jac (MTK-style
+# generated functions carry both dispatches naturally); they error loudly because the
+# driver must only ever call the λ-extended form through its own wrappers.
+
+# S-fold: u^3 - 3u = -3 + 6λ; folds (∂H/∂u = 0) at u = ±1, i.e. λ = 5/6 and 1/6, so the
+# path from the λ=0 lower root to the λ=1 upper root is non-monotone in λ — the analytic
+# jac is consumed by the genuinely bordered machinery, not an easy λ-sweep.
+target = 2.1038034
+f_fold_oop(u, p, λ) = [u[1]^3 - 3 * u[1] - (-3 + 6λ)]
+f_fold_iip(du, u, p, λ) = (du[1] = u[1]^3 - 3 * u[1] - (-3 + 6λ); nothing)
+
+# --- Augmented corrector consumes the analytic oop jac (default :secant predictor) ---
+oop_jac_λs = Float64[]
+j_oop(u, p, λ) = (push!(oop_jac_λs, λ); reshape([3 * u[1]^2 - 3;;], 1, 1))
+j_oop(u, p) = error("λ-free jac must never be called by arclength")
+prob_oop = HomotopyProblem(
+    NonlinearFunction{false}(f_fold_oop; jac = j_oop), [-target]; λspan = (0.0, 1.0)
+)
+sol_oop = solve(prob_oop, ArcLengthContinuation(; inner = NewtonRaphson()))
+@test SciMLBase.successful_retcode(sol_oop)
+@test sol_oop.u[1] ≈ target atol = 1.0e-4
+@test length(oop_jac_λs) > 0
+# jac evaluations at interior λ can only come from the augmented corrector (the λ-fixed
+# anchor and landing solves evaluate exactly at λ = 0 and λ = 1)
+@test any(l -> 1.0e-3 < l < 1 - 1.0e-3, oop_jac_λs)
+
+# --- Augmented corrector consumes the analytic iip jac ---
+iip_jac_λs = Float64[]
+function j_iip(J, u, p, λ)
+    push!(iip_jac_λs, λ)
+    J[1, 1] = 3 * u[1]^2 - 3
+    return nothing
+end
+j_iip(J, u, p) = error("λ-free jac must never be called by arclength")
+prob_iip = HomotopyProblem(
+    NonlinearFunction{true}(f_fold_iip; jac = j_iip), [-target]; λspan = (0.0, 1.0)
+)
+sol_iip = solve(prob_iip, ArcLengthContinuation(; inner = NewtonRaphson()))
+@test SciMLBase.successful_retcode(sol_iip)
+@test sol_iip.u[1] ≈ target atol = 1.0e-4
+@test any(l -> 1.0e-3 < l < 1 - 1.0e-3, iip_jac_λs)
+
+# --- The :tangent predictor's path Jacobian consumes the analytic jac ---
+empty!(oop_jac_λs)
+sol_tan = solve(
+    prob_oop, ArcLengthContinuation(; inner = NewtonRaphson(), predictor = :tangent)
+)
+@test SciMLBase.successful_retcode(sol_tan)
+@test sol_tan.u[1] ≈ target atol = 1.0e-4
+@test length(oop_jac_λs) > 0
+
+# --- jac correctness: the analytic-jac solution matches the AD solution ---
+prob_ad = HomotopyProblem(NonlinearFunction{false}(f_fold_oop), [-target]; λspan = (0.0, 1.0))
+sol_ad = solve(prob_ad, ArcLengthContinuation(; inner = NewtonRaphson()))
+@test SciMLBase.successful_retcode(sol_ad)
+@test sol_oop.u[1] ≈ sol_ad.u[1] atol = 1.0e-6
+sol_ad_tan = solve(
+    prob_ad, ArcLengthContinuation(; inner = NewtonRaphson(), predictor = :tangent)
+)
+@test sol_tan.u[1] ≈ sol_ad_tan.u[1] atol = 1.0e-6
+
+# --- Bordered prototype structure: user band + dense ∂H/∂λ column + dense constraint
+# row, promoted from Tridiagonal to SparseMatrixCSC ---
+import NonlinearSolveBase
+n = 50
+proto = Tridiagonal(zeros(n - 1), ones(n), zeros(n - 1))
+aug_proto = NonlinearSolveBase._augmented_prototype(proto, n)
+bord_proto = NonlinearSolveBase._bordered_prototype(proto, n)
+@test aug_proto isa SparseMatrixCSC && size(aug_proto) == (n, n + 1)
+@test bord_proto isa SparseMatrixCSC && size(bord_proto) == (n + 1, n + 1)
+Is, Js, _ = findnz(bord_proto)
+S = Set(zip(Is, Js))
+@test all(((i, i + 1) in S) for i in 1:(n - 1))   # superdiagonal survived zero values
+@test all(((i + 1, i) in S) for i in 1:(n - 1))   # subdiagonal survived zero values
+@test all(((i, i) in S) for i in 1:n)             # diagonal
+@test all(((i, n + 1) in S) for i in 1:(n + 1))   # dense ∂H/∂λ column + corner
+@test all(((n + 1, j) in S) for j in 1:n)         # dense constraint row
+# a SparseMatrixCSC prototype borders without conversion
+csc_proto = spdiagm(-1 => ones(n - 1), 0 => ones(n), 1 => ones(n - 1))
+bord_csc = NonlinearSolveBase._bordered_prototype(csc_proto, n)
+@test bord_csc isa SparseMatrixCSC && size(bord_csc) == (n + 1, n + 1)
+@test bord_csc[n + 1, 1] == 1 && bord_csc[1, n + 1] == 1 && bord_csc[2, 1] == 1
+
+# --- n = 50 fold-free banded system: analytic jac + Tridiagonal prototype, :tangent.
+# (1-λ)*(uᵢ-c) + λ*(3uᵢ - uᵢ₋₁ - uᵢ₊₁ + uᵢ³ - c) with zero boundary neighbors:
+# diagonally dominant, tridiagonal ∂H/∂u along the whole path (no folds). ---
+function f_band(du, u, p, λ)
+    for i in 1:length(u)
+        um = i == 1 ? zero(eltype(u)) : u[i - 1]
+        up = i == length(u) ? zero(eltype(u)) : u[i + 1]
+        du[i] = (1 - λ) * (u[i] - p) + λ * (3u[i] - um - up + u[i]^3 - p)
+    end
+    return nothing
+end
+band_J_kinds = Set{Any}()
+function j_band(J, u, p, λ)
+    A = J
+    while A isa SubArray
+        A = parent(A)
+    end
+    push!(band_J_kinds, (typeof(A).name.wrapper, size(A)))
+    for i in 1:length(u)
+        J[i, i] = (1 - λ) + λ * (3 + 3u[i]^2)
+        i > 1 && (J[i, i - 1] = -λ)
+        i < length(u) && (J[i, i + 1] = -λ)
+    end
+    return nothing
+end
+j_band(J, u, p) = error("λ-free jac must never be called by arclength")
+nf_band = NonlinearFunction{true}(f_band; jac = j_band, jac_prototype = proto)
+prob_band = HomotopyProblem(nf_band, fill(1.0, n), 1.0)
+sol_band = solve(
+    prob_band, ArcLengthContinuation(; inner = NewtonRaphson(), predictor = :tangent)
+)
+@test SciMLBase.successful_retcode(sol_band)
+resid_band = zeros(n)
+f_band(resid_band, sol_band.u, 1.0, 1.0)
+@test maximum(abs, resid_band) < 1.0e-8
+# the corrector's Jacobian buffer is the bordered (n+1)×(n+1) SparseMatrixCSC — the
+# user jac saw it through the driver's top-block view
+@test (SparseMatrixCSC, (n + 1, n + 1)) in band_J_kinds
+# the λ-fixed anchor/landing solves kept the user's own Tridiagonal prototype
+@test (Tridiagonal, (n, n)) in band_J_kinds
+
+# --- jac_prototype + colorvec WITHOUT an analytic jac: the packed predictor system
+# sparse-ADs with the extended colorvec, the corrector sparse-ADs with the bordered
+# pattern (its coloring recomputed — the dense constraint row admits no nontrivial
+# column coloring), and everything still solves ---
+band_colorvec = [mod1(i, 3) for i in 1:n]
+nf_proto = NonlinearFunction{true}(
+    f_band; jac_prototype = Tridiagonal(zeros(n - 1), ones(n), zeros(n - 1)),
+    colorvec = band_colorvec
+)
+prob_proto = HomotopyProblem(nf_proto, fill(1.0, n), 1.0)
+sol_proto = solve(
+    prob_proto, ArcLengthContinuation(; inner = NewtonRaphson(), predictor = :tangent)
+)
+@test SciMLBase.successful_retcode(sol_proto)
+resid_proto = zeros(n)
+f_band(resid_proto, sol_proto.u, 1.0, 1.0)
+@test maximum(abs, resid_proto) < 1.0e-8
+
+# --- No derivative fields: the packed and augmented functions are constructed exactly
+# as before ---
+fplain = NonlinearFunction{false}(f_fold_oop)
+g = NonlinearSolveBase.HomotopyResidual(fplain, 1)
+pf = NonlinearSolveBase._arclength_path_function(Val(false), fplain, nothing, 1)
+@test typeof(pf) == typeof(SciMLBase.NonlinearFunction{false}(g))
+@test pf.jac === nothing && pf.jac_prototype === nothing
+aug = NonlinearSolveBase.AugmentedHomotopy(fplain, [0.0, 1.0], [0.0, 0.0], 0.1, 1, 0.5, 0.5)
+af = NonlinearSolveBase._arclength_augmented_function(
+    Val(false), fplain, aug, nothing, nothing, nothing
+)
+@test typeof(af) == typeof(SciMLBase.NonlinearFunction{false}(aug))
+@test af.jac === nothing && af.jac_prototype === nothing
+
+# --- No-field problems solve identically (deterministic root + residual-eval count;
+# the counts below were also verified unchanged against the pre-change base branch) ---
+resid_calls = Ref(0)
+f_cnt(u, p, λ) = (resid_calls[] += 1; [u[1]^3 - 3 * u[1] - (-3 + 6λ)])
+prob_cnt = HomotopyProblem(NonlinearFunction{false}(f_cnt), [-target]; λspan = (0.0, 1.0))
+sol_cnt1 = solve(prob_cnt, ArcLengthContinuation(; inner = NewtonRaphson()))
+calls_secant = resid_calls[]
+resid_calls[] = 0
+sol_cnt2 = solve(prob_cnt, ArcLengthContinuation(; inner = NewtonRaphson()))
+@test SciMLBase.successful_retcode(sol_cnt1)
+@test sol_cnt1.u == sol_cnt2.u
+@test sol_cnt1.u[1] ≈ sol_ad.u[1] atol = 1.0e-10
+@test calls_secant == resid_calls[]
+@test calls_secant > 0
+resid_calls[] = 0
+sol_cnt3 = solve(
+    prob_cnt, ArcLengthContinuation(; inner = NewtonRaphson(), predictor = :tangent)
+)
+calls_tangent = resid_calls[]
+@test SciMLBase.successful_retcode(sol_cnt3)
+@test sol_cnt3.u[1] ≈ sol_ad_tan.u[1] atol = 1.0e-10
+@test calls_tangent > 0

--- a/test/Core/arclength_jac_tests__item1.jl
+++ b/test/Core/arclength_jac_tests__item1.jl
@@ -90,6 +90,15 @@ S = Set(zip(Is, Js))
 @test all(((i, i) in S) for i in 1:n)             # diagonal
 @test all(((i, n + 1) in S) for i in 1:(n + 1))   # dense ∂H/∂λ column + corner
 @test all(((n + 1, j) in S) for j in 1:n)         # dense constraint row
+# Diagonal is the type where plain `sparse` is value-based (`sparse(Diagonal(zeros(n)))`
+# has zero stored entries) — the structural conversion must keep the full diagonal
+diag_aug = NonlinearSolveBase._augmented_prototype(Diagonal(zeros(n)), n)
+@test diag_aug isa SparseMatrixCSC && size(diag_aug) == (n, n + 1)
+Id, Jd, _ = findnz(diag_aug)
+Sd = Set(zip(Id, Jd))
+@test all(((i, i) in Sd) for i in 1:n)            # diagonal survived zero values
+@test all(((i, n + 1) in Sd) for i in 1:n)        # dense ∂H/∂λ column
+
 # a SparseMatrixCSC prototype borders without conversion
 csc_proto = spdiagm(-1 => ones(n - 1), 0 => ones(n), 1 => ones(n - 1))
 bord_csc = NonlinearSolveBase._bordered_prototype(csc_proto, n)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,6 +143,7 @@ else
             @time @safetestset "ArcLengthContinuation tangent predictor" include("Core/arclength_tests__item6.jl")
             @time @safetestset "ArcLengthContinuation bordered tangent + θ-weighted metric" include("Core/arclength_tests__item7.jl")
             @time @safetestset "Homotopy sweeps consume jac/jac_prototype/sparsity/colorvec" include("Core/homotopy_jac_tests__item1.jl")
+            @time @safetestset "ArcLengthContinuation consumes jac/jac_prototype/sparsity/colorvec" include("Core/arclength_jac_tests__item1.jl")
             @time @safetestset "Homotopy tracking_maxiters caps interior corrector work" include("Core/homotopy_effort_tests__item1.jl")
             @time @safetestset "Homotopy maxsteps guard + effort-band step control" include("Core/homotopy_effort_tests__item2.jl")
             return @time @safetestset "HomotopyPolyAlgorithm stages, fallback, both-fail" include("Core/homotopy_polyalg_tests__item1.jl")


### PR DESCRIPTION
> [!IMPORTANT]
> **Please ignore this PR until it has been reviewed by @ChrisRackauckas.** Opened as a draft by an agent; do not merge or act on it before that review.

Implements derivative-field consumption (`jac` / `jac_prototype` / `sparsity` / `colorvec`) for `ArcLengthContinuation` — item 2 of the #1020 roadmap for the arclength driver, i.e. the follow-up explicitly left out of #1022 (which did the same for the sweep drivers, `HomotopySweep` / `SimpleHomotopySweep`).

## Stacking

~~This PR is stacked on #1021.~~ **#1021 has merged**; this branch is now rebased directly onto master and carries only its own commits (the derivative-field work plus the `structural_sparse` docstring/test correction from review). Full arclength suite re-run locally post-rebase: 145/145 pass.

## Why this needs more than the sweep's λ-fixing wrapper

The user's λ-extended `jac(u, p, λ)` provides only the n×n **∂H/∂u** block, but the arclength driver differentiates two *larger* systems over the packed variable `x = [u; λ]`:

1. **Tangent predictor** — needs the n×(n+1) augmented path Jacobian `[∂H/∂u | ∂H/∂λ]`.
2. **Augmented corrector** — needs the (n+1)×(n+1) bordered Jacobian `[∂H/∂u  ∂H/∂λ; wᵀ]` where `w` is the θ-weighted Keller constraint row.

## Design

- **∂H/∂λ column**: it is a *scalar-parameter* derivative, so it is computed as **one forward-mode derivative of the residual in λ at fixed u** (DifferentiationInterface `derivative` of a λ-shifted residual with `(u, p)` as `Constant` contexts, prepared once per solve and reused) — never a wholesale differentiation of the packed system. `AugmentedPathJac` assembles `[user ∂H/∂u | ∂H/∂λ]` under the standard 2/3-argument Jacobian convention and is wired as the analytic `jac` of the packed `HomotopyResidual` NonlinearFunction, so the `:tangent` predictor consumes it through `construct_jacobian_cache`'s existing `has_jac` path with no changes to the Jacobian tooling.
- **Corrector Jacobian**: `AugmentedHomotopyJac` embeds the same path Jacobian as its top n rows and writes the constraint row analytically. It reads the **same in-place-updated τ buffer** that the per-step `AugmentedHomotopy` residual reads (mirroring the base branch's τ threading), so the Jacobian and residual can never desynchronize; `ds`/`xcur` do not enter the Jacobian because the constraint is affine in `x`.
- **Bordered prototypes**: `jac_prototype` / matrix `sparsity` are extended to the augmented shapes — a structurally dense ∂H/∂λ column for the predictor (`n×(n+1)`), plus the structurally dense constraint row for the corrector (`(n+1)×(n+1)`, i.e. `[proto col; rowᵀ 1]`). Sparse/**structured** prototypes are promoted to `SparseMatrixCSC` — a bordered `Tridiagonal` is no longer tridiagonal, and CSC is what the coloring and sparse-LU machinery handle. The conversion goes through a new `Utils.structural_sparse` (SparseArrays extension) that preserves the *structural* pattern: `sparse(x)` would silently drop zero-valued band entries (the standard `Tridiagonal(zeros, ones, zeros)` prototype idiom). Without SparseArrays loaded, structured prototypes fall back to a dense bordered prototype. Dense prototypes stay dense; prototypes are not eltype-promoted with λ (same documented choice as #1022).
- **sparsity / colorvec**: a sparsity *detector* is forwarded unchanged (it detects the augmented pattern from the augmented residual itself); a matrix sparsity is borderized, preserving the `sparsity === jac_prototype` object identity the `NonlinearFunction` constructor establishes (required by `construct_concrete_adtype`). The user `colorvec` is forwarded to the predictor's system extended by one fresh color for the dense λ column (valid for column coloring); it is **not** forwarded to the corrector — the structurally dense constraint row makes every pair of columns conflict, so no nontrivial column coloring exists for the bordered pattern, and its coloring (when sparse AD applies) is recomputed. The bordered prototype's value for the corrector is chiefly the sparse linear solve.
- **Anchor/landing solves**: the λ-fixed solves now reuse `_sweep_nonlinear_function` from #1022 (λ-fixed `FixLambdaJac`, fields forwarded unchanged), so the whole driver is consistent.
- **No-field problems**: every construction branches on the problem's type exactly like `_sweep_nonlinear_function` and is byte-identical to the base branch when no derivative field is present. Verified by running a residual-counting closure on the S-fold problem against the unmodified base branch: secant 203 evals / tangent 158 evals and bit-identical roots on both branches.

Same SciMLBase wrinkle as #1022: `NonlinearFunction`'s arity-based conformance check rejects bare λ-extended jacs, so the tests supply loudly-erroring dummy λ-free methods. A SciMLBase-side fix is in flight separately; nothing here waits on it.

## Tests

New `test/Core/arclength_jac_tests__item1.jl`, registered in the `core` group right after `homotopy_jac_tests__item1.jl`:

- analytic oop **and** iip jac consumed via the augmented corrector (`inner = NewtonRaphson()`, default `:secant`): counters > 0, jac evaluations at interior λ (only the corrector evaluates there — anchor/landing sit at exactly λ = 0/1), S-fold root correct to 1e-4;
- analytic jac consumed via the `:tangent` predictor: counter > 0, root correct to 1e-4;
- analytic-jac solutions match the AD solutions (both predictors);
- augmented/bordered prototype structure: zero-valued Tridiagonal bands survive as pattern, dense λ column + dense constraint row present, CSC promotion, CSC prototypes border without conversion;
- n = 50 tridiagonal fold-free system with `:tangent`: jac + prototype (asserts the corrector's Jacobian buffer is the bordered (n+1)×(n+1) `SparseMatrixCSC` and the anchor kept the user's own `Tridiagonal`), and prototype + colorvec **without** an analytic jac (sparse AD end-to-end); both solve to residual < 1e-8;
- no-field constructions are type-identical to the bare ones; no-field solves are deterministic in root and residual-eval count (and match the base branch, see above).

`SparseArrays` (stdlib) and `SparseMatrixColorings` were added to the root `[extras]`/test target for the sparse assertions. No version bumps.

## What ran locally (Julia 1.11.9)

- New test file standalone: **40/40 pass**.
- Full battery with absolute `@safetestset` include paths: `homotopy_sweep_tests__item{1–21}`, `arclength_tests__item{1–7}`, `homotopy_jac_tests__item1`, `arclength_jac_tests__item1` (new), `homotopy_effort_tests__item{1,2}`, `homotopy_polyalg_tests__item1` — **338/338 pass, exit 0** (33 items; the battery was run twice — 336/336 on the previous base tip, and 338/338 after rebasing onto the base's latest LinearSolve-backed bordered-solve commit, which added 2 tests).
- Base-branch comparison run for the no-field counting closure (see above).
- Runic `--inplace` then `--check` (exit 0) on all touched files.

Note: this branch is rebased onto the *pushed* `arclength-bordered-theta` tip (currently the LinearSolve-backed bordered-solve review commit), not the stale local copy it started from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)