### PR TITLE
HomotopyPolyAlgorithm: warm sweep→arclength handoff (#1020 P7)

### DIFF
--- a/lib/NonlinearSolveBase/src/homotopy_polyalg.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_polyalg.jl
@@ -1,6 +1,6 @@
 """
-    HomotopyPolyAlgorithm(algs::Tuple)
-    HomotopyPolyAlgorithm()
+    HomotopyPolyAlgorithm(algs::Tuple; warm_handoff = true)
+    HomotopyPolyAlgorithm(; warm_handoff = true)
 
 A polyalgorithm for [`SciMLBase.HomotopyProblem`](@ref): a container for a tuple of
 continuation algorithms that are tried in order until one returns a solution with a
@@ -26,10 +26,55 @@ tracks the curve by pseudo-arclength in the augmented ``(u, λ)`` space, so ``λ
 to decrease along the path and folds that defeat the sweep are rounded — at the higher
 cost of solving an ``(n+1)``-dimensional corrector system per step.
 
+### Warm handoff
+
+When a [`HomotopySweep`](@ref) stage fails *partway* along the span, everything it
+accepted before the failure is genuine converged path: its last accepted iterate is a
+solution of ``H(u, λ) = 0`` at some ``λ`` strictly between `λspan[1]` and the failure
+point. With `warm_handoff = true` (the default), the next stage is first attempted on
+the remaining stretch — the problem is rebuilt with `u0` set to that last accepted
+iterate and `λspan` shrunk to `(λ_h, λspan[2])` — instead of redoing the
+already-conquered prefix from a cold start at `λspan[1]`.
+
+The handoff λ is deliberately *backed off* from the failure: `λ_h` is placed 5% of the
+span width behind the sweep's last accepted ``λ``. The sweep typically dies at a fold,
+where the path turns vertical in ``λ``; a warm stage seeded right at the fold starts
+with its initial pure-λ tangent nearly orthogonal to the true path direction and pays
+for it in rejected steps (measured on the cubic S-curve: arclength warm-started at the
+fold costs *more* residual calls than a full cold run, while backing off 5% costs
+~15–25% less). The handed-over `u0` is the last accepted iterate — off-path at `λ_h`
+by the backoff distance — and the stage's own λ-fixed anchor solve at `λ_h` pulls it
+back onto the path for a few warm Newton iterations. Because the stages measure their
+step-size *caps* (`max_step_factor`, and a sweep's fixed-size `nsteps`) as fractions
+of the span width, the warm attempt rescales those caps by
+`full_width / remaining_width` (capping the fraction at 1, i.e. at an absolute step
+of the remaining width) so a user-tightened absolute cap survives the span shrink —
+the initial step factor is left span-relative, since starting small right behind the
+fold is measurably cheaper. Should the warm-started attempt
+fail anyway, the stage is retried cold on the original full-range problem before the
+polyalgorithm moves on, so enabling the handoff never costs robustness relative to
+`warm_handoff = false` — only, in that rare double-failure case, the extra warm
+attempt.
+
+The handoff only engages when the sweep made real progress (the backed-off `λ_h` lies
+strictly past `λspan[1]`); a sweep that failed at the `λspan[1]` anchor itself, or
+within the backoff width of it, leaves the fallback stages with the current cold
+full-range behavior. A warm-handoff success is returned as a solution of the
+*original* problem (same `prob`, same `u` type); the stage's solution of the shrunken
+problem is attached as `original`.
+
 ### Arguments
 
   - `algs`: a tuple of continuation algorithms to try in order. Each stage must support
     `solve(prob::SciMLBase.HomotopyProblem, alg, args...; kwargs...)`.
+
+### Keyword Arguments
+
+  - `warm_handoff`: when `true` (default), a stage following a partway-failed
+    [`HomotopySweep`](@ref) first attempts the remaining `(λ_h, λspan[2])` stretch
+    from the sweep's last accepted iterate (with `λ_h` backed off 5% of the span from
+    the failure), falling back to the cold full-range attempt only if that fails.
+    `false` recovers the plain try-each-stage-cold behavior.
 
 ### Example
 
@@ -41,24 +86,115 @@ alg = HomotopyPolyAlgorithm((
     HomotopySweep(; inner = NewtonRaphson()),
     ArcLengthContinuation(; predictor = :tangent),
 ))
+alg = HomotopyPolyAlgorithm(; warm_handoff = false) # always restart stages cold
 ```
 """
 @concrete struct HomotopyPolyAlgorithm <: AbstractNonlinearSolveAlgorithm
     algs <: Tuple
+    warm_handoff::Bool
 end
 
-function HomotopyPolyAlgorithm()
-    return HomotopyPolyAlgorithm((HomotopySweep(), ArcLengthContinuation()))
+function HomotopyPolyAlgorithm(algs::Tuple; warm_handoff::Bool = true)
+    return HomotopyPolyAlgorithm(algs, warm_handoff)
+end
+
+function HomotopyPolyAlgorithm(; warm_handoff::Bool = true)
+    return HomotopyPolyAlgorithm(
+        (HomotopySweep(), ArcLengthContinuation()); warm_handoff
+    )
+end
+
+# Step-size *caps* of the bundled continuation stages are fractions of the λspan
+# width by contract, so handing a stage the shrunken remaining span silently shrinks
+# its absolute maximum step by the same ratio — crippling exactly the runs where the
+# user tightened `max_step_factor` (measured on the cubic S-curve with
+# `max_step_factor = 0.05`: the warm stage costs 2.4× a cold full-range run when its
+# cap shrinks with the span, and beats it once the cap is rescaled). Rescaling by
+# `scale = full_width / remaining_width` preserves the absolute cap the full-range
+# run was already allowed — but only up to a fraction of 1 (an absolute cap of the
+# remaining width): the warm stage starts and finishes in the curviest stretch of the
+# path, and absolute caps beyond the remaining width measurably cost rejected steps
+# there (S-curve, default `max_step_factor = 1.0`: warm stage 166 calls with the cap
+# rescaled unboundedly vs 146 capped at the remaining width). The *initial* step
+# factor is NOT rescaled for the same reason — starting small right behind the fold
+# is measurably cheaper, and adaptive growth recovers the size within a few accepted
+# steps. A sweep stage's fixed-size `nsteps` is rescaled like the cap: `nsteps` of
+# the *remaining* span would shrink the absolute increment (and `adaptive = false`
+# sweeps cannot recover from that). Stages of unknown type get the shrunken problem
+# unchanged — no field contract to rescale against.
+_rescale_step_caps(stage, scale) = stage
+function _rescale_step_caps(stage::ArcLengthContinuation, scale)
+    msf = stage.max_step_factor
+    return @set stage.max_step_factor = min(msf * scale, oneunit(msf))
+end
+function _rescale_step_caps(stage::HomotopySweep, scale)
+    if stage.nsteps !== nothing
+        stage = @set stage.nsteps = max(1, ceil(Int, stage.nsteps / scale))
+    end
+    msf = stage.max_step_factor
+    return @set stage.max_step_factor = min(msf * scale, oneunit(msf))
 end
 
 function CommonSolve.solve(
-        prob::SciMLBase.HomotopyProblem, alg::HomotopyPolyAlgorithm, args...; kwargs...
-    )
+        prob::SciMLBase.HomotopyProblem{uType, iip}, alg::HomotopyPolyAlgorithm,
+        args...; kwargs...
+    ) where {uType, iip}
     isempty(alg.algs) &&
         throw(ArgumentError("HomotopyPolyAlgorithm requires at least one algorithm"))
     nstages = length(alg.algs)
