### PR TITLE
Homotopy sweeps: loose-then-tight tracking tolerances (tracking_abstol)

### DIFF
--- a/lib/NonlinearSolveBase/src/homotopy_sweep.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_sweep.jl
@@ -2,7 +2,8 @@
     HomotopySweep(; inner = nothing, nsteps = nothing, adaptive = true,
         initial_step_factor = 0.1, min_dλ = nothing, max_step_factor = 1.0,
         expand_factor = 2.0, expand_threshold = 2, expand_quality = 0.25,
-        predictor = :secant, tracking_maxiters = 10, maxsteps = 10000)
+        predictor = :secant, tracking_maxiters = 10, tracking_abstol = nothing,
+        maxsteps = 10000)
 
 Natural-parameter continuation solver for a [`SciMLBase.HomotopyProblem`](@ref). The
 scalar continuation parameter ``λ`` is swept across the problem's `λspan`. The sweep
@@ -95,6 +96,23 @@ Keyword arguments:
     increment from a warm start, so failing fast is far cheaper than exhausting the
     inner solver's full budget. Never applied to the `λspan[1]` anchor solve or the
     final step landing on `λspan[2]`; an explicit user-passed `maxiters` always wins.
+  - `tracking_abstol`: loose absolute tolerance for the inner corrector on interior
+    tracking steps (default `nothing` = disabled: every step solves to the full
+    tolerance). Interior iterates only serve as warm starts and secant-predictor
+    history for the next step, so they need just enough accuracy to stay inside the
+    next corrector's convergence basin — the reference trackers exploit exactly this
+    (Bertini tracks at 1e-5/1e-6 and only the endgame runs tight;
+    HomotopyContinuation.jl accepts on Newton contraction and polishes the endpoint).
+    Values around `1e-4`–`1e-6` are good starting points when opting in. Never applied
+    to the `λspan[1]` anchor solve (the one cold start, and the returned solution for a
+    zero-width span) or to the final step landing on `λspan[2]`, so the returned
+    solution always satisfies the full tolerances: the landing runs on the loose cache
+    first and is then re-polished at the full tolerance from that warm start (~1–2
+    extra corrector iterations). An explicit user-passed `abstol` or `reltol` (solve
+    kwarg or problem kwarg) disables the loosening entirely. The looser interior
+    iterates slightly degrade the secant/quality signals the step controller reads,
+    which is why the default stays tight (opt-in loose, per the discussion in
+    SciML/NonlinearSolve.jl#1020).
   - `maxsteps`: a hard cap on the total number of predictor-corrector attempts
     (accepted steps plus bisection retries). Exceeding it returns a
     `ReturnCode.MaxIters` failure carrying the last converged iterate. Must be ≥ 1.
@@ -121,6 +139,7 @@ systems whose target form is hard to solve cold; it is unrelated to the polynomi
     expand_quality
     predictor::Symbol
     tracking_maxiters
+    tracking_abstol
     maxsteps::Int
 end
 
@@ -128,7 +147,8 @@ function HomotopySweep(;
         inner = nothing, nsteps = nothing, adaptive = true,
         initial_step_factor = 0.1, min_dλ = nothing, max_step_factor = 1.0,
         expand_factor = 2.0, expand_threshold = 2, expand_quality = 0.25,
-        predictor = :secant, tracking_maxiters = 10, maxsteps = 10000
+        predictor = :secant, tracking_maxiters = 10, tracking_abstol = nothing,
+        maxsteps = 10000
     )
     if nsteps !== nothing && nsteps < 1
         throw(ArgumentError("HomotopySweep `nsteps` must be ≥ 1, got $nsteps"))
@@ -197,13 +217,21 @@ function HomotopySweep(;
             )
         )
     end
+    if tracking_abstol !== nothing && !(tracking_abstol > 0)
+        throw(
+            ArgumentError(
+                "HomotopySweep `tracking_abstol` must be positive (nothing disables " *
+                    "the loose tracking tolerance), got $tracking_abstol"
+            )
+        )
+    end
     if maxsteps < 1
         throw(ArgumentError("HomotopySweep `maxsteps` must be ≥ 1, got $maxsteps"))
     end
     return HomotopySweep(
         inner, nsteps, adaptive, initial_step_factor, min_dλ,
         max_step_factor, expand_factor, expand_threshold, expand_quality, predictor,
-        tracking_maxiters, maxsteps
+        tracking_maxiters, tracking_abstol, maxsteps
     )
 end
 
@@ -289,6 +317,20 @@ function _tracking_budget(tracking_maxiters, prob_kwargs, kwargs)
     return Int(tracking_maxiters), true
 end
 
