### PR TITLE
Fix NonlinearSolveBase QA: import ArrayInterface via its owner in SparseArrays ext

### DIFF
--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseSparseArraysExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseSparseArraysExt.jl
@@ -1,5 +1,6 @@
 module NonlinearSolveBaseSparseArraysExt
 
+using ArrayInterface: ArrayInterface
 using SparseArrays: AbstractSparseMatrix, AbstractSparseMatrixCSC, nonzeros, sparse
 
 using NonlinearSolveBase: NonlinearSolveBase, Utils
@@ -22,7 +23,7 @@ happen to be zero can silently lose pattern entries that sparse AD coloring need
 Going through `findstructralnz` makes the conversion value-independent for every type.
 """
 function Utils.structural_sparse(x::AbstractMatrix)
-    rows, cols = NonlinearSolveBase.ArrayInterface.findstructralnz(x)
+    rows, cols = ArrayInterface.findstructralnz(x)
     # indexed comprehensions, not collect: the structured-matrix index iterators
     # (e.g. ArrayInterface.TridiagonalIndex) advertise eltype Any and fail collect
     I = Int[rows[k] for k in 1:length(rows)]

--- a/lib/NonlinearSolveBase/test/qa/qa.jl
+++ b/lib/NonlinearSolveBase/test/qa/qa.jl
@@ -38,10 +38,10 @@ run_qa(
         #   Base: add_sum;  Core(.Compiler): Compiler, return_type;  LinearAlgebra: inv!
         #   FunctionWrappers: FunctionWrapper
         #   NonlinearSolveBase(.Utils/.InternalAPI): additional_incompatible_backend_check,
-        #     condition_number, get_raw_f, get_u, make_sparse, maybe_pinv!!_workspace,
-        #     maybe_symmetric, nlls_generate_vjp_function, nodual_value,
-        #     nonlinearsolve_∂f_∂p, nonlinearsolve_∂f_∂u, reinit!, restructure, safe_reshape,
-        #     safe_similar, sparse_or_structured_prototype
+        #     condition_number, get_raw_f, get_u, is_extension_loaded, make_sparse,
+        #     maybe_pinv!!_workspace, maybe_symmetric, nlls_generate_vjp_function,
+        #     nodual_value, nonlinearsolve_∂f_∂p, nonlinearsolve_∂f_∂u, reinit!, restructure,
+        #     safe_reshape, safe_similar, sparse_or_structured_prototype, structural_sparse
         all_qualified_accesses_are_public = (;
             ignore = (
                 :ChainRulesOriginator, :DAEInitializationAlgorithm, :EnzymeOriginator,
@@ -51,11 +51,12 @@ run_qa(
                 :Dual, :Partials, :Tag, :can_dual, :derivative, :gradient, :jacobian,
                 :partials, :pickchunksize, :value, :add_sum, :Compiler, :return_type, :inv!,
                 :FunctionWrapper, :additional_incompatible_backend_check, :condition_number,
-                :get_raw_f, :get_u, :make_sparse, Symbol("maybe_pinv!!_workspace"),
+                :get_raw_f, :get_u, :is_extension_loaded, :make_sparse,
+                Symbol("maybe_pinv!!_workspace"),
                 :maybe_symmetric, :nlls_generate_vjp_function, :nodual_value,
                 Symbol("nonlinearsolve_∂f_∂p"), Symbol("nonlinearsolve_∂f_∂u"),
                 :reinit!, :restructure, :safe_reshape, :safe_similar,
-                :sparse_or_structured_prototype,
+                :sparse_or_structured_prototype, :structural_sparse,
             ),
         ),
         # Still non-public in their owning packages. AbstractODEIntegrator / __init /


### PR DESCRIPTION
**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

## Problem

`GROUP=QA julia +1.11 -e 'using Pkg; Pkg.activate("lib/NonlinearSolveBase"); Pkg.test()'` errors on master (reproduced on 3f64085d with Julia 1.11.9, SciMLTesting 1.8.0, ExplicitImports 1.15.0, Aqua 0.8.16, ArrayInterface 7.27.0): **15 passed, 2 errored**.

```
all_qualified_accesses_via_owners: QualifiedAccessesFromNonOwnerException
- `ArrayInterface` has owner `ArrayInterface` but it was accessed from `NonlinearSolveBase`
  at ext/NonlinearSolveBaseSparseArraysExt.jl:25:37

all_qualified_accesses_are_public: NonPublicQualifiedAccessException
- `ArrayInterface` is not public in `NonlinearSolveBase` (same location)
- `is_extension_loaded` is not public in `NonlinearSolveBase.Utils` (line 11:7)
- `structural_sparse` is not public in `NonlinearSolveBase.Utils` (line 24:16)
```

## Bisect

Introduced by **7ff32391** ("ArcLengthContinuation: consume jac/jac_prototype/sparsity/colorvec", PR #1025), which added `Utils.structural_sparse` (containing the `NonlinearSolveBase.ArrayInterface.findstructralnz` access) and `Utils.is_extension_loaded(::Val{:SparseArrays})` to the SparseArrays extension. Verified with today's dependency versions: the parent commit f9444faf passes QA **17/17** in the identical environment, so this is a repo regression, not a new ExplicitImports/SciMLTesting release.

## Fix

- `ext/NonlinearSolveBaseSparseArraysExt.jl`: `using ArrayInterface: ArrayInterface` (a hard dep of NonlinearSolveBase; the ForwardDiff and LinearSolve extensions already import it this way) and call `ArrayInterface.findstructralnz` directly. `findstructralnz` is declared public in ArrayInterface 7.26+, so this satisfies both the owner and publicness checks with no ignore entry.
- `test/qa/qa.jl`: add `:is_extension_loaded` and `:structural_sparse` to the existing `all_qualified_accesses_are_public` per-name ignore list. These are NonlinearSolveBase's own internal extension hooks defined via qualified `Utils.` names — exactly the pattern of the sibling hooks (`make_sparse`, `condition_number`, `maybe_symmetric`, `maybe_pinv!!_workspace`, `sparse_or_structured_prototype`) already on that list. No checks weakened, no `ei_broken`.

## Verification (run locally on this branch)

- `GROUP=QA` NonlinearSolveBase: **17/17 pass** ("Testing NonlinearSolveBase tests passed")
- `GROUP=Core` NonlinearSolveBase: all pass ("Testing NonlinearSolveBase tests passed")

Changed files were Runic-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)