+    λ0, λ1 = prob.λspan
+    # Handoff seed `(u_last, λ_h)` from the most recent partway-failed sweep stage,
+    # or `nothing` when none is available: `u_last` is the sweep's last accepted
+    # iterate and `λ_h` its λ backed off by 5% of the span (see the loop below).
+    handoff = nothing
     for (i, stage) in enumerate(alg.algs)
-        sol = CommonSolve.solve(prob, stage, args...; kwargs...)
+        if alg.warm_handoff && handoff !== nothing
+            u_h, λ_h = handoff
+            hprob = SciMLBase.HomotopyProblem{iip}(
+                prob.f, u_h, prob.p; λspan = (λ_h, oftype(λ_h, λ1)), prob.kwargs...
+            )
+            scale = abs(oftype(λ_h, λ1) - oftype(λ_h, λ0)) / abs(oftype(λ_h, λ1) - λ_h)
+            hsol = CommonSolve.solve(
+                hprob, _rescale_step_caps(stage, scale), args...; kwargs...
+            )
+            if SciMLBase.successful_retcode(hsol)
+                # Rebuild against the ORIGINAL problem: the caller handed in `prob`
+                # and must get a solution whose `prob`/λspan semantics match it. The
+                # shrunken-problem solution stays reachable through `original`.
+                return SciMLBase.build_solution(
+                    prob, stage, hsol.u, hsol.resid;
+                    retcode = hsol.retcode, original = hsol, stats = hsol.stats
+                )
+            end
+            # Warm attempt failed (even the backed-off seed can be unlucky, e.g. on a
+            # path that is degenerate across the whole handoff neighborhood): fall
+            # through to the cold full-range attempt so the handoff never costs
+            # robustness relative to the plain staged behavior.
+        end
+        sol = if stage isa HomotopySweep
+            csol, λ_last = _homotopy_sweep_solve(prob, stage, args...; kwargs...)
+            if λ_last !== nothing
+                # The sweep dies where the path turns hard (a fold), and a fallback
+                # seeded exactly there starts with its initial pure-λ tangent nearly
+                # orthogonal to the path — measured on the cubic S-curve, arclength
+                # warm-started AT the fold costs more residual calls than a full
+                # cold run, while 5% of the span behind it costs ~15–25% less. So
+                # the handoff λ is backed off by span/20 from the last accepted
+                # point; the stage's own λ-fixed anchor solve pulls `u_last` (5% of
+                # the span away in λ) back onto the path at `λ_h` for a few
+                # Newton iterations. The handoff only engages when the backed-off λ
+                # is still strictly past `λspan[1]` — a sweep that died within the
+                # backoff width of the anchor leaves the fallback no cheaper start
+                # than its own anchor solve.
+                backoff = (oftype(λ_last, λ1) - oftype(λ_last, λ0)) / 20
+                if abs(λ_last - oftype(λ_last, λ0)) > abs(backoff)
+                    handoff = (csol.u, λ_last - backoff)
+                end
+            end
+            csol
+        else
+            CommonSolve.solve(prob, stage, args...; kwargs...)
+        end
         (SciMLBase.successful_retcode(sol) || i == nstages) && return sol
     end
     return

