### PR TITLE
Rename fold solution variable for spellcheck

### DIFF
--- a/test/Core/homotopy_effort_tests__item2.jl
+++ b/test/Core/homotopy_effort_tests__item2.jl
@@ -64,7 +64,7 @@ target = 2.1038034
 Hf(u, p, λ) = [u[1]^3 - 3 * u[1] - (-3 + 6λ)]
 probf = HomotopyProblem(Hf, [-target]; λspan = (0.0, 1.0))
 for tm in (100, 20)
-    solf = solve(probf, ArcLengthContinuation(; tracking_maxiters = tm))
-    @test SciMLBase.successful_retcode(solf)
-    @test solf.u[1] ≈ target atol = 1.0e-4
+    fold_solution = solve(probf, ArcLengthContinuation(; tracking_maxiters = tm))
+    @test SciMLBase.successful_retcode(fold_solution)
+    @test fold_solution.u[1] ≈ target atol = 1.0e-4
 end


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## Summary

- Rename the fold-continuation test result from `solf` to `fold_solution`.
- Preserve the test behavior while satisfying typos-cli 1.48.0 without an allowlist or skipped check.

## Root cause

On clean master `c22bc9482254f58461cfa48361b739628f9087ab`, typos-cli 1.48.0 reports `solf` at `test/Core/homotopy_effort_tests__item2.jl:67-69`.

A clean-worktree `git bisect run` identified `611cdf895a4ebc5e55e4d59fc552ee64889ea4b3` as the first bad commit. Its parent `b704340349f0ed9014d108fca0b94c2d357e14a5` is good because the test file did not yet exist; the introducing commit creates the file with the flagged identifier.

This failure is unrelated to #1013, whose diff only touches the NonlinearSolveBase Enzyme extension.

## Validation

- `timeout 3600 /home/crackauc/sandbox/tmp_20260708_165650_11549/tools/typos-v1.48.0/typos`
  - Exit 0, no findings.
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1 --project=@runic -e 'using Runic; exit(Runic.main(["--check", "--diff", "."]))'`
  - Exit 0, no formatting diff.
- `timeout 3600 env GROUP=Core /home/crackauc/.juliaup/bin/julia +1 --project=. -e 'using Pkg; Pkg.test(; coverage=false)'`
  - `Homotopy maxsteps guard + effort-band step control | 19/19`
  - Ends with `Testing NonlinearSolve tests passed`.
- `git diff --check`
  - Exit 0.