+# Resolve the loose tolerance interior tracking steps run under, returning
+# `(tracking_abstol, tol_active)`. Explicit user tolerances always win (mirroring
+# `_tracking_budget`): any user-passed `abstol` OR `reltol` (solve kwargs shadow
+# problem kwargs) disables the loosening entirely — splicing a loose `abstol` next to
+# a user `reltol` would let the loose criterion fire first in the default OR-combined
+# termination modes, silently overriding the user's intent.
+function _tracking_tolerance(tracking_abstol, prob_kwargs, kwargs)
+    tracking_abstol === nothing && return nothing, false
+    (haskey(kwargs, :abstol) || haskey(kwargs, :reltol)) && return nothing, false
+    (haskey(prob_kwargs, :abstol) || haskey(prob_kwargs, :reltol)) &&
+        return nothing, false
+    return tracking_abstol, true
+end
+
 # AUTO-07p ADPTDS-style effort bands, scaling the growth multiplier by the accepted
 # step's corrector iteration count `nit` relative to its iteration budget: a near-free
 # corrector earns the full `expand_factor`, moderate effort earns milder growth, and
@@ -316,14 +358,17 @@ function _effort_wants_shrink(nit::Int, budget::Int)
     return nit >= 0 && nit <= budget && 4 * nit >= 3 * budget
 end
 