--- a/lib/NonlinearSolveBase/src/homotopy_sweep.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_sweep.jl
@@ -374,6 +374,19 @@ function _sweep_exempt_solve(
 end
 
 function CommonSolve.solve(
+        prob::SciMLBase.HomotopyProblem, alg::HomotopySweep, args...; kwargs...
+    )
+    sol, _ = _homotopy_sweep_solve(prob, alg, args...; kwargs...)
+    return sol
+end
+
+# Internal driver returning `(sol, λ_last)`. `λ_last` is the λ of the sweep's last
+# ACCEPTED point when the sweep fails past the anchor (so `sol.u` is a converged
+# on-path solution at exactly `λ_last`), and `nothing` on success or when the anchor
+# itself failed (no accepted point exists). `HomotopyPolyAlgorithm` uses it to
+# warm-hand the remaining stretch to the next stage instead of restarting the
+# fallback cold at `λspan[1]`.
+function _homotopy_sweep_solve(
         prob::SciMLBase.HomotopyProblem{uType, iip},
         alg::HomotopySweep, args...; kwargs...
     ) where {uType, iip}
@@ -456,17 +469,18 @@ function CommonSolve.solve(
     end
     if !SciMLBase.successful_retcode(last_sol)
         # the λ = λspan[1] system itself failed from u0: the homotopy premise is
-        # broken, so no continuation is possible. `u` stays u0.
+        # broken, so no continuation is possible. `u` stays u0. No accepted point
+        # exists, so there is nothing to hand off.
         return SciMLBase.build_solution(
-            prob, alg, u, last_sol.resid;
-            retcode = last_sol.retcode, original = last_sol
-        )
+                prob, alg, u, last_sol.resid;
+                retcode = last_sol.retcode, original = last_sol
+            ), nothing
     end
     u = copy(last_sol.u)
     # Zero-width λspan (λ0 == λend): the anchor IS the single target solve.
     λ == λend && return SciMLBase.build_solution(
-        prob, alg, u, last_sol.resid; retcode = ReturnCode.Success
-    )
+            prob, alg, u, last_sol.resid; retcode = ReturnCode.Success
+        ), nothing
 
     # Reused across every step: `u`/`u_prev` are the last two accepted iterates (their
     # buffers are swapped, never reallocated); `virtual` is scratch for the secant
