### PR TITLE
Release prep: bump NonlinearSolveBase 2.34.0, SimpleNonlinearSolve 2.13.0, NonlinearSolve 4.20.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.20.3"
+version = "4.20.4"
 authors = ["SciML"]
 
 [deps]

--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.33.0"
+version = "2.34.0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/SimpleNonlinearSolve/Project.toml
+++ b/lib/SimpleNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleNonlinearSolve"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 authors = ["SciML"]
-version = "2.12.1"
+version = "2.13.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

The registered versions predate the recently merged homotopy work, so none of it is releasable without bumps:

| package | registered | this PR | why |
|---|---|---|---|
| NonlinearSolveBase | 2.33.0 (2026-07-06) | **2.34.0** | #1021 bordered tangent/θ-metric, #1022/#1025 derivative fields, #1024 tracking_maxiters/effort bands, #1028 `tracking_abstol`, #1029 corrector cache parity — new public API ⇒ minor |
| SimpleNonlinearSolve | 2.12.1 | **2.13.0** | #1024/#1028 added `tracking_maxiters`/`tracking_abstol` to `SimpleHomotopySweep` ⇒ minor |
| NonlinearSolve | 4.20.3 | **4.20.4** | #1027 raised the SciMLBase compat floor to 3.34 ⇒ patch |

Inter-package compat floors (NLSB `2.31`/`2.20`, Simple `2.10`) already admit the new versions — no compat edits needed. Suggested registration order after merge: NonlinearSolveBase (subdir), then SimpleNonlinearSolve (subdir), then NonlinearSolve. Registration itself needs @ChrisRackauckas — JuliaRegistrator rejects the agent account (not a public SciML member).

🤖 Generated with [Claude Code](https://claude.com/claude-code)