### PR TITLE
ArcLengthContinuation: corrector cache parity with the sweep driver (#1020 P6, stacked on #1025)

### DIFF
--- a/lib/NonlinearSolveBase/src/arclength.jl
+++ b/lib/NonlinearSolveBase/src/arclength.jl
@@ -253,37 +253,53 @@ end
 
 @inline _theta_norm(x, wu, wλ, n) = sqrt(_theta_dot(x, x, wu, wλ, n))
 
+# ⟨τ, x - x0⟩_θ without materializing the difference. The corrector residual evaluates
+# this once per inner iteration with `x` possibly Dual-typed under the inner solver's
+# AD, so a temporary `x .- x0` would heap-allocate on every residual call; the loop
+# stays generic in the eltype (duals flow through the accumulator).
+@inline function _theta_dot_shifted(τ, x, x0, wu, wλ, n)
+    acc = zero(τ[1] * (x[1] - x0[1]))
+    @inbounds @simd for i in 1:n
+        acc += τ[i] * (x[i] - x0[i])
+    end
+    return wu * acc + wλ * (τ[n + 1] * (x[n + 1] - x0[n + 1]))
+end
+
 # Residual of the augmented (n+1) corrector system: the n homotopy equations stacked
 # with the scalar Keller pseudo-arclength constraint. A named struct (not a closure) so
 # the inner solver's compilation is reused across continuation steps. `f` is the raw
 # user homotopy `f(u, p, λ)` / `f(du, u, p, λ)`; `τ` and `xcur` are the (θ-metric unit)
-# predictor direction and the last accepted packed point `[u; λ]`; `ds` is the arclength
-# step and `wu`/`wλ` are the θ-metric weights, so the constraint row reads
+# predictor direction and the last accepted packed point `[u; λ]` — both alias STABLE
+# driver buffers that are updated in place between steps — and `ds` is a mutable field,
+# so the SAME residual (and the one inner-solver cache built around it) is reused for
+# every corrector attempt: advancing the continuation is a couple of buffer/field
+# writes, not a new function/problem/solver allocation (mirroring the sweep's
+# `FixLambda`). `wu`/`wλ` are the θ-metric weights, so the constraint row reads
 # ⟨τ, x - xcur⟩_θ = ds. The augmented variable is `x = [u; λ]`; the solver passes the
 # problem parameter `p` through (as for any `NonlinearProblem` residual) and it is
 # forwarded to the user homotopy.
-struct AugmentedHomotopy{F, V, T}
-    f::F
-    τ::V
-    xcur::V
+mutable struct AugmentedHomotopy{F, V, T}
+    const f::F
+    const τ::V
+    const xcur::V
     ds::T
-    n::Int
-    wu::T
-    wλ::T
+    const n::Int
+    const wu::T
+    const wλ::T
 end
 
 function (a::AugmentedHomotopy)(x, p)
-    u = x[1:(a.n)]
+    u = view(x, 1:(a.n))
     λ = x[a.n + 1]
     Hval = a.f(u, p, λ)
-    c = _theta_dot(a.τ, x .- a.xcur, a.wu, a.wλ, a.n) - a.ds
+    c = _theta_dot_shifted(a.τ, x, a.xcur, a.wu, a.wλ, a.n) - a.ds
     return vcat(Hval, c)
 end
 
 function (a::AugmentedHomotopy)(res, x, p)
     n = a.n
     a.f(view(res, 1:n), view(x, 1:n), p, x[n + 1])
-    res[n + 1] = _theta_dot(a.τ, x .- a.xcur, a.wu, a.wλ, n) - a.ds
+    res[n + 1] = _theta_dot_shifted(a.τ, x, a.xcur, a.wu, a.wλ, n) - a.ds
     return nothing
 end
 
@@ -669,9 +685,14 @@ function CommonSolve.solve(
 
     n = length(u)
     Tx = promote_type(eltype(u), λT)
-    pack(uvec, λval) = Tx[uvec..., λval]
-    xcur = pack(u, λ)
-    xprev = xcur                       # no history yet → secant falls back to pure-λ
+    # Packed current point `[u; λ]` and its predecessor: STABLE buffers written in
+    # place for the rest of the solve. `xcur` is aliased by the corrector residual
+    # built once below, so accepting a step copies through these buffers instead of
+    # rebinding them.
+    xcur = Vector{Tx}(undef, n + 1)
+    copyto!(view(xcur, 1:n), u)
+    xcur[n + 1] = λ
+    xprev = copy(xcur)                 # no history yet → secant falls back to pure-λ
     have_prev = false
 
     min_ds = alg.min_ds === nothing ? sqrt(eps(λT)) : λT(alg.min_ds)
@@ -691,7 +712,8 @@ function CommonSolve.solve(
     wu = θw / n
     wλ = one(Tx) - θw
     # pure-λ direction toward λend, unit in the θ metric (‖[0; a]‖_θ = √wλ·|a|).
-    τseed = pack(zeros(Tx, n), sλ / sqrt(wλ))
+    τseed = zeros(Tx, n + 1)
+    τseed[n + 1] = sλ / sqrt(wλ)
 
     use_tangent = alg.predictor === :tangent
     # Analytic path Jacobian assembled from the user's jac (nothing without one),
@@ -730,6 +752,41 @@ function CommonSolve.solve(
         prob.f.sparsity
     end
 
+    # ONE corrector residual/function/inner-solver cache, mirroring the sweep's cache
+    # driver: the residual reads the in-place-updated `τ`/`xcur` buffers and its `ds`
+    # is a mutable field, so each corrector attempt is a couple of buffer/field writes
+    # plus a `reinit!` with the new prediction — the inner solver's workspace (Newton
+    # state, Jacobian cache, linear-solve cache) is reused across every continuation
+    # step instead of being reconstructed. The residual is length n+1 and never
+    # in-place even for an iip homotopy — the constraint row has no user-facing
+    # buffer, so we always own it. `xpred` is handed to the cache and may be iterated
+    # in place when aliasing is forwarded; it is fully rewritten before every attempt.
+    # When the tracking cap is active it is baked into this cache — every corrector
+    # solve runs capped; the λ-fixed anchor above and the landing solves below are
+    # separate full-budget solves — and an explicit user `maxiters` always wins
+    # (`cap_active` is false in that case).
+    aug = AugmentedHomotopy(prob.f, τ, xcur, Tx(ds), n, wu, wλ)
+    augf = _arclength_augmented_function(
+        Val(iip), prob.f, aug, aug_jac, aug_proto, aug_sparsity
+    )
+    xpred = copy(xcur)
+    corr_cache = if cap_active
+        init(
+            NonlinearProblem{iip}(augf, xpred, prob.p), alg.inner, args...;
+            prob.kwargs..., kwargs..., maxiters = budget
+        )
+    else
+        init(
+            NonlinearProblem{iip}(augf, xpred, prob.p), alg.inner, args...;
+            prob.kwargs..., kwargs...
+        )
+    end
+    # Accepted-state buffers reused every step: `ubuf` receives the accepted u-block
+    # (the failure returns hand it out), `uland` the interpolated warm start of the
+    # λ-fixed landing solve.
+    ubuf = Vector{Tx}(undef, n)
+    uland = Vector{Tx}(undef, n)
+
     for _ in 1:(alg.maxsteps)
         # Predictor direction τ (θ-metric unit, length n+1).
         if use_tangent
@@ -751,29 +808,16 @@ function CommonSolve.solve(
             copyto!(τ, τseed)
         end
 
-        xpred = xcur .+ ds .* τ
-        aug = AugmentedHomotopy(prob.f, τ, xcur, Tx(ds), n, wu, wλ)
-        # length n+1; never in-place even for an iip homotopy — the constraint row has no
-        # user-facing buffer, so we always own the residual.
-        augf = _arclength_augmented_function(
-            Val(iip), prob.f, aug, aug_jac, aug_proto, aug_sparsity
-        )
-        corr_prob = NonlinearProblem{iip}(augf, copy(xpred), prob.p)
-        # The cap is spliced BEFORE the user kwargs so an explicit `maxiters` always
-        # wins (and `cap_active` is false in that case anyway).
-        last_sol = if cap_active
-            solve(
-                corr_prob, alg.inner, args...;
-                maxiters = budget, prob.kwargs..., kwargs...
-            )
-        else
-            solve(corr_prob, alg.inner, args...; prob.kwargs..., kwargs...)
-        end
+        @. xpred = xcur + ds * τ
+        aug.ds = Tx(ds)
+        SciMLBase.reinit!(corr_cache, xpred)
+        last_sol = CommonSolve.solve!(corr_cache)
 
         if SciMLBase.successful_retcode(last_sol)
             xnew = last_sol.u
-            chord = xnew .- xcur
-            nchord = _theta_norm(chord, wu, wλ, n)
+            # realized chord, built in the (currently free) secant scratch
+            @. tscratch = xnew - xcur
+            nchord = _theta_norm(tscratch, wu, wλ, n)
 
             # Curvature control: the realized step direction vs. the predictor measures the
             # path's turn. A large turn means either real high curvature or that the
@@ -783,7 +827,7 @@ function CommonSolve.solve(
             # history (its pure-λ bootstrap is legitimately misaligned with a sloped branch).
             trust = use_tangent || have_prev
             cosang = (trust && nchord > 0) ?
-                clamp(_theta_dot(τ, chord, wu, wλ, n) / nchord, -one(Tx), one(Tx)) :
+                clamp(_theta_dot(τ, tscratch, wu, wλ, n) / nchord, -one(Tx), one(Tx)) :
                 one(Tx)
             if trust && cosang < cos_reject && alg.adaptive && ds / 2 >= min_ds
                 ds = ds / 2
@@ -791,13 +835,17 @@ function CommonSolve.solve(
                 continue
             end
 
-            unew = xnew[1:n]
             λnew = xnew[n + 1]
             λold = λ
 
-            xprev = xcur
-            xcur = copy(xnew)
-            u = copy(unew)
+            # Accept: shift the packed history through the stable buffers (the
+            # corrector residual aliases `xcur`, so the buffers are copied through,
+            # never swapped or rebound) and keep the accepted u-block in `ubuf` for
+            # the failure returns.
+            copyto!(xprev, xcur)
+            copyto!(xcur, xnew)
+            copyto!(ubuf, view(xcur, 1:n))
+            u = ubuf
             λ = λnew
             have_prev = true
 
@@ -806,10 +854,9 @@ function CommonSolve.solve(
             if (λold - λend) * (λnew - λend) <= 0
                 denom = λnew - λold
                 frac = denom == 0 ? one(Tx) : Tx((λend - λold) / denom)
-                uprev = xprev[1:n]
-                uguess = uprev .+ frac .* (unew .- uprev)
+                @views @. uland = xprev[1:n] + frac * (xcur[1:n] - xprev[1:n])
                 final_sol = _arclength_fixed_solve(
-                    prob, alg.inner, uguess, λend, args...; kwargs...
+                    prob, alg.inner, uland, λend, args...; kwargs...
                 )
                 if SciMLBase.successful_retcode(final_sol)
                     return SciMLBase.build_solution(

--- a/test/Core/arclength_tests__item8.jl
+++ b/test/Core/arclength_tests__item8.jl
@@ -1,0 +1,62 @@
+using NonlinearSolve
+
+using SciMLBase
+
+# Per-step allocation regression for the corrector cache driver: the inner Newton
+# cache, its Jacobian cache, and the linear-solve cache are built ONCE and reused via
+# `reinit!`/`solve!` every continuation step, so post-warmup per-step allocation is
+# bounded by the inner solver's own iteration internals — rebuilding the corrector
+# problem/cache per step (the pre-cache behavior) costs several hundred KB per step at
+# n = 50 and blows well past these bounds.
+#
+# The measurement takes the SLOPE between two fixed-step runs of different lengths:
+# compile-time and one-time init allocations cancel, leaving pure per-step cost. The
+# in-place homotopy keeps the user residual allocation-free so the bound tracks the
+# driver, and `adaptive = false` with a tiny fixed ds makes the step count exactly
+# `maxsteps` (the run never brackets λend).
+nbig = 50
+function Hbig!(r, u, p, λ)
+    n = length(u)
+    for i in 1:n
+        acc = u[i]
+        i > 1 && (acc += 0.25 * u[i - 1])
+        i < n && (acc += 0.25 * u[i + 1])
+        r[i] = acc + λ * u[i]^3 - p.c[i]
+    end
+    return nothing
+end
+cbig = [1.0 + 0.25 * ((i > 1) + (i < nbig)) + 1.0 for i in 1:nbig]
+prob_big = HomotopyProblem(Hbig!, ones(nbig), (c = cbig,); λspan = (0.0, 1.0))
+
+function run_fixed(prob, predictor, N)
+    alg = ArcLengthContinuation(;
+        predictor, adaptive = false, initial_step_factor = 1.0e-4, maxsteps = N
+    )
+    return solve(prob, alg)
+end
+
+function per_step_bytes(prob, predictor; N1 = 50, N2 = 250)
+    sol = run_fixed(prob, predictor, 5)   # warm up compilation
+    @test sol.retcode == SciMLBase.ReturnCode.MaxIters
+    run_fixed(prob, predictor, 5)
+    GC.gc()
+    a1 = @allocated run_fixed(prob, predictor, N1)
+    GC.gc()
+    a2 = @allocated run_fixed(prob, predictor, N2)
+    return (a2 - a1) / (N2 - N1)
+end
+
+# Measured ≈ 56 KB (secant) / 77 KB (tangent) per step at n = 50 with the cache
+# driver — the default inner polyalgorithm's per-iteration internals (LU workspace,
+# quasi-Newton updates). The pre-cache driver measured ≈ 274 KB / 295 KB. Bounds sit
+# at roughly 2× the cached cost, well under half the uncached cost.
+@test per_step_bytes(prob_big, :secant) < 128_000
+@test per_step_bytes(prob_big, :tangent) < 160_000
+
+# the fixed-step measurement configuration must not change the answer: the standard
+# adaptive solve still lands on u = ones(n)
+for predictor in (:secant, :tangent)
+    sol = solve(prob_big, ArcLengthContinuation(; predictor))
+    @test SciMLBase.successful_retcode(sol)
+    @test maximum(abs, sol.u .- 1.0) < 1.0e-6
+end

--- a/test/Core/arclength_tests__item8.jl
+++ b/test/Core/arclength_tests__item8.jl
@@ -47,9 +47,15 @@ function per_step_bytes(prob, predictor; N1 = 50, N2 = 250)
 end
 
 # Measured ≈ 56 KB (secant) / 77 KB (tangent) per step at n = 50 with the cache
-# driver — the default inner polyalgorithm's per-iteration internals (LU workspace,
-# quasi-Newton updates). The pre-cache driver measured ≈ 274 KB / 295 KB. Bounds sit
-# at roughly 2× the cached cost, well under half the uncached cost.
+# driver; the driver's own glue profiles at < 1 KB/step. The remainder is the shared
+# Newton stack, attributed by Profile.Allocs: ~21.5 KB/step is LinearSolve's
+# `lu(A, check = false)` copy on refactorization (skippable via its in-place `lu!`
+# path, gated on `alias_A = true` at init — a `construct_linear_solver` follow-up,
+# not driver work), ~21.5 KB/step is Broyden's initial J⁻¹ (`maybe_pinv!!` does a
+# fresh `lu(A)`), and ~10 KB/step is Klement/termination internals of the default
+# inner polyalgorithm. The pre-cache driver measured ≈ 274 KB / 295 KB. Bounds sit
+# at roughly 2× the cached cost, well under half the uncached cost, and hold
+# regardless of whether the Newton-stack follow-ups land.
 @test per_step_bytes(prob_big, :secant) < 128_000
 @test per_step_bytes(prob_big, :tangent) < 160_000
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -142,6 +142,7 @@ else
             @time @safetestset "ArcLengthContinuation fails (no hang) on an unreachable target" include("Core/arclength_tests__item5.jl")
             @time @safetestset "ArcLengthContinuation tangent predictor" include("Core/arclength_tests__item6.jl")
             @time @safetestset "ArcLengthContinuation bordered tangent + θ-weighted metric" include("Core/arclength_tests__item7.jl")
+            @time @safetestset "ArcLengthContinuation corrector cache per-step allocations" include("Core/arclength_tests__item8.jl")
             @time @safetestset "Homotopy sweeps consume jac/jac_prototype/sparsity/colorvec" include("Core/homotopy_jac_tests__item1.jl")
             @time @safetestset "ArcLengthContinuation consumes jac/jac_prototype/sparsity/colorvec" include("Core/arclength_jac_tests__item1.jl")
             @time @safetestset "Homotopy tracking_maxiters caps interior corrector work" include("Core/homotopy_effort_tests__item1.jl")


### PR DESCRIPTION
~~Stacked on #1025.~~ **#1025 has merged**; this branch is rebased directly onto master and carries only its own commit. Full arclength suite (including the new allocation-regression test) re-run locally post-rebase: 153/153 pass.

**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

Part of #1020 (P6 — the remaining per-step allocation bulk in `ArcLengthContinuation`).

## What

The merged #1021 moved the bordered tangent solve into a preallocated workspace, but the arclength **corrector** still rebuilt its residual closure, `NonlinearProblem`, and inner-solver cache (Newton state + Jacobian cache + linear-solve cache) on every continuation step, plus a pile of glue temporaries (`vcat`/`copy`/broadcast temporaries in the predictor/accept/landing paths). The `HomotopySweep` driver already had the one-cache `reinit!`/`solve!` pattern; this PR gives the arclength corrector parity:

- `AugmentedHomotopy` becomes mutable-with-const-fields (mirroring the sweep's `FixLambda`): `τ`/`xcur` alias stable driver buffers updated in place, `ds` is a field write — the ONE residual (and the one inner-solver cache built around it at init) is reused for every corrector attempt.
- The Keller constraint row evaluates `⟨τ, x − x₀⟩_θ` via a new `_theta_dot_shifted` without materializing `x .- xcur` (that temporary heap-allocated on **every inner residual call**, in Dual eltype under the corrector's AD).
- Glue temporaries get preallocated buffers: `xpred`, the realized chord (reusing the secant scratch), the packed-history shift, the accepted u-block, the landing warm start; the splatting `pack()` helper is gone.
- When `tracking_maxiters` is active the cap is baked into the one cache (`reinit!` preserves `cache.maxiters`); the anchor and landing solves keep the user's full budget, exactly as before.

## Measured per-step allocations

n = 50 coupled cubic system (the `arclength_tests__item7.jl` benchmark), fixed-ds slope between 50- and 250-step runs, post-warmup, Julia 1.12:

| case | before | after |
|---|---|---|
| iip, secant | 274 KB | **56 KB** |
| iip, tangent | 295 KB | **77 KB** |
| oop, secant | 441 KB | **160 KB** |
| oop, tangent | 507 KB | **226 KB** |

The remainder is the inner polyalgorithm's own per-iteration internals (LinearSolve LU workspace, quasi-Newton update rules), which are shared with the sweep — `HomotopySweep` itself measures ~74 KB/step on the same problem, so the corrector driver is now at (slightly better than) sweep parity. The oop rows additionally carry the user residual's own `similar(u)` + `vcat` per call, inherent to oop.

## Tests

- All existing `test/Core/arclength*.jl` files pass **unmodified** (153 tests), plus the `homotopy_effort`/`homotopy_polyalg`/`homotopy_jac` suites that exercise `ArcLengthContinuation` (102 tests), run locally against this branch.
- New allocation-regression test `test/Core/arclength_tests__item8.jl` bounds the post-warmup per-step slope (secant < 128 KB, tangent < 160 KB — ~2× the cached cost, under half the uncached cost, so a per-step cache rebuild regression trips it with wide margin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)