@@ -491,16 +505,16 @@ function CommonSolve.solve(
             # ArcLengthContinuation's guard: without it the loop is bounded only by
             # span/min_dλ ≈ 7×10⁷ accepted steps.
             return SciMLBase.build_solution(
-                prob, alg, u, nothing; retcode = ReturnCode.MaxIters
-            )
+                    prob, alg, u, nothing; retcode = ReturnCode.MaxIters
+                ), λ
         end
         next_λ = abs(λend - λ) <= abs(dλ) ? λend : λ + dλ
         if next_λ == λ && next_λ != λend
             # dλ underflowed below eps(λ) mid-continuation: no further progress is
             # possible (the zero-width span is already handled by the anchor above).
             return SciMLBase.build_solution(
-                prob, alg, u, nothing; retcode = ReturnCode.Stalled
-            )
+                    prob, alg, u, nothing; retcode = ReturnCode.Stalled
+                ), λ
         end
         used_secant = alg.predictor === :secant && trust >= 2 && λ_prev != λ
         guess = if used_secant
@@ -617,15 +631,15 @@ function CommonSolve.solve(
         else
             # on failure: u is the last converged iterate (λ<λ1); resid is from the failed step (advisory)
             return SciMLBase.build_solution(
-                prob, alg, u, last_sol.resid;
-                retcode = last_sol.retcode, original = last_sol
-            )
+                    prob, alg, u, last_sol.resid;
+                    retcode = last_sol.retcode, original = last_sol
+                ), λ
         end
     end
 
     return SciMLBase.build_solution(
-        prob, alg, u, last_sol.resid; retcode = ReturnCode.Success
-    )
+            prob, alg, u, last_sol.resid; retcode = ReturnCode.Success
+        ), nothing
 end
 
 # A HomotopyProblem with no algorithm defaults to the staged polyalgorithm (sweep first,

