### PR TITLE
Rename j_soop test identifiers flagged by typos CI

### DIFF
--- a/test/Core/homotopy_jac_tests__item1.jl
+++ b/test/Core/homotopy_jac_tests__item1.jl
@@ -59,15 +59,15 @@ sol_ad = solve(prob_ad, HomotopySweep(; inner = NewtonRaphson()))
 
 # --- SimpleHomotopySweep consumes an analytic jac (SimpleNewtonRaphson honors f.jac) ---
 simple_oop_jac_calls = Ref(0)
-function j_soop(u, p, λ)
+function j_short_oop(u, p, λ)
     simple_oop_jac_calls[] += 1
     return reshape([(1 - λ) + λ * 3 * u[1]^2;;], 1, 1)
 end
-j_soop(u, p) = error("λ-free jac must never be called by the sweep")
-prob_soop = HomotopyProblem(NonlinearFunction{false}(f_oop; jac = j_soop), [2.0], 2.0)
-sol_soop = solve(prob_soop, SimpleHomotopySweep(; inner = SimpleNewtonRaphson()))
-@test SciMLBase.successful_retcode(sol_soop)
-@test sol_soop.u[1] ≈ cbrt(2.0) atol = 1.0e-8
+j_short_oop(u, p) = error("λ-free jac must never be called by the sweep")
+prob_short_oop = HomotopyProblem(NonlinearFunction{false}(f_oop; jac = j_short_oop), [2.0], 2.0)
+sol_short_oop = solve(prob_short_oop, SimpleHomotopySweep(; inner = SimpleNewtonRaphson()))
+@test SciMLBase.successful_retcode(sol_short_oop)
+@test sol_short_oop.u[1] ≈ cbrt(2.0) atol = 1.0e-8
 @test simple_oop_jac_calls[] > 0
 
 simple_iip_jac_calls = Ref(0)


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

The typos spell-checker flags the `soop` ("scalar oop") identifier suffix in `test/Core/homotopy_jac_tests__item1.jl` (merged in #1022) as a misspelling of "soup"/"scoop", so **Spell Check fails on master** and therefore on every open PR (first observed on #1021's checks). Renamed `j_soop`/`prob_soop`/`sol_soop` → `*_short_oop`. No behavior change; the test file passes 30/30 locally (Julia 1.11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)