-# Full-budget standalone solve at a fixed λ. Used only when the tracking cap is active
-# but must not bind — rescuing the λspan[1] anchor and the final landing on λspan[2] —
-# so it runs with the user's original kwargs, outside the capped cache.
-function _sweep_uncapped_solve(
+# Full-fidelity standalone solve at a fixed λ, with the user's original kwargs (full
+# iteration budget, full tolerances) outside the tracking cache. Used only where the
+# tracking cap / loose tracking tolerance are active but must not bind: the λspan[1]
+# anchor and the final landing on λspan[2]. Forwards the problem's derivative fields
+# exactly like the tracking cache, so an analytic/sparse Jacobian keeps working on
+# these exempt solves.
+function _sweep_exempt_solve(
         prob::SciMLBase.HomotopyProblem{uType, iip}, inner, uguess, λfix,
         args...; kwargs...
     ) where {uType, iip}
-    fλ = SciMLBase.NonlinearFunction{iip}(FixLambda(prob.f, λfix))
+    fλ = _sweep_nonlinear_function(Val(iip), prob.f, FixLambda(prob.f, λfix))
     inner_prob = NonlinearProblem{iip}(fλ, copy(uguess), prob.p)
     return solve(inner_prob, inner, args...; prob.kwargs..., kwargs...)
 end
@@ -344,6 +389,9 @@ function CommonSolve.solve(
     abs(dλ) > abs(max_dλ) && (dλ = max_dλ)
     u = copy(prob.u0)
     budget, cap_active = _tracking_budget(alg.tracking_maxiters, prob.kwargs, kwargs)
+    track_abstol, tol_active = _tracking_tolerance(
+        alg.tracking_abstol, prob.kwargs, kwargs
+    )
 
     # One inner-solver cache, built once around the mutable `FixLambda` and reused for
     # every solve of the sweep (the anchor below and each continuation step): advancing
@@ -352,17 +400,29 @@ function CommonSolve.solve(
     # may be iterated in place when aliasing is forwarded; `u` is a separately-owned
     # buffer the inner solver never writes, so a FAILED attempt leaves the last
     # converged iterate intact for retries and the failure returns below. When the
-    # tracking cap is active it is baked into this cache (the many interior steps all
-    # run capped); the anchor and the final landing are exempted through the
-    # `_sweep_uncapped_solve` rescues below rather than a second full-budget cache, so
-    # the happy path keeps a single inner workspace.
+    # tracking cap / loose tracking tolerance are active they are baked into this
+    # cache (the many interior steps all run capped/loose; `abstol` cannot reliably be
+    # changed through `reinit!` — e.g. the default polyalgorithm's cache `reinit!`
+    # accepts no tolerance kwargs); the anchor and the final landing are exempted
+    # through the `_sweep_exempt_solve` calls below rather than a second full-fidelity
+    # cache, so the happy path keeps a single inner workspace.
     fixλ = FixLambda(prob.f, λ)
     fλ = _sweep_nonlinear_function(Val(iip), prob.f, fixλ)
     guess = copy(u)
-    cache = if cap_active
+    cache = if cap_active && tol_active
+        init(
+            NonlinearProblem{iip}(fλ, guess, prob.p), alg.inner, args...;
+            prob.kwargs..., kwargs..., maxiters = budget, abstol = track_abstol
+        )
+    elseif cap_active
         init(
             NonlinearProblem{iip}(fλ, guess, prob.p), alg.inner, args...;
             prob.kwargs..., kwargs..., maxiters = budget
+        )
+    elseif tol_active
+        init(
+            NonlinearProblem{iip}(fλ, guess, prob.p), alg.inner, args...;
+            prob.kwargs..., kwargs..., abstol = track_abstol
         )
     else
         init(
@@ -378,13 +438,21 @@ function CommonSolve.solve(
     # first inner solve runs at λ0 + dλ warm-started from u0, so a poor u0 can
     # converge onto the wrong branch and the sweep then tracks that branch all
     # the way to a wrong root with a success retcode.
-    last_sol = CommonSolve.solve!(cache)
-    if cap_active && !SciMLBase.successful_retcode(last_sol)
+    last_sol = if tol_active
+        # The anchor is exempt from the loose tracking tolerance — it is the one
+        # cold-start solve (and the returned solution when the span is zero-width),
+        # so it runs standalone at the user's full tolerances (and full budget, which
+        # also covers the tracking-cap exemption). A one-time cost when opting in.
+        _sweep_exempt_solve(prob, alg.inner, u, λ, args...; kwargs...)
+    else
+        CommonSolve.solve!(cache)
+    end
+    if cap_active && !tol_active && !SciMLBase.successful_retcode(last_sol)
         # The anchor is exempt from the tracking cap — it is the one cold-start solve
         # the homotopy contract is designed around, so it may legitimately need many
         # more iterations than a warm-started tracking step. Rerun it with the full
         # user budget before declaring the homotopy premise broken.
-        last_sol = _sweep_uncapped_solve(prob, alg.inner, u, λ, args...; kwargs...)
+        last_sol = _sweep_exempt_solve(prob, alg.inner, u, λ, args...; kwargs...)
     end
     if !SciMLBase.successful_retcode(last_sol)
         # the λ = λspan[1] system itself failed from u0: the homotopy premise is
@@ -447,19 +515,32 @@ function CommonSolve.solve(
         SciMLBase.reinit!(cache, guess)
         last_sol = CommonSolve.solve!(cache)
 
-        if cap_active && next_λ == λend && !SciMLBase.successful_retcode(last_sol)
-            # The final landing on λspan[2] is exempt from the tracking cap: give it
-            # the full user budget before letting the failure feed the bisection
-            # logic. The prediction is recomputed (never reuse `guess`: the capped
-            # solve may have iterated in place in that buffer).
-            retry_guess = if used_secant
-                _sweep_extrapolate!(virtual, u, u_prev, (next_λ - λ) / (λ - λ_prev))
-            else
-                u
+        if next_λ == λend
+            if cap_active && !SciMLBase.successful_retcode(last_sol)
+                # The final landing on λspan[2] is exempt from the tracking cap: give
+                # it the full user budget before letting the failure feed the
+                # bisection logic. The prediction is recomputed (never reuse `guess`:
+                # the capped solve may have iterated in place in that buffer). The
+                # exempt solve also runs at the full tolerances, so it covers the
+                # loose-tolerance exemption when both are active.
+                retry_guess = if used_secant
+                    _sweep_extrapolate!(virtual, u, u_prev, (next_λ - λ) / (λ - λ_prev))
+                else
+                    u
+                end
+                last_sol = _sweep_exempt_solve(
+                    prob, alg.inner, retry_guess, next_λ, args...; kwargs...
+                )
+            elseif tol_active && SciMLBase.successful_retcode(last_sol)
+                # The landing is exempt from the loose tracking tolerance: the loose
+                # cache solve above did the bulk of the convergence, now re-polish at
+                # the user's full tolerances warm-started from it (~1–2 corrector
+                # iterations), so the returned solution's accuracy semantics are
+                # unchanged. A failed polish feeds the ordinary bisection logic.
+                last_sol = _sweep_exempt_solve(
+                    prob, alg.inner, last_sol.u, next_λ, args...; kwargs...
+                )
             end
-            last_sol = _sweep_uncapped_solve(
-                prob, alg.inner, retry_guess, next_λ, args...; kwargs...
-            )
         end
 
         if SciMLBase.successful_retcode(last_sol)

--- a/lib/SimpleNonlinearSolve/src/simple_homotopy_sweep.jl
+++ b/lib/SimpleNonlinearSolve/src/simple_homotopy_sweep.jl
@@ -3,7 +3,7 @@
         adaptive = true, initial_step_factor = 0.1, min_dλ = nothing,
         max_step_factor = 1.0, expand_factor = 2.0, expand_threshold = 2,
         expand_quality = 0.25, predictor = :secant, tracking_maxiters = 10,
-        maxsteps = 10000)
+        tracking_abstol = nothing, maxsteps = 10000)
 
 Natural-parameter continuation solver for a `SciMLBase.HomotopyProblem`, the
 SimpleNonlinearSolve counterpart of `HomotopySweep`. The algorithm is the same —
@@ -36,11 +36,16 @@ Keyword arguments are identical to `HomotopySweep` except that `inner` defaults 
 NonlinearSolve polyalgorithm. In particular `tracking_maxiters` caps the inner
 corrector's iterations for interior tracking steps only (never the `λspan[1]` anchor,
 never the final landing on `λspan[2]`, and never overriding an explicit user-passed
-`maxiters`), the success-side step growth is scaled by the corrector's iteration
-count (the AUTO-07p `ADPTDS` effort bands, including a proactive halving when a
-success nearly exhausts the budget), and `maxsteps` caps the total number of
-predictor-corrector attempts, returning `ReturnCode.MaxIters` with the last converged
-iterate when exceeded.
+`maxiters`), `tracking_abstol` (default `nothing` = disabled) loosens the inner
+corrector's absolute tolerance on those same interior steps only — the anchor and the
+final landing always run at the user's full tolerances (each step here is a fresh
+standalone solve, so the exemption is simply not splicing the loose tolerance into
+the exempt solves — no re-polish is needed), and an explicit user-passed `abstol` or
+`reltol` (solve kwarg or problem kwarg) disables the loosening entirely — the
+success-side step growth is scaled by the corrector's iteration count (the AUTO-07p
+`ADPTDS` effort bands, including a proactive halving when a success nearly exhausts
+the budget), and `maxsteps` caps the total number of predictor-corrector attempts,
+returning `ReturnCode.MaxIters` with the last converged iterate when exceeded.
 
 When the sweep cannot reach the end of `λspan`, the returned solution carries a
 failure retcode: its `u` is the last converged iterate (at some ``λ`` short of
@@ -62,6 +67,7 @@ which is part of what keeps the sweep allocation-free).
     expand_quality
     predictor::Symbol
     tracking_maxiters