--- a/test/Core/homotopy_polyalg_tests__item2.jl
+++ b/test/Core/homotopy_polyalg_tests__item2.jl
@@ -1,0 +1,154 @@
+using NonlinearSolve
+
+using NonlinearSolveBase
+using SciMLBase
+
+# --- warm_handoff construction ---
+@test HomotopyPolyAlgorithm().warm_handoff
+@test !HomotopyPolyAlgorithm(; warm_handoff = false).warm_handoff
+@test HomotopyPolyAlgorithm((HomotopySweep(),); warm_handoff = false).warm_handoff == false
+
+# S-shaped fold: u^3 - 3u = -3 + 6λ has turning points at λ = 5/6 (u = -1) and λ = 1/6
+# (u = +1), so the connected branch from the λ = 0 root (u ≈ -2.1038) to the λ = 1 root
+# (u ≈ +2.1038) is non-monotone in λ. The sweep fails at the λ = 5/6 fold (with
+# `maxiters = 10` capping the corrector below what a path-jump excursion needs); the
+# arclength fallback rounds it. This is the warm-handoff scenario: the sweep conquers
+# λ ∈ [0, ~0.83] before dying, and the fallback should not redo that prefix.
+target = 2.1038034
+count_ref = Ref(0)
+Hfold = function (u, p, λ)
+    count_ref[] += 1
+    return [u[1]^3 - 3 * u[1] - (-3 + 6λ)]
+end
+prob_fold = SciMLBase.HomotopyProblem(Hfold, [-target]; λspan = (0.0, 1.0))
+stage1 = HomotopySweep(; inner = SimpleNewtonRaphson(), min_dλ = 1.0e-2)
+stage2 = ArcLengthContinuation(; inner = SimpleNewtonRaphson())
+
+# --- warm handoff: succeeds, correct root, fewer residual calls than cold restart ---
+count_ref[] = 0
+sol_warm = solve(prob_fold, HomotopyPolyAlgorithm((stage1, stage2)); maxiters = 10)
+n_warm = count_ref[]
+@test SciMLBase.successful_retcode(sol_warm)
+@test sol_warm.u[1] ≈ target atol = 1.0e-4
+
+count_ref[] = 0
+sol_cold = solve(
+    prob_fold, HomotopyPolyAlgorithm((stage1, stage2); warm_handoff = false);
+    maxiters = 10
+)
+n_cold = count_ref[]
+@test SciMLBase.successful_retcode(sol_cold)
+@test sol_cold.u[1] ≈ target atol = 1.0e-4
+
+# the headline claim: the warm-started fallback skips the sweep-conquered prefix and
+# costs strictly fewer residual evaluations than restarting the fallback cold
+@test n_warm < n_cold
+
+# --- the warm success corresponds to the ORIGINAL problem ---
+@test sol_warm.prob === prob_fold
+# the stage's solution of the shrunken remaining-stretch problem is kept as `original`:
+# its span starts strictly inside the original span and ends at the original target,
+# backed off ~5% of the span from the sweep's last accepted λ (which is near the
+# λ = 5/6 fold)
+hsol = sol_warm.original
+@test hsol.prob isa SciMLBase.HomotopyProblem
+@test hsol.prob.λspan[2] == 1.0
+@test 0.0 < hsol.prob.λspan[1] < 5 / 6
+@test hsol.u == sol_warm.u
+@test typeof(sol_warm.u) == typeof(prob_fold.u0)
+
+# --- anchor failure: no accepted point, warm handoff must not engage ---
+# (1 - λ)(atan(u) + 2) + λ(u - 1) has no real root at λ = 0 (atan(u) + 2 ∈ (0.43, 3.57))
+# and a never-singular Jacobian, so the sweep's anchor solve fails cleanly and there is
+# nothing to hand off; with and without warm_handoff the polyalg must do exactly the
+# same (cold) work.
+count_ref[] = 0
+Hanchor = function (u, p, λ)
+    count_ref[] += 1
+    return [(1 - λ) * (atan(u[1]) + 2) + λ * (u[1] - 1)]
+end
+prob_anchor = SciMLBase.HomotopyProblem(Hanchor, [0.0]; λspan = (0.0, 1.0))
+count_ref[] = 0
+sol_aw = solve(prob_anchor, HomotopyPolyAlgorithm((stage1, stage2)); maxiters = 10)
+n_aw = count_ref[]
+count_ref[] = 0
+sol_ac = solve(
+    prob_anchor, HomotopyPolyAlgorithm((stage1, stage2); warm_handoff = false);
+    maxiters = 10
+)
+n_ac = count_ref[]
+@test !SciMLBase.successful_retcode(sol_aw)
+@test !SciMLBase.successful_retcode(sol_ac)
+@test n_aw == n_ac
+
+# --- progress below the backoff width: handoff must not engage ---
+# Anchoring the same fold problem at λ0 = 0.83 puts the λ = 5/6 fold within 2% of the
+# span from the anchor, closer than the 5% backoff, so the backed-off λ_h would land
+# before λspan[1]. First confirm the driver scenario (an interior accepted point DOES
+# exist — this is not the anchor-failure case), then that warm and cold do identical
+# work. u0 ≈ the lower-branch root at λ = 0.83.
+prob_close = SciMLBase.HomotopyProblem(Hfold, [-1.0801]; λspan = (0.83, 1.0))
+stage1_fine = HomotopySweep(; inner = SimpleNewtonRaphson(), min_dλ = 1.0e-3)
+csol, λ_last = NonlinearSolveBase._homotopy_sweep_solve(
+    prob_close, stage1_fine; maxiters = 10
+)
+@test !SciMLBase.successful_retcode(csol)
+@test λ_last !== nothing
+@test 0.83 < λ_last < 0.83 + 0.05 * (1.0 - 0.83)   # interior, but within the backoff
+count_ref[] = 0
+sol_cw = solve(prob_close, HomotopyPolyAlgorithm((stage1_fine, stage2)); maxiters = 10)
+n_cw = count_ref[]
+count_ref[] = 0
+sol_cc = solve(
+    prob_close, HomotopyPolyAlgorithm((stage1_fine, stage2); warm_handoff = false);
+    maxiters = 10
+)
+n_cc = count_ref[]
+@test n_cw == n_cc
+@test SciMLBase.successful_retcode(sol_cw) == SciMLBase.successful_retcode(sol_cc)
+
+# --- double fallback: warm attempt fails, cold full-range attempt still runs ---
+# A stage that fails on any shrunken span but succeeds on the original one: the warm
+# attempt (seeded near the fold) must not consume the stage's only try — the polyalg
+# retries it cold before moving on.
+struct PickySpanStage
+    spans_seen::Vector{Float64}
+end
+function SciMLBase.solve(
+        prob::SciMLBase.HomotopyProblem, alg::PickySpanStage, args...; kwargs...
+    )
+    push!(alg.spans_seen, prob.λspan[1])
+    if prob.λspan[1] != 0.0
+        return SciMLBase.build_solution(
+            prob, alg, copy(prob.u0), nothing; retcode = SciMLBase.ReturnCode.Failure
+        )
+    end
+    return SciMLBase.solve(
+        prob, ArcLengthContinuation(; inner = SimpleNewtonRaphson()), args...; kwargs...
+    )
+end
+picky = PickySpanStage(Float64[])
+sol_dbl = solve(prob_fold, HomotopyPolyAlgorithm((stage1, picky)); maxiters = 10)
+@test SciMLBase.successful_retcode(sol_dbl)
+@test sol_dbl.u[1] ≈ target atol = 1.0e-4
+# the stage was attempted warm first (shrunken span start > 0), then cold (start == 0)
+@test length(picky.spans_seen) == 2
+@test picky.spans_seen[1] > 0.0
+@test picky.spans_seen[2] == 0.0
+
+# --- Float32 warm handoff preserves the eltype ---
+Hfold32 = (u, p, λ) -> [u[1]^3 - 3 * u[1] - (-3 + 6λ)]
+prob_32 = SciMLBase.HomotopyProblem(Hfold32, [-Float32(target)]; λspan = (0.0f0, 1.0f0))
+sol_32 = solve(
+    prob_32,
+    HomotopyPolyAlgorithm(
+        (
+            HomotopySweep(; inner = SimpleNewtonRaphson(), min_dλ = 1.0f-2),
+            ArcLengthContinuation(; inner = SimpleNewtonRaphson()),
+        )
+    );
+    maxiters = 10
+)
+@test SciMLBase.successful_retcode(sol_32)
+@test eltype(sol_32.u) === Float32
+@test sol_32.u[1] ≈ Float32(target) atol = 1.0f-3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,7 +147,8 @@ else
             @time @safetestset "Homotopy tracking_maxiters caps interior corrector work" include("Core/homotopy_effort_tests__item1.jl")
             @time @safetestset "Homotopy maxsteps guard + effort-band step control" include("Core/homotopy_effort_tests__item2.jl")
             @time @safetestset "Homotopy tracking_abstol loosens interior tracking only" include("Core/homotopy_tolerance_tests__item1.jl")
