### PR TITLE
Inner-algorithm retention for the homotopy continuation drivers (sticky polyalg rung + lazy reinit!)

### DIFF
--- a/lib/NonlinearSolveBase/src/arclength.jl
+++ b/lib/NonlinearSolveBase/src/arclength.jl
@@ -76,6 +76,11 @@ Keyword arguments:
 
   - `inner`: the inner nonlinear algorithm used for both the initial on-curve correction
     and the augmented corrector; `nothing` selects NonlinearSolve's default polyalgorithm.
+    A polyalgorithm inner runs the augmented corrector with best-subalgorithm retention
+    (see [`NonlinearSolvePolyAlgorithm`](@ref)): after the first corrector solve
+    discovers the winning subalgorithm, each warm-started corrector resumes from it
+    instead of re-running the ladder from its start, escalating only when it fails. The
+    λ-fixed anchor and landing solves always run the full ladder.
   - `initial_step_factor`: the initial arclength step `Δs` as a fraction of the `λspan`
     width. Must be in `(0, 1]`.
   - `adaptive`: when `true` (default), a corrector failure halves `Δs` and retries from
@@ -810,7 +815,11 @@ function CommonSolve.solve(
 
         @. xpred = xcur + ds * τ
         aug.ds = Tx(ds)
-        SciMLBase.reinit!(corr_cache, xpred)
+        # Retaining reinit!: a polyalgorithm inner resumes from the subalgorithm that
+        # won the previous corrector solve (the first corrector runs the full ladder
+        # and discovers the winner) instead of re-failing the cheaper ladder members
+        # on every warm-started step.
+        reinit_retaining!(corr_cache, xpred)
         last_sol = CommonSolve.solve!(corr_cache)
 
         if SciMLBase.successful_retcode(last_sol)

--- a/lib/NonlinearSolveBase/src/homotopy_sweep.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_sweep.jl
@@ -17,7 +17,13 @@ The inner solver is initialized once and re-driven each step through the
 `init`/`reinit!`/`solve!` cache interface, so the continuation loop reuses the inner
 solver's workspace (Jacobian buffers, linear-solver storage) instead of reconstructing
 the solver every step; the sweep's own per-step state lives in a fixed set of
-preallocated buffers.
+preallocated buffers. When the inner solver is a polyalgorithm (as the default is),
+the warm-started tracking steps additionally arm best-subalgorithm retention on that
+cache (see [`NonlinearSolvePolyAlgorithm`](@ref)): each step resumes from the
+subalgorithm that produced the previous step's success instead of re-running the
+polyalgorithm ladder from its start, escalating (and eventually wrapping around) only
+when the retained subalgorithm fails. The cold anchor solve at `λspan[1]` always runs
+the full ladder — that is where the winning subalgorithm is discovered.
 
 Optional derivative fields of the problem's `NonlinearFunction` (which
 [`SciMLBase.HomotopyProblem`](@ref) requires to follow the same λ-extended argument
@@ -526,7 +532,10 @@ function _homotopy_sweep_solve(
             _sweep_warmstart!(guess, u)
         end
         fixλ.λ = next_λ
-        SciMLBase.reinit!(cache, guess)
+        # Retaining reinit!: a polyalgorithm inner resumes from the subalgorithm that
+        # won the previous solve (the anchor's full-ladder run discovers the winner)
+        # instead of re-failing the cheaper ladder members on every warm-started step.
+        reinit_retaining!(cache, guess)
         last_sol = CommonSolve.solve!(cache)
 
         if next_λ == λend

--- a/lib/NonlinearSolveBase/src/polyalg.jl
+++ b/lib/NonlinearSolveBase/src/polyalg.jl
@@ -26,6 +26,41 @@ using NonlinearSolve
 
 alg = NonlinearSolvePolyAlgorithm((NewtonRaphson(), Broyden()))
 ```
+
+### Best-subalgorithm retention (`reinit!(cache; retain_best = true)`)
+
+When the polyalgorithm's cache is reused across a sequence of warm-started solves
+(`init`/`reinit!`/`solve!`), each `reinit!` by default restarts the ladder at
+`start_index`, so every solve re-fails the same cheap subalgorithms before reaching
+the one that works. Passing `retain_best = true` to `reinit!` makes the next `solve!`
+start from the subalgorithm that produced the most recent success instead. Escalation
+is preserved: if that subalgorithm fails, the ladder continues upward as usual, and
+once the last subalgorithm fails it wraps around to the subalgorithms that were
+skipped at the start (they occasionally succeed where the retained one stagnates), so
+retention never tries fewer subalgorithms than a full ladder run. When no success has
+been recorded yet, `retain_best = true` starts the ladder at `start_index` as usual.
+The default (`retain_best = false`) is the status-quo full restart.
+
+The wrap-around never goes below the algorithm's `start_index`, so retention never
+attempts a subalgorithm the algorithm itself excludes.
+
+Retention periodically *re-probes* the skipped cheaper subalgorithms: when the
+retained subalgorithm sits above `start_index`, every
+`RETAIN_REPROBE_INTERVAL`-th (8th) retained `reinit!` starts one solve from
+`start_index` again. A cheap subalgorithm that failed once transiently (escalating
+`best` to an expensive one that then always succeeds) is therefore rediscovered
+instead of being locked out for the rest of the warm-started sequence, at a bounded
+cost of at most one status-quo-style ladder step per interval.
+
+A `retain_best = true` `reinit!` also reinitializes the subalgorithm caches *lazily*:
+only the starting subalgorithm's cache is reinitialized up front, and each further
+one is reinitialized at the moment escalation reaches it. Since every subcache
+`reinit!` evaluates the residual at the new `u0`, this reduces the per-`reinit!`
+residual cost from one evaluation per subalgorithm to one per subalgorithm actually
+attempted (usually just the retained one). A consequence is that the shared `stats`
+of a solution produced after mid-solve escalation only reflect the subalgorithms run
+since the last deferred reinitialization, i.e. effectively the winning subalgorithm's
+own effort.
 """
 @concrete struct NonlinearSolvePolyAlgorithm <: AbstractNonlinearSolveAlgorithm
     static_length <: Val
@@ -50,6 +85,19 @@ end
     best::Int
     current::Int
     nsteps::Int
+
+    # Best-subalgorithm retention (see the algorithm docstring): `retain_best` arms it
+    # for the next solve, `start_current` records where that solve's ladder started
+    # (so wrap-around knows where the already-attempted stretch begins), and `wrapped`
+    # marks that the ladder already wrapped past the end back to index 1.
+    # `deferred_u0`/`deferred_p` carry the `reinit!` arguments for the subcaches whose
+    # reinitialization was deferred until escalation reaches them.
+    retain_best::Bool
+    start_current::Int
+    wrapped::Bool
+    retain_count::Int
+    deferred_u0
+    deferred_p
 
     stats::NLStats
     total_time::Float64
@@ -115,16 +163,67 @@ end
 function SciMLBase.reinit!(cache::NonlinearSolvePolyAlgorithmCache, u0; kwargs...)
     return InternalAPI.reinit!(cache; u0, kwargs...)
 end
+# Every RETAIN_REPROBE_INTERVAL-th retained `reinit!` whose retained subalgorithm sits
+# above `start_index` starts one solve from `start_index` again instead. Without this,
+# a single transient failure of a cheap subalgorithm escalates `best` to an expensive
+# one that then succeeds on every later warm-started solve, locking the cheap winner
+# out forever (measured: a near-linear n = 100 sweep where Broyden/Klement steady-state
+# beats Newton ran ~2x slower under pure sticky-best than under the full-restart status
+# quo). The re-probe rediscovers the cheaper subalgorithm at a bounded cost: at most
+# one status-quo-style ladder step per interval.
+const RETAIN_REPROBE_INTERVAL = 8
+
 function InternalAPI.reinit!(
-        cache::NonlinearSolvePolyAlgorithmCache, args...; p = cache.prob.p, u0 = cache.u0
+        cache::NonlinearSolvePolyAlgorithmCache, args...; p = cache.prob.p, u0 = cache.u0,
+        retain_best::Bool = false
     )
-    foreach(cache.caches) do cache
-        InternalAPI.reinit!(cache, args...; u = get_u(cache), p, u0)
+    cache.retain_best = retain_best
+    cache.retain_count = retain_best ? cache.retain_count + 1 : 0
+    retained = retain_best && 1 ≤ cache.best ≤ Utils.unwrap_val(cache.static_length)
+    reprobe = retained && cache.best > cache.alg.start_index &&
+        cache.retain_count % RETAIN_REPROBE_INTERVAL == 0
+    cache.current = (retained && !reprobe) ? cache.best : cache.alg.start_index
+    cache.start_current = cache.current
+    cache.wrapped = false
+    if retain_best
+        # Lazy subcache reinitialization: every subcache `reinit!` evaluates the
+        # residual at the new `u0` (`Utils.reinit_common!`), so eagerly
+        # reinitializing all N subcaches costs N residual calls per warm-started
+        # solve even though a retained solve usually runs only the starting
+        # subalgorithm. Reinitialize just that one here and defer the rest to the
+        # moment escalation actually reaches them (`deferred_subcache_reinit!`).
+        cache.deferred_u0 = u0
+        cache.deferred_p = p
+        subcache = cache.caches[cache.current]
+        InternalAPI.reinit!(subcache, args...; u = get_u(subcache), p, u0)
+    else
+        foreach(cache.caches) do cache
+            InternalAPI.reinit!(cache, args...; u = get_u(cache), p, u0)
+        end
     end
-    cache.current = cache.alg.start_index
     InternalAPI.reinit!(cache.stats)
     cache.nsteps = 0
     return cache.total_time = 0.0
+end
+
+# Reinitializes a subcache whose reinitialization was deferred by a
+# `retain_best = true` `reinit!`, at the moment ladder escalation reaches it.
+# Mirrors the kwargs of the eager loop in `reinit!` above.
+function deferred_subcache_reinit!(cache::NonlinearSolvePolyAlgorithmCache, subcache)
+    InternalAPI.reinit!(
+        subcache; u = get_u(subcache), p = cache.deferred_p, u0 = cache.deferred_u0
+    )
+    return nothing
+end
+
+# `reinit!` with best-subalgorithm retention when the cache supports it (see the
+# `NonlinearSolvePolyAlgorithm` docstring), a plain `reinit!` otherwise. The
+# continuation drivers call this on their warm-started tracking steps so the inner
+# default polyalgorithm resumes from the subalgorithm that won the previous step
+# instead of re-failing the cheaper ones every step.
+reinit_retaining!(cache, u0) = SciMLBase.reinit!(cache, u0)
+function reinit_retaining!(cache::NonlinearSolvePolyAlgorithmCache, u0)
+    return SciMLBase.reinit!(cache, u0; retain_best = true)
 end
 
 function SciMLBase.__init(
@@ -170,7 +269,8 @@ function SciMLBase.__init(
                 initializealg = SciMLBase.NoInit(), kwargs...
             )
         end,
-        alg, -1, alg.start_index, 0, stats, 0.0, maxtime,
+        alg, -1, alg.start_index, 0, false, alg.start_index, false, 0, u0, prob.p,
+        stats, 0.0, maxtime,
         ReturnCode.Default, false, maxiters, internalnorm,
         u0, u0_aliased, alias_u0, initializealg, verbose
     )
@@ -199,8 +299,25 @@ end
                             cache.best = $(i)
                             cache.force_stop = true
                             cache.retcode = $(cache_syms[i]).retcode
+                        elseif cache.wrapped && $(i + 1) ≥ cache.start_current
+                            # a wrapped-around ladder stops where the original
+                            # (retained) start already ran; every subalgorithm has
+                            # now been attempted
+                            minfu, idx = findmin_caches(cache.prob, cache.caches)
+                            cache.best = idx
+                            cache.retcode = cache.caches[idx].retcode
+                            cache.force_stop = true
                         else
                             cache.current = $(i + 1)
+                            $(
+                                i == N ? :(nothing) : quote
+                                        if cache.retain_best
+                                            deferred_subcache_reinit!(
+                                                cache, cache.caches[$(i + 1)]
+                                            )
+                                    end
+                                    end
+                            )
                         end
                     end
                     return
@@ -212,6 +329,16 @@ end
     push!(
         calls, quote
             if !(1 ≤ cache.current ≤ length(cache.caches))
+                if cache.retain_best && !cache.wrapped &&
+                        cache.start_current > cache.alg.start_index
+                    # retention started the ladder mid-way; wrap around to the
+                    # skipped cheaper subalgorithms (never below the algorithm's own
+                    # `start_index`) before giving up
+                    cache.wrapped = true
+                    cache.current = cache.alg.start_index
+                    deferred_subcache_reinit!(cache, cache.caches[cache.current])
+                    return
+                end
                 minfu, idx = findmin_caches(cache.prob, cache.caches)
                 cache.best = idx
                 cache.retcode = cache.caches[idx].retcode

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -383,34 +383,77 @@ end
         end
     )
 
+    # The per-subalgorithm attempt body, shared by the normal in-order pass and the
+    # retention wrap-around pass below (`cache_syms[i]` is assigned unconditionally in
+    # the first pass, and a given `i` runs in at most one of the two passes, so the
+    # `sol`/`u_result` symbols can be shared).
+    attempt_block = i -> quote
+        if cache.retain_best && $(i) != cache.start_current
+            # a `retain_best` reinit! only reinitialized the starting subcache;
+            # escalation freshens each further subcache right before its attempt
+            deferred_subcache_reinit!(cache, $(cache_syms[i]))
+        end
+        cache.alias_u0 && copyto!(cache.u0_aliased, cache.u0)
+        $(sol_syms[i]) = CommonSolve.solve!($(cache_syms[i]))
+        if SciMLBase.successful_retcode($(sol_syms[i]))
+            stats = $(sol_syms[i]).stats
+            cache.best = $(i)
+            if cache.alias_u0
+                copyto!(cache.u0, $(sol_syms[i]).u)
+                $(u_result_syms[i]) = cache.u0::_uType
+            else
+                $(u_result_syms[i]) = $(sol_syms[i]).u::_uType
+            end
+            fu = NonlinearSolveBase.get_fu($(cache_syms[i]))::_fuType
+            return build_solution_less_specialize(
+                cache.prob, cache.alg, $(u_result_syms[i]), fu;
+                retcode = $(sol_syms[i]).retcode, stats,
+                original = $(sol_syms[i]), trace = ($(sol_syms[i]).trace::_traceType),
+                store_original = cache.alg.store_original
+            )
+        elseif cache.alias_u0
+            # For safety we need to maintain a copy of the solution
+            $(u_result_syms[i]) = copy($(sol_syms[i]).u)
+        end
+        cache.current = $(i + 1)
+    end
+
     for i in 1:N
         push!(
             calls,
             quote
                 $(cache_syms[i]) = cache.caches[$(i)]
                 if $(i) == cache.current
-                    cache.alias_u0 && copyto!(cache.u0_aliased, cache.u0)
-                    $(sol_syms[i]) = CommonSolve.solve!($(cache_syms[i]))
-                    if SciMLBase.successful_retcode($(sol_syms[i]))
-                        stats = $(sol_syms[i]).stats
-                        if cache.alias_u0
-                            copyto!(cache.u0, $(sol_syms[i]).u)
-                            $(u_result_syms[i]) = cache.u0::_uType
-                        else
-                            $(u_result_syms[i]) = $(sol_syms[i]).u::_uType
-                        end
-                        fu = NonlinearSolveBase.get_fu($(cache_syms[i]))::_fuType
-                        return build_solution_less_specialize(
-                            cache.prob, cache.alg, $(u_result_syms[i]), fu;
-                            retcode = $(sol_syms[i]).retcode, stats,
-                            original = $(sol_syms[i]), trace = ($(sol_syms[i]).trace::_traceType),
-                            store_original = cache.alg.store_original
-                        )
-                    elseif cache.alias_u0
-                        # For safety we need to maintain a copy of the solution
-                        $(u_result_syms[i]) = copy($(sol_syms[i]).u)
-                    end
-                    cache.current = $(i + 1)
+                    $(attempt_block(i))
+                end
+            end
+        )
+    end
+
+    # Retention wrap-around (see the `NonlinearSolvePolyAlgorithm` docstring): when
+    # `reinit!` armed `retain_best` and the retained subalgorithm's ladder started
+    # past the algorithm's own `start_index`, a fully-failed pass continues with the
+    # skipped cheaper subalgorithms before falling through to the lowest-residual
+    # selection. The wrapped pass starts at `start_index` (never below it — retention
+    # must not attempt subalgorithms the algorithm itself excludes) and stops where
+    # the retained start already ran, so every subalgorithm of a full ladder run is
+    # attempted exactly once.
+    push!(
+        calls,
+        quote
+            if cache.retain_best && !cache.wrapped &&
+                    cache.start_current > cache.alg.start_index
+                cache.wrapped = true
+                cache.current = cache.alg.start_index
+            end
+        end
+    )
+    for i in 1:(N - 1)
+        push!(
+            calls,
+            quote
+                if cache.wrapped && $(i) == cache.current && $(i) < cache.start_current
+                    $(attempt_block(i))
                 end
             end
         )

--- a/test/Core/homotopy_retention_tests__item1.jl
+++ b/test/Core/homotopy_retention_tests__item1.jl
@@ -1,0 +1,99 @@
+# Driver-level inner-algorithm retention: the homotopy continuation drivers reuse one
+# inner cache across warm-started steps and arm best-subalgorithm retention on their
+# tracking reinit!s, so a polyalgorithm inner (the default) no longer re-fails its
+# cheap rungs — nor pays a full-ladder reinit! — on every continuation step.
+using NonlinearSolve, SciMLBase
+
+using Test
+
+const NF = Ref(0)
+
+function count_nf(prob, alg)
+    NF[] = 0
+    sol = solve(prob, alg)
+    return sol, NF[]
+end
+
+# n = 50 coupled cubic with u = ones(n) solving λ = 1: the post-#1029 benchmark
+# problem where the default inner used to cost ~1.65x a plain NewtonRaphson inner
+# (2295 vs 1400 residual calls; 1577 with retention).
+const N = 50
+function coupled_cubic!(du, u, p, λ)
+    NF[] += 1
+    n = length(u)
+    for i in 1:n
+        c = 2.0 + 0.25 * (i > 1) + 0.25 * (i < n)
+        du[i] = u[i] + 0.25 * (i > 1 ? u[i - 1] : 0.0) +
+            0.25 * (i < n ? u[i + 1] : 0.0) + λ * u[i]^3 - c
+    end
+    return nothing
+end
+
+@testset "sweep: default inner stays close to a Newton inner (n = 50)" begin
+    prob = HomotopyProblem{true}(coupled_cubic!, ones(N), nothing; λspan = (0.0, 1.0))
+    sol_d, nf_d = count_nf(prob, HomotopySweep())
+    sol_n, nf_n = count_nf(prob, HomotopySweep(; inner = NewtonRaphson()))
+    @test SciMLBase.successful_retcode(sol_d)
+    @test SciMLBase.successful_retcode(sol_n)
+    @test sol_d.u ≈ ones(N) atol = 1.0e-6
+    # measured 1577 vs 1400 (1.13x) with retention, 2295 (1.64x) without; the
+    # generous margin only trips when retention regresses
+    @test nf_d ≤ 1.35 * nf_n
+end
+
+@testset "sweep: default inner stays close to a Newton inner (scalar)" begin
+    H(u, p, λ) = (NF[] += 1; [(1 - λ) * (u[1] - 4.0) + λ * (u[1]^2 - 4.0)])
+    prob = HomotopyProblem(H, [4.0], nothing; λspan = (0.0, 1.0))
+    sol_d, nf_d = count_nf(prob, HomotopySweep())
+    sol_n, nf_n = count_nf(prob, HomotopySweep(; inner = NewtonRaphson()))
+    @test SciMLBase.successful_retcode(sol_d)
+    @test SciMLBase.successful_retcode(sol_n)
+    @test sol_d.u[1] ≈ 2.0 atol = 1.0e-6
+    # measured 94 vs 86 (1.09x) with retention, 150 (1.74x) without
+    @test nf_d ≤ 1.3 * nf_n
+end
+
+@testset "arclength: retention on the augmented corrector cache" begin
+    H(u, p, λ) = (NF[] += 1; [u[1]^3 - 3u[1] - (-3 + 6λ)])
+    prob = HomotopyProblem(H, [-2.1038034], nothing; λspan = (0.0, 1.0))
+    sol_d, nf_d = count_nf(prob, ArcLengthContinuation())
+    sol_n, nf_n = count_nf(prob, ArcLengthContinuation(; inner = NewtonRaphson()))
+    @test SciMLBase.successful_retcode(sol_d)
+    @test SciMLBase.successful_retcode(sol_n)
+    @test sol_d.u[1] ≈ sol_n.u[1] atol = 1.0e-6
+    # measured 267 vs 188 (1.42x) with retention, 381 (2.03x) without; the corrector
+    # fails repeatedly while rounding the fold, and each polyalgorithm failure runs
+    # its whole ladder, so parity with a bare Newton inner is not reachable here
+    @test nf_d ≤ 1.7 * nf_n
+end
+
+@testset "anchor still runs the full ladder" begin
+    # The λspan[1] anchor is the one cold-start solve: Newton stalls from u0 = 0
+    # (singular Jacobian at the origin), so the anchor only succeeds if the inner
+    # ladder escalates to Broyden there. Retention on the interior steps then starts
+    # from the anchor's winner.
+    H(u, p, λ) = [u[1]^3 - 2.0 - λ]
+    prob = HomotopyProblem(H, [0.0], nothing; λspan = (0.0, 1.0))
+    inner = NonlinearSolvePolyAlgorithm((NewtonRaphson(), Broyden()))
+    sol = solve(prob, HomotopySweep(; inner))
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[1] ≈ cbrt(3.0) atol = 1.0e-6
+end
+
+@testset "sticky-rung failure mid-continuation escalates and the sweep still lands" begin
+    # Difficulty jump: past λ = 0.5 the residual reports NaN to any non-Float64
+    # (dual) evaluation, so the retained Jacobian-based rung (NewtonRaphson) fails
+    # every corrector there while the identity-initialized derivative-free Broyden
+    # rung still converges — the sweep only lands if escalation keeps working on
+    # retained steps. The path u = 2 + λ itself stays smooth and easy.
+    function gated(u, p, λ)
+        bad = λ > 0.5 && !(u[1] isa Float64)
+        r = u[1] - 2.0 - λ
+        return [bad ? oftype(r, NaN) : r]
+    end
+    prob = HomotopyProblem(gated, [2.0], nothing; λspan = (0.0, 1.0))
+    inner = NonlinearSolvePolyAlgorithm((NewtonRaphson(), Broyden()))
+    sol = solve(prob, HomotopySweep(; inner))
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[1] ≈ 3.0 atol = 1.0e-6
+end

--- a/test/Core/polyalg_retention_tests__item1.jl
+++ b/test/Core/polyalg_retention_tests__item1.jl
@@ -1,0 +1,125 @@
+# Best-subalgorithm retention on the NonlinearSolvePolyAlgorithm cache
+# (`reinit!(cache; retain_best = true)`): sticky start on the last winner, lazy
+# subcache reinitialization, upward escalation, wrap-around floored at the
+# algorithm's `start_index`, and exact status-quo behavior when retention is off.
+using NonlinearSolve, SciMLBase
+
+using Test
+
+# Residual-call counter shared by every subalgorithm of the polyalgorithm (AD dual
+# evaluations count too, which is fine: the assertions below are either exact reinit!
+# counts or generous bounds).
+const NF = Ref(0)
+fcubic(u, p) = (NF[] += 1; u .^ 3 .- 2.0)
+const ROOT = cbrt(2.0)
+
+# Subalgorithm behaviors this file relies on (verified standalone): NewtonRaphson
+# succeeds from u0 = 100 but stalls from u0 = 0 (singular Jacobian at the origin);
+# Broyden (identity-initialized, derivative-free) succeeds from 0, 1.2, and 100.
+
+@testset "retention picks the winning subalgorithm on the next solve" begin
+    alg = NonlinearSolvePolyAlgorithm((NewtonRaphson(), Broyden()))
+    prob = NonlinearProblem(fcubic, [0.0])
+    cache = init(prob, alg)
+    sol1 = solve!(cache)
+    @test SciMLBase.successful_retcode(sol1)
+    @test cache.best == 2      # Newton stalled at the singular point; Broyden won
+    newton_nsteps = cache.caches[1].nsteps
+    @test newton_nsteps > 0    # Newton was attempted before Broyden
+
+    # Lazy reinit: a retaining reinit! reinitializes ONLY the retained subcache
+    NF[] = 0
+    reinit!(cache, [1.2]; retain_best = true)
+    @test cache.current == 2
+    @test NF[] == 1            # one residual evaluation, not one per subalgorithm
+
+    NF[] = 0
+    sol2 = solve!(cache)
+    @test SciMLBase.successful_retcode(sol2)
+    @test sol2.u[1] ≈ ROOT atol = 1.0e-6
+    @test cache.best == 2
+    # Newton's subcache was neither reinitialized nor stepped again
+    @test cache.caches[1].nsteps == newton_nsteps
+    # warm Broyden alone; generous bound, far below a Newton-then-Broyden rerun
+    @test NF[] ≤ 15
+end
+
+@testset "escalation continues up the ladder when the sticky rung fails" begin
+    alg = NonlinearSolvePolyAlgorithm((NewtonRaphson(), Broyden()))
+    prob = NonlinearProblem(fcubic, [100.0])
+    cache = init(prob, alg)
+    sol1 = solve!(cache)
+    @test SciMLBase.successful_retcode(sol1)
+    @test cache.best == 1                  # Newton wins from 100
+    reinit!(cache, [0.0]; retain_best = true)
+    @test cache.current == 1
+    sol2 = solve!(cache)                   # Newton stalls at 0 → escalate to Broyden
+    @test SciMLBase.successful_retcode(sol2)
+    @test sol2.u[1] ≈ ROOT atol = 1.0e-6
+    @test cache.best == 2
+end
+
+@testset "wrap-around reaches the skipped cheaper rungs" begin
+    alg = NonlinearSolvePolyAlgorithm((Broyden(), NewtonRaphson()))
+    prob = NonlinearProblem(fcubic, [0.0])
+    cache = init(prob, alg)
+    # simulate a previous solve won by the LAST rung, as a continuation driver
+    # retaining Newton across steps would have it
+    cache.best = 2
+    reinit!(cache, [0.0]; retain_best = true)
+    @test cache.current == 2
+    sol = solve!(cache)      # Newton stalls at 0 → ladder exhausted → wrap to rung 1
+    @test cache.wrapped
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[1] ≈ ROOT atol = 1.0e-6
+    @test cache.best == 1
+end
+
+@testset "wrap-around never goes below the algorithm's start_index" begin
+    alg = NonlinearSolvePolyAlgorithm((Broyden(), NewtonRaphson()); start_index = 2)
+    prob = NonlinearProblem(fcubic, [0.0])
+    cache = init(prob, alg)
+    cache.best = 2
+    reinit!(cache, [0.0]; retain_best = true)
+    @test cache.current == 2
+    sol = solve!(cache)
+    # Newton stalls and rung 1 is excluded by start_index: no wrap, failed solve
+    @test !cache.wrapped
+    @test !SciMLBase.successful_retcode(sol)
+    @test cache.caches[1].nsteps == 0     # Broyden was never attempted
+end
+
+@testset "periodic re-probe rediscovers a cheaper subalgorithm" begin
+    alg = NonlinearSolvePolyAlgorithm((Broyden(), NewtonRaphson()))
+    prob = NonlinearProblem(fcubic, [1.2])
+    cache = init(prob, alg)
+    cache.best = 2     # as if Newton had rescued a transient Broyden failure earlier
+    for k in 1:7
+        reinit!(cache, [1.2]; retain_best = true)
+        @test cache.current == 2         # sticky on the retained rung
+    end
+    reinit!(cache, [1.2]; retain_best = true)    # 8th retained reinit! re-probes
+    @test cache.current == 1
+    sol = solve!(cache)
+    @test SciMLBase.successful_retcode(sol)
+    @test cache.best == 1     # Broyden won the re-probe and is retained again
+    reinit!(cache, [1.2]; retain_best = true)
+    @test cache.current == 1
+end
+
+@testset "retention off is the status-quo full restart" begin
+    alg = NonlinearSolvePolyAlgorithm((NewtonRaphson(), Broyden()))
+    prob = NonlinearProblem(fcubic, [0.0])
+    cache = init(prob, alg)
+    sol1 = solve!(cache)
+    @test SciMLBase.successful_retcode(sol1)
+    @test cache.best == 2
+    NF[] = 0
+    reinit!(cache, [1.2])                  # plain reinit!: no retention
+    @test cache.current == 1               # ladder restarts at start_index
+    @test cache.retain_best == false
+    @test NF[] == 2                        # every subcache reinitialized eagerly
+    sol2 = solve!(cache)
+    @test SciMLBase.successful_retcode(sol2)
+    @test sol2.u[1] ≈ ROOT atol = 1.0e-6
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -148,6 +148,8 @@ else
             @time @safetestset "Homotopy tracking_maxiters caps interior corrector work" include("Core/homotopy_effort_tests__item1.jl")
             @time @safetestset "Homotopy maxsteps guard + effort-band step control" include("Core/homotopy_effort_tests__item2.jl")
             @time @safetestset "Homotopy tracking_abstol loosens interior tracking only" include("Core/homotopy_tolerance_tests__item1.jl")
+            @time @safetestset "PolyAlgorithm best-subalgorithm retention (reinit! retain_best)" include("Core/polyalg_retention_tests__item1.jl")
+            @time @safetestset "Homotopy drivers retain the winning inner subalgorithm" include("Core/homotopy_retention_tests__item1.jl")
             @time @safetestset "HomotopyPolyAlgorithm stages, fallback, both-fail" include("Core/homotopy_polyalg_tests__item1.jl")
             return @time @safetestset "HomotopyPolyAlgorithm warm sweep→fallback handoff" include("Core/homotopy_polyalg_tests__item2.jl")
         end,


### PR DESCRIPTION
Part of #1020; addresses the default-inner overhead found in the post-#1029 benchmarks.

**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

## Problem

The homotopy continuation drivers (`HomotopySweep`, the `ArcLengthContinuation` corrector) solve a sequence of warm-started problems through one persistent inner cache (`init`/`reinit!`/`solve!`). With the default inner (the `FastShortcutNonlinearPolyalg` ladder), every `reinit!` restarted the ladder at `start_index` and eagerly reinitialized **all** subcaches. That cost the drivers twice:

1. **Ladder re-failing**: for `n > 25` (`start_index = 1`) every warm step re-failed Broyden/Klement before Newton succeeded again.
2. **Eager `reinit!` cost**: every subcache `reinit!` evaluates the residual at the new `u0` (`Utils.reinit_common!`), so each continuation step paid one residual call *per ladder rung* (6 for the default ladder) versus 1 for a bare `NewtonRaphson()` inner. For small systems the default ladder already starts at Newton (`start_index = 3` for `u0_len ≤ 25`), so this eager-reinit cost was the *entire* measured 2x overhead there — not ladder re-failing.

Result on the post-#1029 benchmark set: the default inner cost ~1.6–2x a plain `NewtonRaphson()` inner everywhere.

## Design

### `reinit!(cache; retain_best = true)` on the polyalgorithm cache (opt-in)

- **Sticky start**: the polyalg cache records which subalgorithm produced the last success (`cache.best`, now also set on the `solve!` path). A `retain_best = true` `reinit!` starts the next `solve!` from that index instead of `start_index`. Plain `reinit!` (the default) is the exact status-quo full restart, so no polyalg user outside the homotopy drivers sees any behavior change.
- **Upward escalation preserved**: if the sticky rung fails, the ladder continues up exactly as before.
- **Wrap-around, floored at `start_index`**: when the retained start was past `start_index` and the top of the ladder fails too, the ladder wraps around to the skipped cheaper rungs before falling through to the lowest-residual selection — retention never tries *fewer* rungs than a full ladder run, and never tries rungs the algorithm's own `start_index` excludes.
- **Lazy subcache reinitialization**: a retaining `reinit!` reinitializes only the starting subcache; escalation freshens each further subcache at the moment it is attempted. This reduces the per-step `reinit!` cost from one residual call per rung to one per rung *attempted* (usually just the retained one) — this is what closes the gap on small systems.
- **Periodic re-probe**: when the retained rung sits above `start_index`, every 8th retained `reinit!` starts one solve from `start_index` again, so a cheap rung that failed once transiently is rediscovered instead of locked out forever. Bounded cost: at most one status-quo-style ladder step per interval.

### Drivers arm it on tracking steps only

`HomotopySweep` and the `ArcLengthContinuation` corrector call `reinit_retaining!` (retaining for a polyalg cache, plain `reinit!` otherwise) on their warm-started tracking `reinit!`s. The cold anchor solve at `λspan[1]` (and arclength's λ-fixed anchor/landing solves) still runs the full ladder — that is where the winner is discovered. `SimpleHomotopySweep` is untouched: it deliberately reconstructs a fresh stack-allocated `solve` per step (no persistent inner cache), and its default inner is `SimpleNewtonRaphson`, not a polyalgorithm, so there is nothing to retain there.

### Wrap-around decision (measured)

Three variants were measured on the benchmark set:

- **Wrap to rung 1**: made the *failure* path more expensive than the status quo (P2 sweep cost-to-fail 2944 vs 2506 on master), because small systems (`start_index = 3`) suddenly attempted Broyden/Klement — rungs the status-quo ladder never runs — on every bisection retry at the fold.
- **No wrap (report failure)**: cheapest failures, but a wrapped rung genuinely can rescue a stagnating retained rung, and a driver-side corrector failure feeds bisection (more retries), so cheap-but-avoidable failures are not free either.
- **Wrap floored at `start_index`** (chosen): when the retained rung *is* the ladder's `start_index` (the common steady state), the failure path is exactly the status-quo ladder — the wrap only engages in the rare retained-past-start case, keeping the robustness of trying every rung of a full ladder run. Measured: P2 sweep cost-to-fail drops to 2344 (below the 2506 status quo, thanks to the lazy reinit), P2 arclength 291 → 267.

## Benchmarks (residual calls via `Ref` counter, measured on this branch at its final state)

P1 scalar monotone `(1-λ)(u-4) + λ(u²-4)`; P2 cubic S-curve fold `u³-3u-(-3+6λ)`; P3 n=50 coupled cubic iip; P4 hard ramp `u³-1-7λ` from `u0=100`:

| problem | default (master) | default + retention | `NewtonRaphson()` | Newton-first static `(NR, TR)` |
|---|---|---|---|---|
| P1 sweep | 150 | **94** | 86 | 88 |
| P2 sweep (cost-to-fail) | 2506 | **2344** | 746 | 1294 |
| P2 arclength (full solve) | 381 | **267** | 188 | 210 |
| P3 sweep n=50 | 2295 | **1577** | 1400 | 1451 |
| P4 sweep | 246 | **204** | 123 | 146 |

- P1 lands within 9% and P3 within 13% of the `NewtonRaphson()` inner (target was 10–20%), while staying fully adaptive; the static Newton-first ladder is matched or beaten on the success-path problems.
- P4's remaining gap is **entirely the anchor**: anchor-only cost (zero-width span) is 140 (default) vs 59 (Newton), and 204−123 = 140−59 = 81 — interior tracking overhead with retention is zero. The cold anchor deliberately runs the full ladder (under the tracking cap, then exempt-rerun), which is pre-existing behavior this PR intentionally does not change.
- P2's sweep row is a *cost-to-fail* (the sweep cannot pass the fold; failure hands off to arclength). A polyalgorithm failure intrinsically runs its whole ladder, so Newton-parity is unreachable there; retention + lazy reinit still brings it below master. Same effect explains most of P2-arclength's remaining gap (fold-region corrector failures).

### Where a quasi-Newton rung genuinely wins (honest findings)

Two constructed n=100 problems (`start_index = 1`):

| problem | default (master) | default + retention | `NewtonRaphson()` | Klement-only |
|---|---|---|---|---|
| P5 mild `u + 0.1λ sin(u) + 0.25u₊ − 1` | 2882 | **1556** | 1229 | — |
| P6 near-linear `u − 1 + 0.05λ tanh(u) + 0.05λ u₊` | **918** | 1806 | 1229 | 1088 |

- On P6 a `Klement()` inner (1088) genuinely beats `NewtonRaphson()` (1229) — quasi-Newton *can* win steady-state.
- On that same P6, **master's full-restart default (918) beats everything**, including retention (1806) and the static Newton-first ladder (1330). Mechanism: the status quo re-runs Broyden first every step, which succeeds at moderate effort; that effort keeps the step controller's dλ small-but-cheap. Once retention escalates to Newton (after one transient quasi-Newton failure), Newton's near-free correctors grow dλ, and at the larger step size the cheap rungs *fail* their periodic re-probes — so sticky-best stays locked on Newton's more-expensive-per-call equilibrium. The re-probe (kept: bounded cost, and it does rescue lock-in when the cheap rung succeeds at the prevailing step size) cannot recover this case; recovering it would need cost-aware retention (retain the cheapest recent winner, not the last winner), which interacts with the step controller and is deliberately left as future work.
- On P5 (Broyden mostly failing warm) retention wins big (2882 → 1556). The two problems bracket the trade: retention wins when the cheap rungs mostly fail, ties on small systems, and can lose to full restart on problems where a cheap rung succeeds-with-effort every step. Given P1–P5 and that the drivers' benchmark set motivating this PR all improve, the trade looks right for the homotopy drivers' default.

## Stage-level retention (follow-up)

Carrying the winning inner rung across the sweep → arclength handoff (stage-level retention in `HomotopyPolyAlgorithm`) is deliberately **not** part of this PR: #1030 is churning `homotopy_polyalg.jl` (warm handoff), so that follow-up should land after #1030 merges.

## Tests

- `test/Core/polyalg_retention_tests__item1.jl`: sticky start picks the winning rung on the next solve (asserted via subsolver `nsteps` and exact residual-call counts of the lazy reinit), escalation past a failing sticky rung, wrap-around rescuing via a skipped cheaper rung, wrap-around refusing to go below `start_index`, the periodic re-probe rediscovering a cheaper rung, and `retain_best = false` ⇒ exact status-quo behavior (eager reinit of every subcache, ladder restart at `start_index`).
- `test/Core/homotopy_retention_tests__item1.jl`: residual-call reduction on the benchmark problems with generous margins (each margin trips on master's numbers), anchor still runs the full ladder (an anchor that *requires* escalation), and a difficulty-jump path where the retained Jacobian-based rung hard-fails mid-continuation and escalation must rescue the sweep.

All existing homotopy sweep/arclength/effort/tolerance/jac tests, the homotopy polyalg tests, the core polyalg/reinit!/cache/issue tests, and NonlinearSolveBase's polyalg solution-type tests pass locally (output in the PR conversation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