+    tracking_abstol
     maxsteps::Int
 end
 
@@ -69,7 +75,8 @@ function SimpleHomotopySweep(;
         inner = SimpleNewtonRaphson(), nsteps = nothing, adaptive = true,
         initial_step_factor = 0.1, min_dλ = nothing, max_step_factor = 1.0,
         expand_factor = 2.0, expand_threshold = 2, expand_quality = 0.25,
-        predictor = :secant, tracking_maxiters = 10, maxsteps = 10000
+        predictor = :secant, tracking_maxiters = 10, tracking_abstol = nothing,
+        maxsteps = 10000
     )
     if nsteps !== nothing && nsteps < 1
         throw(ArgumentError("SimpleHomotopySweep `nsteps` must be ≥ 1, got $nsteps"))
@@ -141,13 +148,21 @@ function SimpleHomotopySweep(;
             )
         )
     end
+    if tracking_abstol !== nothing && !(tracking_abstol > 0)
+        throw(
+            ArgumentError(
+                "SimpleHomotopySweep `tracking_abstol` must be positive (nothing " *
+                    "disables the loose tracking tolerance), got $tracking_abstol"
+            )
+        )
+    end
     if maxsteps < 1
         throw(ArgumentError("SimpleHomotopySweep `maxsteps` must be ≥ 1, got $maxsteps"))
     end
     return SimpleHomotopySweep(
         inner, nsteps, adaptive, initial_step_factor, min_dλ,
         max_step_factor, expand_factor, expand_threshold, expand_quality, predictor,
-        tracking_maxiters, maxsteps
+        tracking_maxiters, tracking_abstol, maxsteps
     )
 end
 
@@ -197,15 +212,27 @@ end
 # immutable/StaticArray/scalar `u` cannot be mutated and passes through (stack).
 _simple_sweep_guess(u) = NLBUtils.can_setindex(u) ? copy(u) : u
 
-# Local duplicates of NonlinearSolveBase's `_tracking_budget` / `_effort_growth_factor`
-# / `_effort_wants_shrink` (see homotopy_sweep.jl there for the rationale): duplicated
-# rather than shared so this package does not depend on new NonlinearSolveBase
-# internals, and kept branch-only/isbits so the StaticArray path stays kernel-safe.
+# Local duplicates of NonlinearSolveBase's `_tracking_budget` / `_tracking_tolerance`
+# / `_effort_growth_factor` / `_effort_wants_shrink` (see homotopy_sweep.jl there for
+# the rationale): duplicated rather than shared so this package does not depend on new
+# NonlinearSolveBase internals, and kept branch-only/isbits so the StaticArray path
+# stays kernel-safe.
 function _simple_tracking_budget(tracking_maxiters, prob_kwargs, kwargs)
     haskey(kwargs, :maxiters) && return Int(kwargs[:maxiters]), false
     haskey(prob_kwargs, :maxiters) && return Int(prob_kwargs[:maxiters]), false
     tracking_maxiters === nothing && return 1000, false
     return Int(tracking_maxiters), true
+end
+
+# any explicit user tolerance (abstol OR reltol; solve kwargs shadow problem kwargs)
+# disables the loosening — a loose abstol spliced next to a user reltol would fire
+# first in the default OR-combined termination modes
+function _simple_tracking_tolerance(tracking_abstol, prob_kwargs, kwargs)
+    tracking_abstol === nothing && return nothing, false
+    (haskey(kwargs, :abstol) || haskey(kwargs, :reltol)) && return nothing, false
+    (haskey(prob_kwargs, :abstol) || haskey(prob_kwargs, :reltol)) &&
+        return nothing, false
+    return tracking_abstol, true
 end
 
 function _simple_effort_growth_factor(nit::Int, budget::Int, expand_factor::T) where {T}