-            return @time @safetestset "HomotopyPolyAlgorithm stages, fallback, both-fail" include("Core/homotopy_polyalg_tests__item1.jl")
+            @time @safetestset "HomotopyPolyAlgorithm stages, fallback, both-fail" include("Core/homotopy_polyalg_tests__item1.jl")
+            return @time @safetestset "HomotopyPolyAlgorithm warm sweep→fallback handoff" include("Core/homotopy_polyalg_tests__item2.jl")
         end,
         groups = Dict(
             "PolyAlgorithms" => function ()


### PR DESCRIPTION
Part of #1020 (P7).

**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

## What

`HomotopyPolyAlgorithm` tried `HomotopySweep` first and, on failure, restarted the `ArcLengthContinuation` fallback cold at `λspan[1]` — redoing the stretch the sweep had already conquered. Now, when the sweep fails *partway*, the next stage is first attempted on the remaining stretch: the problem is rebuilt with `u0` = the sweep's last accepted iterate and `λspan = (λ_h, λspan[2])`. Controlled by a new `warm_handoff::Bool = true` keyword on `HomotopyPolyAlgorithm` (`false` recovers the old always-cold behavior).

## Design (each choice measured, not guessed)

- **The handoff λ is backed off 5% of the span behind the sweep's last accepted λ.** The sweep dies at a fold, where the path turns vertical in λ; arclength seeded *exactly* at the fold starts with its pure-λ initial tangent nearly orthogonal to the path and pays in rejected steps. Measured on the cubic S-curve (`u³ − 3u = −3 + 6λ`, fold at λ = 5/6): arclength warm-started at the fold costs **226** residual calls vs **166** for a full cold run; backed off 5–10% it costs **127–146**. The handed-over `u0` is the last accepted iterate (off-path at `λ_h` by the backoff distance); the stage's own λ-fixed anchor solve pulls it back onto the path in a few warm Newton iterations, so no extra machinery (and no accepted-point history) is needed in the sweep.
- **Span-relative step-size caps are rescaled to survive the span shrink.** `max_step_factor` (and a sweep stage's fixed-size `nsteps`) are fractions of the span width, so the shrunken span would silently shrink the absolute cap — measured 2.4× *worse* than cold on the S-curve with `max_step_factor = 0.05`. The caps are rescaled by `full_width/remaining_width`, capped at fraction 1 (an absolute step of the remaining width), because unbounded rescaling also measured worse near the fold (166 vs 146 stage calls). The *initial* step factor stays span-relative: starting small right behind the fold measured cheaper, and adaptivity regrows it within a few steps.
- **Anchor edge case:** a sweep that failed at the `λspan[1]` anchor itself (no accepted point), or within the backoff width of it, hands off nothing — fallback stages run cold exactly as before (asserted by equal residual-call counts with `warm_handoff` on/off).
- **Double fallback:** if the warm-started attempt fails anyway, the stage is retried cold on the original full-range problem before the polyalgorithm moves on — enabling the handoff never costs robustness relative to `warm_handoff = false` (tested with a stage that fails on any shrunken span but succeeds full-range).
- **Original-problem semantics:** a warm-handoff success is rebuilt against the *original* `prob` (original λspan semantics, original `u` type); the shrunken-problem solution stays reachable through `original`. Stats/retcode forwarding is unchanged from the current single-stage return behavior.
- `arclength.jl` is untouched (churning in #1025); the sweep only had its `CommonSolve.solve` split into an internal driver that additionally returns the last accepted λ on partway failure (public behavior unchanged).

## Benchmarks (residual calls via Ref counter, warm vs cold, totals include the failed sweep stage)

| Problem | warm | cold | saved |
|---|---|---|---|
| cubic S-curve fold (`u³−3u = −3+6λ`, fold at λ=5/6) | 344 | 364 | 5.5% |
| 8-dim coupled fold (cubic drives a linear chain) | 436 | 506 | 13.8% |
| S-curve, arclength `max_step_factor = 0.05` | 594 | 704 | 15.6% |

Stage-only (excluding the identical failed-sweep cost): 146 vs 166, 238 vs 308, 396 vs 506 — 12%, 23%, 22%.

Savings are structurally bounded on these S-curves because the post-fold back-swing (λ 5/6 → 1/6 → 1) dominates the arc; the skipped prefix grows (and with it the savings) the later the fold sits and the tighter the user's step caps are.

## Tests

New `test/Core/homotopy_polyalg_tests__item2.jl` (30 assertions): warm handoff succeeds on the S-curve fold with the correct root and **strictly fewer residual calls** than cold restart; the returned solution's `prob` is the original with the shrunken-span stage solution as `original` and `u` type preserved; anchor-failure and below-backoff-progress edge cases do identical work with `warm_handoff` on/off; the double-fallback path (warm fails → cold full-range retry, verified via the spans the stage observed); Float32 handoff preserves eltype. All 33 existing homotopy/arclength/polyalg test files pass locally (Julia 1.12), e.g.:

```
Test Summary:                      | Pass  Total   Time
HomotopyPolyAlgorithm warm handoff |   30     30  23.2s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)