@@ -238,6 +265,9 @@ function CommonSolve.solve(
     abs(dλ) > abs(max_dλ) && (dλ = max_dλ)
     u = _simple_sweep_guess(prob.u0)
     budget, cap_active = _simple_tracking_budget(alg.tracking_maxiters, prob.kwargs, kwargs)
+    track_abstol, tol_active = _simple_tracking_tolerance(
+        alg.tracking_abstol, prob.kwargs, kwargs
+    )
 
     # Anchor: solve the system at λ = λspan[1] from u0 before stepping (see
     # `HomotopySweep` — same contract: a failed anchor means the homotopy premise is
@@ -296,13 +326,27 @@ function CommonSolve.solve(
         else
             _simple_sweep_guess(u)
         end
-        # Interior tracking steps run under the tracking cap; the final landing on λend
-        # keeps the full user budget (the anchor above never enters this loop). The cap
-        # is spliced BEFORE the user kwargs so an explicit `maxiters` always wins (and
-        # `cap_active` is false in that case anyway).
-        last_sol = if cap_active && next_λ != λend
+        # Interior tracking steps run under the tracking cap and the loose tracking
+        # tolerance; the final landing on λend keeps the full user budget and full
+        # tolerances (the anchor above never enters this loop) — every step here is a
+        # fresh standalone solve, so the exemption is simply not splicing the loose
+        # kwargs, with no re-polish needed. The cap/tolerance are spliced BEFORE the
+        # user kwargs so explicit user values always win (and `cap_active`/`tol_active`
+        # are false in those cases anyway).
+        interior = next_λ != λend
+        last_sol = if interior && cap_active && tol_active
+            _simple_sweep_solve(
+                prob, alg.inner, guess, next_λ, args...;
+                maxiters = budget, abstol = track_abstol, kwargs...
+            )
+        elseif interior && cap_active
             _simple_sweep_solve(
                 prob, alg.inner, guess, next_λ, args...; maxiters = budget, kwargs...
+            )
+        elseif interior && tol_active
+            _simple_sweep_solve(
+                prob, alg.inner, guess, next_λ, args...;
+                abstol = track_abstol, kwargs...
             )
         else
             _simple_sweep_solve(prob, alg.inner, guess, next_λ, args...; kwargs...)

--- a/lib/SimpleNonlinearSolve/test/core/homotopy_sweep_tests__item1.jl
+++ b/lib/SimpleNonlinearSolve/test/core/homotopy_sweep_tests__item1.jl
@@ -16,6 +16,8 @@ alg = SimpleHomotopySweep()
 @test_throws ArgumentError SimpleHomotopySweep(; expand_threshold = 0)
 @test_throws ArgumentError SimpleHomotopySweep(; expand_quality = 0.0)
 @test_throws ArgumentError SimpleHomotopySweep(; predictor = :tangent)
+@test_throws ArgumentError SimpleHomotopySweep(; tracking_abstol = 0.0)
+@test_throws ArgumentError SimpleHomotopySweep(; tracking_abstol = -1.0e-3)
 
 # ---- correctness across container types ----
 # (1-λ)(u - p) + λ(u² - p): root path from u = p at λ = 0 to u = √p at λ = 1

--- a/test/Core/homotopy_tolerance_tests__item1.jl
+++ b/test/Core/homotopy_tolerance_tests__item1.jl
@@ -1,0 +1,172 @@
+using NonlinearSolve
+
+using SciMLBase
+using StaticArrays
+
+# `tracking_abstol` loosens the inner corrector's tolerance on interior tracking steps
+# only: interior iterates just need to stay inside the next step's Newton convergence
+# basin, while the λspan[1] anchor and the final landing on λspan[2] always run at the
+# user's full tolerances, so the returned solution's accuracy semantics are unchanged.
+# Reference measurements (Julia 1.12, this commit) on u³ - 1 - λ with a NewtonRaphson
+# inner: 53 residual calls tight vs 43 at tracking_abstol = 1e-3 (19%); on the n = 50
+# coupled cubic: 1247 vs 835 (33%); SimpleHomotopySweep scalar path: 43 vs 27 (37%).
+# The thresholds below carry generous margin over those measurements.
+
+# ---- (a) + (b): final solution stays tight, residual-call count drops ----
+nf = Ref(0)
+H(u, p, λ) = (nf[] += 1; [u[1]^3 - 1 - λ])
+prob = HomotopyProblem(H, [1.0]; λspan = (0.0, 1.0))
+
+nf[] = 0
+sol = solve(prob, HomotopySweep(; inner = NewtonRaphson()))
+@test SciMLBase.successful_retcode(sol)
+nf_tight = nf[]
+
+nf[] = 0
+sol = solve(prob, HomotopySweep(; inner = NewtonRaphson(), tracking_abstol = 1.0e-3))
+@test SciMLBase.successful_retcode(sol)
+# despite the loose interior tracking, the landing runs at the full tolerance
+@test sol.u[1] ≈ cbrt(2) atol = 1.0e-9
+nf_loose = nf[]
+@test nf_loose < nf_tight
+
+# the default (tracking_abstol = nothing) must not change behavior at all
+nf[] = 0
+sol_def = solve(prob, HomotopySweep(; inner = NewtonRaphson(), tracking_abstol = nothing))
+@test nf[] == nf_tight
+
+# stronger margin on the n = 50 coupled cubic system (measured 33% reduction)
+nfn = Ref(0)
+function Hn(du, u, p, λ)
+    nfn[] += 1
+    for i in 1:length(u)
+        um = i == 1 ? zero(eltype(u)) : u[i - 1]
+        up = i == length(u) ? zero(eltype(u)) : u[i + 1]
+        du[i] = (1 - λ) * (u[i] - p) + λ * (3u[i] - um - up + u[i]^3 - p)
+    end
+    return nothing
+end
+probn = HomotopyProblem(NonlinearFunction{true}(Hn), fill(1.0, 50), 1.0)
+nfn[] = 0
+soln = solve(probn, HomotopySweep(; inner = NewtonRaphson()))
+@test SciMLBase.successful_retcode(soln)
+nfn_tight = nfn[]
+nfn[] = 0
+soln = solve(probn, HomotopySweep(; inner = NewtonRaphson(), tracking_abstol = 1.0e-3))
+@test SciMLBase.successful_retcode(soln)
+nfn_loose = nfn[]
+@test nfn_loose < (nfn_tight * 85) ÷ 100
+residn = zeros(50)
+Hn(residn, soln.u, 1.0, 1.0)
+@test maximum(abs, residn) < 1.0e-9   # landing at full tolerance, not 1e-3
+
+# SimpleHomotopySweep: same semantics on the value-oriented driver
+nfs = Ref(0)
+Hs(u, p, λ) = (nfs[] += 1; SA[u[1]^3 - 1 - λ])
+probs = HomotopyProblem(Hs, SA[1.0]; λspan = (0.0, 1.0))
+nfs[] = 0
+sols = solve(probs, SimpleHomotopySweep())
+@test SciMLBase.successful_retcode(sols)
+nfs_tight = nfs[]
+nfs[] = 0
+sols = solve(probs, SimpleHomotopySweep(; tracking_abstol = 1.0e-3))
+@test SciMLBase.successful_retcode(sols)
+@test sols.u[1] ≈ cbrt(2) atol = 1.0e-9
+nfs_loose = nfs[]
+@test nfs_loose < (nfs_tight * 85) ÷ 100
+
+# ---- (c) anchor exemption ----
+# Zero-width λspan: the anchor IS the returned solve. A standalone solve at the loose
+# tolerance stops far from the root (verified directly below), yet the sweep's result
+# is tight because the anchor is exempt from tracking_abstol.
+Ha(u, p, λ) = [u[1]^3 - 1 - λ]
+proba = HomotopyProblem(Ha, [3.0]; λspan = (0.0, 0.0))
+loose_direct = solve(
+    NonlinearProblem((u, p) -> [u[1]^3 - 1], [3.0]), NewtonRaphson(); abstol = 0.5
+)
+@test abs(loose_direct.u[1] - 1) > 1.0e-3
+for alg in (
+        HomotopySweep(; inner = NewtonRaphson(), tracking_abstol = 0.5),
+        HomotopySweep(; tracking_abstol = 0.5),
+    )
+    sola = solve(proba, alg)
+    @test SciMLBase.successful_retcode(sola)
+    @test sola.u[1] ≈ 1.0 atol = 1.0e-8
+end
+
+Has(u, p, λ) = SA[u[1]^3 - 1 - λ]
+probas = HomotopyProblem(Has, SA[3.0]; λspan = (0.0, 0.0))
+solas = solve(probas, SimpleHomotopySweep(; tracking_abstol = 0.5))
+@test SciMLBase.successful_retcode(solas)
+@test solas.u[1] ≈ 1.0 atol = 1.0e-8
+
+# ---- (c) landing exemption ----
+# With a single fixed step (nsteps = 1, adaptive = false) the only step IS the landing.
+# A standalone solve at the loose tolerance stops far from the λ = 1 root u = 2
+# (verified directly below), yet the sweep's landing is exempt and returns it tight.
+Hl(u, p, λ) = [u[1]^3 - 1 - 7λ]
+probl = HomotopyProblem(Hl, [1.0]; λspan = (0.0, 1.0))
+loose_landing_direct = solve(
+    NonlinearProblem((u, p) -> [u[1]^3 - 8], [1.0]), NewtonRaphson(); abstol = 0.5
+)
+@test abs(loose_landing_direct.u[1] - 2) > 1.0e-3
+sol = solve(
+    probl,
+    HomotopySweep(;
+        inner = NewtonRaphson(), nsteps = 1, adaptive = false, tracking_abstol = 0.5
+    )
+)
+@test SciMLBase.successful_retcode(sol)
+@test sol.u[1] ≈ 2.0 atol = 1.0e-8
+
+Hls(u, p, λ) = SA[u[1]^3 - 1 - 7λ]
+probls = HomotopyProblem(Hls, SA[1.0]; λspan = (0.0, 1.0))
+sol = solve(
+    probls, SimpleHomotopySweep(; nsteps = 1, adaptive = false, tracking_abstol = 0.5)
+)
+@test SciMLBase.successful_retcode(sol)
+@test sol.u[1] ≈ 2.0 atol = 1.0e-8
+
+# ---- (d) explicit user tolerances win over the tracking default ----
+# With a user-passed abstol the loosening is disabled outright, so the run is
+# identical (deterministic solver, exact same code path) to tracking_abstol = nothing.
+nf[] = 0
+solve(prob, HomotopySweep(; inner = NewtonRaphson()); abstol = 1.0e-12)
+nf_user = nf[]
+nf[] = 0
+solve(prob, HomotopySweep(; inner = NewtonRaphson(), tracking_abstol = 1.0e-3); abstol = 1.0e-12)
+@test nf[] == nf_user
+
+# problem-level abstol wins the same way
+probkw = HomotopyProblem(H, [1.0]; λspan = (0.0, 1.0), abstol = 1.0e-12)
+nf[] = 0
+solve(probkw, HomotopySweep(; inner = NewtonRaphson()))
+nf_probkw = nf[]
+nf[] = 0
+solve(probkw, HomotopySweep(; inner = NewtonRaphson(), tracking_abstol = 1.0e-3))
+@test nf[] == nf_probkw
+
+# a user reltol also disables the loosening (a loose abstol spliced next to a user
+# reltol would fire first in the OR-combined default termination modes)
+nf[] = 0
+solve(prob, HomotopySweep(; inner = NewtonRaphson()); reltol = 1.0e-10)
+nf_rel = nf[]
+nf[] = 0
+solve(prob, HomotopySweep(; inner = NewtonRaphson(), tracking_abstol = 1.0e-3); reltol = 1.0e-10)
+@test nf[] == nf_rel
+
+# SimpleHomotopySweep: user abstol wins identically
+nfs[] = 0
+solve(probs, SimpleHomotopySweep(); abstol = 1.0e-12)
+nfs_user = nfs[]
+nfs[] = 0
+solve(probs, SimpleHomotopySweep(; tracking_abstol = 1.0e-3); abstol = 1.0e-12)
+@test nfs[] == nfs_user
+
+# ---- (e) constructor validation ----
+@test_throws ArgumentError HomotopySweep(; tracking_abstol = 0.0)
+@test_throws ArgumentError HomotopySweep(; tracking_abstol = -1.0e-3)
+@test_throws ArgumentError SimpleHomotopySweep(; tracking_abstol = 0.0)
+@test_throws ArgumentError SimpleHomotopySweep(; tracking_abstol = -1.0e-3)
+@test HomotopySweep(; tracking_abstol = nothing) isa HomotopySweep
+@test SimpleHomotopySweep(; tracking_abstol = 1.0e-4) isa SimpleHomotopySweep

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -145,6 +145,7 @@ else
             @time @safetestset "Homotopy sweeps consume jac/jac_prototype/sparsity/colorvec" include("Core/homotopy_jac_tests__item1.jl")
             @time @safetestset "Homotopy tracking_maxiters caps interior corrector work" include("Core/homotopy_effort_tests__item1.jl")
             @time @safetestset "Homotopy maxsteps guard + effort-band step control" include("Core/homotopy_effort_tests__item2.jl")
+            @time @safetestset "Homotopy tracking_abstol loosens interior tracking only" include("Core/homotopy_tolerance_tests__item1.jl")
             return @time @safetestset "HomotopyPolyAlgorithm stages, fallback, both-fail" include("Core/homotopy_polyalg_tests__item1.jl")
         end,
         groups = Dict(


### PR DESCRIPTION
Part of #1020 (P5).

**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

## What

Adds an opt-in `tracking_abstol` keyword to `HomotopySweep` and `SimpleHomotopySweep`. Interior tracking steps of a continuation sweep only need enough accuracy to keep the secant predictor useful and to stay inside the next step's Newton convergence basin — they are warm starts, not answers. With `tracking_abstol` set, those interior corrector solves run at the loose absolute tolerance while the returned solution still satisfies the user's full tolerances, so the accuracy semantics of the result are unchanged.

This is standard practice in production path trackers: Bertini tracks at `1e-5`/`1e-6` and only the endgame runs tight; HomotopyContinuation.jl accepts steps on Newton contraction and polishes endpoints; AUTO-07p correctors run at path-tracking tolerances well looser than typical solution reporting tolerances. Values around `1e-4`–`1e-6` are good starting points when opting in.

## Design (mirrors the `tracking_maxiters` precedent from #1024 exactly)

- **Anchor and landing are exempt.** The `λspan[1]` anchor solve (the one cold start, and the returned solution for a zero-width span) and the final landing on `λspan[2]` always run at the user's full tolerances.
- **Cache driver (`HomotopySweep`):** the loose `abstol` is baked into the single shared inner cache. It cannot be changed per-`reinit!` — the polyalgorithm cache's `InternalAPI.reinit!` accepts only `p`/`u0`, no tolerance kwargs (checked in `lib/NonlinearSolveBase/src/polyalg.jl`). So the anchor runs as a standalone full-tolerance solve, and the landing is **re-polished** at the full tolerance warm-started from the loose landing solve (~1–2 extra corrector iterations). The existing `_sweep_uncapped_solve` rescue was generalized into `_sweep_exempt_solve` (which now also forwards `jac`/`jac_prototype`/`sparsity`/`colorvec` like the tracking cache, matching #1022).
- **Value driver (`SimpleHomotopySweep`):** every step is a fresh standalone solve, so the exemption is simply not splicing the loose kwargs into the anchor/landing solves — no re-polish needed. The StaticArray/scalar paths remain allocation-free (AllocCheck run locally, including with `tracking_abstol` active).
- **Explicit user tolerances win:** a user-passed `abstol` **or** `reltol` (solve kwarg or problem kwarg) disables the loosening entirely. Splicing a loose `abstol` next to a user `reltol` would let the loose criterion fire first in the default OR-combined termination modes, silently overriding the user's intent.
- **Constructor validation** consistent with `tracking_maxiters`: must be positive, `nothing` disables.
- **Default is `nothing` (disabled).** Loose interior iterates slightly degrade the secant/quality signals the step controller reads, and on trivial problems the two extra standalone solves (anchor + landing polish) can cost more wall time than the saved residual calls (see benchmarks), so the loosening stays opt-in.

## Benchmarks (Julia 1.12, `tracking_abstol = 1e-4` vs disabled)

| Problem | retcode tight→loose | resid calls tight | resid calls loose | time tight | time loose | final \|Δu\| |
|---|---|---|---|---|---|---|
| scalar monotone `u³-1-λ` (Newton inner) | Success → Success | 53 | 43 (−19%) | 2.88e-05 s | 4.85e-05 s (+68%) | 0 |
| scalar monotone (SimpleHomotopySweep) | Success → Success | 43 | 27 (−37%) | 5.63e-06 s | 3.65e-06 s (−35%) | 0 |
| S-curve `u³-3u = -3+6λ` (Newton inner) | MaxIters → Success | 746 | 98 (−87%) | 2.67e-04 s | 6.95e-05 s (−74%) | n/a |
| S-curve (SimpleHomotopySweep) | Success → Success | 76 | 64 (−16%) | 9.93e-06 s | 8.29e-06 s (−17%) | 0 |
| n=50 coupled cubic (Newton inner) | Success → Success | 1247 | 835 (−33%) | 1.31e-03 s | 8.27e-04 s (−37%) | 2.2e-16 |
| n=50 coupled cubic (default polyalg inner) | Success → Success | 2122 | 1442 (−32%) | 2.93e-03 s | 2.21e-03 s (−25%) | 2.2e-16 |

Honest notes on two rows:

- **Scalar HomotopySweep wall time goes up** despite fewer residual calls: the anchor's standalone solve and the landing re-polish each pay one full `solve` pipeline entry (~10 μs), which dominates a trivial scalar problem. The constant is amortized on anything nontrivial (n=50: −37% wall time). This is part of why the default is off — the feature targets problems where residual/Jacobian evaluations are the cost.
- **The S-curve row is a fold problem** (turning points at λ = 1/6, 5/6), which natural continuation fundamentally cannot round. Tight, the NewtonRaphson sweep burns 746 residual calls bisecting into the fold and fails with `MaxIters`; loose, the corrector branch-jumps across the fold and lands (verified at full tolerance by the exempt landing) on the correct λ=1 root. The Simple driver's tight baseline already branch-jumps the same way. Branch jumping at folds is inherent to natural continuation — `ArcLengthContinuation` remains the right tool there — but it's worth knowing the loose tolerance makes the jump more likely.

## Tests

`test/Core/homotopy_tolerance_tests__item1.jl` (registered in the Core group), covering for both drivers: (a) the final solution meets the full tolerance (residual < 1e-9 with `tracking_abstol = 1e-3`), (b) residual-call counts drop vs disabled (Ref-counter pattern per the effort tests, with generous margins over the measured reductions), (c) anchor exemption (zero-width span with a loose tolerance that provably stops far from the root standalone) and landing exemption (`nsteps = 1, adaptive = false` so the only step is the landing), (d) user `abstol`/`reltol` override at both solve and problem level (bitwise-identical call counts to disabled), (e) constructor validation. Also verified locally: all 231 Core homotopy tests, all 64 SimpleNonlinearSolve homotopy tests, and the SimpleNonlinearSolve AllocCheck homotopy tests (plus new AllocCheck runs with `tracking_abstol` enabled) pass.

## Follow-up

`ArcLengthContinuation` intentionally untouched — `lib/NonlinearSolveBase/src/arclength.jl` is churning in the open #1025. It gets the same loose-then-tight treatment in a follow-up PR once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)