### PR TITLE
Fix continuation drivers returning Any-typed solutions at the source (val-gated `original`)

### DIFF
--- a/lib/NonlinearSolveBase/src/arclength.jl
+++ b/lib/NonlinearSolveBase/src/arclength.jl
@@ -3,7 +3,8 @@
         adaptive = true, min_ds = nothing, max_step_factor = 1.0,
         expand_factor = 2.0, expand_threshold = 2, max_angle = π / 6,
         predictor = :secant, autodiff = nothing, linsolve = nothing,
-        tracking_maxiters = 10, maxsteps = 10000, theta = 0.5)
+        tracking_maxiters = 10, maxsteps = 10000, theta = 0.5,
+        store_original = Val(false))
 
 Pseudo-arclength continuation solver for a `SciMLBase.HomotopyProblem`. Unlike
 [`HomotopySweep`](@ref), which marches the scalar parameter ``λ`` monotonically, this
@@ -142,6 +143,12 @@ Keyword arguments:
     `(0, 1)`; the default `0.5` weighs the (size-normalized) state block and the
     parameter equally. Larger `theta` emphasizes the state components, smaller `theta`
     emphasizes ``λ``.
+  - `store_original`: whether to store the failing inner solve in the `original` field of
+    the returned solution. Default `Val(false)` to keep the returned solution type
+    concrete (the anchor/corrector inner solves' return type inference gives up, so
+    storing one would pin the returned solution's `original` slot to `Any`). Set to
+    `Val(true)` to keep the payload for debugging. Mirrors
+    [`NonlinearSolvePolyAlgorithm`](@ref)'s option of the same name.
 
 When the solver cannot reach `λspan[2]`, the returned solution carries a failure retcode
 and its `u` is the last converged curve point.
@@ -167,6 +174,7 @@ Jacobian.
     tracking_maxiters
     maxsteps::Int
     theta
+    store_original <: Val
 end
 
 function ArcLengthContinuation(;
@@ -174,7 +182,7 @@ function ArcLengthContinuation(;
         min_ds = nothing, max_step_factor = 1.0, expand_factor = 2.0,
         expand_threshold = 2, max_angle = π / 6, predictor = :secant,
         autodiff = nothing, linsolve = nothing, tracking_maxiters = 10,
-        maxsteps = 10000, theta = 0.5
+        maxsteps = 10000, theta = 0.5, store_original::Val = Val(false)
     )
     if !(0 < initial_step_factor <= 1)
         throw(
@@ -242,7 +250,7 @@ function ArcLengthContinuation(;
     return ArcLengthContinuation(
         inner, initial_step_factor, adaptive, min_ds, max_step_factor,
         expand_factor, expand_threshold, max_angle, predictor, autodiff, linsolve,
-        tracking_maxiters, maxsteps, theta
+        tracking_maxiters, maxsteps, theta, store_original
     )
 end
 
@@ -675,9 +683,10 @@ function CommonSolve.solve(
     # Correct the start onto the curve at λ0; everything downstream assumes H(u, λ) = 0.
     start_sol = _arclength_fixed_solve(prob, alg.inner, prob.u0, λ, args...; kwargs...)
     if !SciMLBase.successful_retcode(start_sol)
-        return SciMLBase.build_solution(
+        return build_solution_less_specialize(
             prob, alg, copy(prob.u0), start_sol.resid;
-            retcode = start_sol.retcode, original = start_sol
+            retcode = start_sol.retcode, original = start_sol,
+            store_original = alg.store_original
         )
     end
     u = copy(start_sol.u)
@@ -902,9 +911,10 @@ function CommonSolve.solve(
             ds = ds / 2          # bisect; retry from the same accepted point
             streak = 0
         else
-            return SciMLBase.build_solution(
+            return build_solution_less_specialize(
                 prob, alg, u, nothing;
-                retcode = last_sol.retcode, original = last_sol
+                retcode = last_sol.retcode, original = last_sol,
+                store_original = alg.store_original
             )
         end
     end

--- a/lib/NonlinearSolveBase/src/homotopy_polyalg.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_polyalg.jl
@@ -1,6 +1,6 @@
 """
-    HomotopyPolyAlgorithm(algs::Tuple; warm_handoff = true)
-    HomotopyPolyAlgorithm(; warm_handoff = true)
+    HomotopyPolyAlgorithm(algs::Tuple; warm_handoff = true, store_original = Val(false))
+    HomotopyPolyAlgorithm(; warm_handoff = true, store_original = Val(false))
 
 A polyalgorithm for [`SciMLBase.HomotopyProblem`](@ref): a container for a tuple of
 continuation algorithms that are tried in order until one returns a solution with a
@@ -61,7 +61,8 @@ strictly past `λspan[1]`); a sweep that failed at the `λspan[1]` anchor itself
 within the backoff width of it, leaves the fallback stages with the current cold
 full-range behavior. A warm-handoff success is returned as a solution of the
 *original* problem (same `prob`, same `u` type); the stage's solution of the shrunken
-problem is attached as `original`.
+problem is attached as `original` only when `store_original = Val(true)` (see below) —
+by default it is dropped so the returned solution stays concretely typed.
 
 ### Arguments
 
@@ -75,6 +76,11 @@ problem is attached as `original`.
     from the sweep's last accepted iterate (with `λ_h` backed off 5% of the span from
     the failure), falling back to the cold full-range attempt only if that fails.
     `false` recovers the plain try-each-stage-cold behavior.
+  - `store_original`: whether a warm-handoff success stores its shrunken-problem stage
+    solution in the returned solution's `original` field. Default `Val(false)` keeps the
+    returned solution concretely typed (the stage solution the handoff produces infers
+    as `Any`). Pass `Val(true)` to recover the stage solution through `original` for
+    introspection, at the cost of the returned solution's type no longer being concrete.
 
 ### Example
 
@@ -92,15 +98,20 @@ alg = HomotopyPolyAlgorithm(; warm_handoff = false) # always restart stages cold
 @concrete struct HomotopyPolyAlgorithm <: AbstractNonlinearSolveAlgorithm
     algs <: Tuple
     warm_handoff::Bool
+    store_original <: Val
 end
 
-function HomotopyPolyAlgorithm(algs::Tuple; warm_handoff::Bool = true)
-    return HomotopyPolyAlgorithm(algs, warm_handoff)
+function HomotopyPolyAlgorithm(
+        algs::Tuple; warm_handoff::Bool = true, store_original::Val = Val(false)
+    )
+    return HomotopyPolyAlgorithm(algs, warm_handoff, store_original)
 end
 
-function HomotopyPolyAlgorithm(; warm_handoff::Bool = true)
+function HomotopyPolyAlgorithm(;
+        warm_handoff::Bool = true, store_original::Val = Val(false)
+    )
     return HomotopyPolyAlgorithm(
-        (HomotopySweep(), ArcLengthContinuation()); warm_handoff
+        (HomotopySweep(), ArcLengthContinuation()); warm_handoff, store_original
     )
 end
 
@@ -160,10 +171,14 @@ function CommonSolve.solve(
             if SciMLBase.successful_retcode(hsol)
                 # Rebuild against the ORIGINAL problem: the caller handed in `prob`
                 # and must get a solution whose `prob`/λspan semantics match it. The
-                # shrunken-problem solution stays reachable through `original`.
-                return SciMLBase.build_solution(
+                # shrunken-problem solution stays reachable through `original` when
+                # `store_original = Val(true)`; by default the slot is pinned to
+                # `Nothing` so the warm-handoff solution stays concretely typed (the
+                # inner stage solve infers as `Any`).
+                return build_solution_less_specialize(
                     prob, stage, hsol.u, hsol.resid;
-                    retcode = hsol.retcode, original = hsol, stats = hsol.stats
+                    retcode = hsol.retcode, original = hsol, stats = hsol.stats,
+                    store_original = alg.store_original
                 )
             end
             # Warm attempt failed (even the backed-off seed can be unlucky, e.g. on a

--- a/lib/NonlinearSolveBase/src/homotopy_sweep.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_sweep.jl
@@ -3,7 +3,7 @@
         initial_step_factor = 0.1, min_dλ = nothing, max_step_factor = 1.0,
         expand_factor = 2.0, expand_threshold = 2, expand_quality = 0.25,
         predictor = :secant, tracking_maxiters = 10, tracking_abstol = nothing,
-        maxsteps = 10000)
+        maxsteps = 10000, store_original = Val(false))
 
 Natural-parameter continuation solver for a [`SciMLBase.HomotopyProblem`](@ref). The
 scalar continuation parameter ``λ`` is swept across the problem's `λspan`. The sweep
@@ -122,6 +122,14 @@ Keyword arguments:
   - `maxsteps`: a hard cap on the total number of predictor-corrector attempts
     (accepted steps plus bisection retries). Exceeding it returns a
     `ReturnCode.MaxIters` failure carrying the last converged iterate. Must be ≥ 1.
+  - `store_original`: whether to store the failing inner solve in the `original` field
+    of the returned solution. Default `Val(false)` to keep the returned solution type
+    concrete: the inner solve is a fresh `solve(inner_prob, inner)` whose return type
+    inference gives up (its residual is a `FixLambda` wrapper), so storing it would pin
+    the driver's returned solution's `original` type-slot to `Any`, forcing dynamic
+    dispatch on every downstream field read of that solution. Set to `Val(true)` to keep
+    the payload for debugging (the returned type is then no longer concrete). Mirrors
+    [`NonlinearSolvePolyAlgorithm`](@ref)'s option of the same name.
 
 When the sweep cannot reach the end of `λspan`, the returned solution carries a failure
 retcode: its `u` is the last converged iterate (at some ``λ`` short of `λspan[2]`, or
@@ -147,6 +155,7 @@ systems whose target form is hard to solve cold; it is unrelated to the polynomi
     tracking_maxiters
     tracking_abstol
     maxsteps::Int
+    store_original <: Val
 end
 
 function HomotopySweep(;
@@ -154,7 +163,7 @@ function HomotopySweep(;
         initial_step_factor = 0.1, min_dλ = nothing, max_step_factor = 1.0,
         expand_factor = 2.0, expand_threshold = 2, expand_quality = 0.25,
         predictor = :secant, tracking_maxiters = 10, tracking_abstol = nothing,
-        maxsteps = 10000
+        maxsteps = 10000, store_original::Val = Val(false)
     )
     if nsteps !== nothing && nsteps < 1
         throw(ArgumentError("HomotopySweep `nsteps` must be ≥ 1, got $nsteps"))
@@ -237,7 +246,7 @@ function HomotopySweep(;
     return HomotopySweep(
         inner, nsteps, adaptive, initial_step_factor, min_dλ,
         max_step_factor, expand_factor, expand_threshold, expand_quality, predictor,
-        tracking_maxiters, tracking_abstol, maxsteps
+        tracking_maxiters, tracking_abstol, maxsteps, store_original
     )
 end
 
@@ -268,13 +277,23 @@ end
 # eltype when λ's precision differs from `u0`'s). When no derivative field is present
 # the construction is exactly the bare positional one (the branch is decided by the
 # problem's type, so the unused arm is compiled away).
+#
+# `FullSpecialize` is required, not the `AutoSpecialize` default: the residual is a
+# `FixLambda` wrapper, and `AutoSpecialize`'s `FunctionWrappersWrapper` prototype
+# inference gives up on a wrapper-of-a-wrapper, so inference of the inner `solve` on the
+# resulting problem widens to `Any`. That `Any` reaches the drivers through the fresh
+# `solve(inner_prob, inner)` used for the exempt/anchor/landing solves
+# (`_sweep_exempt_solve`) and the arclength start/corrector solves — whose results are
+# stored into the driver's returned solution as `original`, pinning its `original`
+# type-slot to `Any` and making the whole driver `solve` infer as `Any`. `FullSpecialize`
+# keeps the residual concretely typed so those inner solves infer.
 function _sweep_nonlinear_function(::Val{iip}, f, fixλ::FixLambda) where {iip}
     if f.jac === nothing && f.jac_prototype === nothing && f.sparsity === nothing &&
             f.colorvec === nothing
-        return SciMLBase.NonlinearFunction{iip}(fixλ)
+        return SciMLBase.NonlinearFunction{iip, SciMLBase.FullSpecialize}(fixλ)
     end
     jac = f.jac === nothing ? nothing : FixLambdaJac(fixλ)
-    return SciMLBase.NonlinearFunction{iip}(
+    return SciMLBase.NonlinearFunction{iip, SciMLBase.FullSpecialize}(
         fixλ; jac, jac_prototype = f.jac_prototype,
         sparsity = f.sparsity, colorvec = f.colorvec
     )
@@ -477,9 +496,10 @@ function _homotopy_sweep_solve(
         # the λ = λspan[1] system itself failed from u0: the homotopy premise is
         # broken, so no continuation is possible. `u` stays u0. No accepted point
         # exists, so there is nothing to hand off.
-        return SciMLBase.build_solution(
+        return build_solution_less_specialize(
                 prob, alg, u, last_sol.resid;
-                retcode = last_sol.retcode, original = last_sol
+                retcode = last_sol.retcode, original = last_sol,
+                store_original = alg.store_original
             ), nothing
     end
     u = copy(last_sol.u)
@@ -639,9 +659,10 @@ function _homotopy_sweep_solve(
             trust = 0
         else
             # on failure: u is the last converged iterate (λ<λ1); resid is from the failed step (advisory)
-            return SciMLBase.build_solution(
+            return build_solution_less_specialize(
                     prob, alg, u, last_sol.resid;
-                    retcode = last_sol.retcode, original = last_sol
+                    retcode = last_sol.retcode, original = last_sol,
+                    store_original = alg.store_original
                 ), λ
         end
     end

--- a/test/Core/homotopy_jac_tests__item1.jl
+++ b/test/Core/homotopy_jac_tests__item1.jl
@@ -120,11 +120,15 @@ resid_proto = zeros(n)
 f_band(resid_proto, sol_proto.u, 1.0, 1.0)
 @test maximum(abs, resid_proto) < 1.0e-8
 
-# --- No derivative fields: the inner function is constructed exactly as before ---
+# --- No derivative fields: the inner function is the bare positional construction,
+# built `FullSpecialize` so the inner `solve` on the FixLambda-wrapped problem infers
+# (the `AutoSpecialize` default's FunctionWrappersWrapper prototype inference bails on the
+# wrapper-of-a-wrapper, widening the driver's returned solution type to `Any`). ---
 import NonlinearSolveBase
 fixλ = NonlinearSolveBase.FixLambda(prob_ad.f, 0.0)
 fλ_plain = NonlinearSolveBase._sweep_nonlinear_function(Val(false), prob_ad.f, fixλ)
-@test typeof(fλ_plain) == typeof(SciMLBase.NonlinearFunction{false}(fixλ))
+@test typeof(fλ_plain) ==
+    typeof(SciMLBase.NonlinearFunction{false, SciMLBase.FullSpecialize}(fixλ))
 @test fλ_plain.jac === nothing
 @test fλ_plain.jac_prototype === nothing
 

--- a/test/Core/homotopy_polyalg_tests__item2.jl
+++ b/test/Core/homotopy_polyalg_tests__item2.jl
@@ -46,16 +46,25 @@ n_cold = count_ref[]
 
 # --- the warm success corresponds to the ORIGINAL problem ---
 @test sol_warm.prob === prob_fold
-# the stage's solution of the shrunken remaining-stretch problem is kept as `original`:
-# its span starts strictly inside the original span and ends at the original target,
-# backed off ~5% of the span from the sweep's last accepted λ (which is near the
-# λ = 5/6 fold)
-hsol = sol_warm.original
+@test typeof(sol_warm.u) == typeof(prob_fold.u0)
+# by default `original` is dropped so the returned solution stays concretely typed
+@test fieldtype(typeof(sol_warm), :original) === Nothing
+
+# with `store_original = Val(true)` the stage's solution of the shrunken
+# remaining-stretch problem is kept as `original`: its span starts strictly inside the
+# original span and ends at the original target, backed off ~5% of the span from the
+# sweep's last accepted λ (which is near the λ = 5/6 fold)
+sol_warm_orig = solve(
+    prob_fold, HomotopyPolyAlgorithm((stage1, stage2); store_original = Val(true));
+    maxiters = 10
+)
+@test SciMLBase.successful_retcode(sol_warm_orig)
+@test sol_warm_orig.u[1] ≈ target atol = 1.0e-4
+hsol = sol_warm_orig.original
 @test hsol.prob isa SciMLBase.HomotopyProblem
 @test hsol.prob.λspan[2] == 1.0
 @test 0.0 < hsol.prob.λspan[1] < 5 / 6
-@test hsol.u == sol_warm.u
-@test typeof(sol_warm.u) == typeof(prob_fold.u0)
+@test hsol.u == sol_warm_orig.u
 
 # --- anchor failure: no accepted point, warm handoff must not engage ---
 # (1 - λ)(atan(u) + 2) + λ(u - 1) has no real root at λ = 0 (atan(u) + 2 ∈ (0.43, 3.57))

--- a/test/Core/homotopy_sweep_tests__item22.jl
+++ b/test/Core/homotopy_sweep_tests__item22.jl
@@ -1,0 +1,75 @@
+using NonlinearSolve
+
+using SciMLBase
+
+import NonlinearSolveBase
+
+# Root-cause type-stability regression for the continuation drivers.
+#
+# The drivers assemble their returned solution from an inner solve whose return type
+# inference gives up: `_sweep_exempt_solve` (and its arclength twin) builds a
+# `NonlinearProblem` whose residual is a `FixLambda` wrapper, and the `AutoSpecialize`
+# `FunctionWrappersWrapper` prototype inference bails on that wrapper-of-a-wrapper, so
+# `solve(inner_prob, inner)` widens to `Any`. Storing that `Any`-typed solution into the
+# driver's own returned solution via `original = last_sol` pinned the returned solution's
+# `original` type-slot to `Any`, making the whole driver `solve` infer as `Any` — every
+# downstream `.u`/`.resid`/`.retcode` read on the returned solution then dynamically
+# dispatched. The fix is twofold and mirrors `NonlinearSolvePolyAlgorithm`:
+#   * the inner `NonlinearFunction` is built `FullSpecialize`, so the inner solve infers
+#     (no `Any` from `_sweep_exempt_solve` / `_arclength_fixed_solve`); and
+#   * `original` is gated behind a `store_original::Val` (default `Val(false)`), so the
+#     returned solution's `original` slot is pinned to `Nothing` and the type is concrete
+#     unless the user explicitly opts in.
+
+H!(du, u, p, λ) = (du[1] = (1 - λ) * (u[1] - p[1]) + λ * (u[1]^2 - p[1]); nothing)
+prob = HomotopyProblem(H!, [4.0], [4.0])
+
+# The inner exempt/fixed solves must no longer infer as `Any` (this is what poisoned the
+# driver's returned type). `Nothing` is the concrete type of the default `alg.inner`.
+@test code_typed(
+    NonlinearSolveBase._sweep_exempt_solve,
+    Tuple{typeof(prob), Nothing, Vector{Float64}, Float64}; optimize = true
+)[1].second !== Any
+@test code_typed(
+    NonlinearSolveBase._arclength_fixed_solve,
+    Tuple{typeof(prob), Nothing, Vector{Float64}, Float64}; optimize = true
+)[1].second !== Any
+
+# By default the drivers drop `original`, so their returned solution is concretely typed
+# (its `original` slot is `Nothing`, not `Any`), and the full `solve` no longer infers as
+# `Any`.
+for alg in (HomotopySweep(), ArcLengthContinuation())
+    sol = solve(prob, alg)
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[1] ≈ 2.0 atol = 1.0e-6
+    @test isconcretetype(typeof(sol))
+    @test fieldtype(typeof(sol), :original) === Nothing
+    @test sol.original === nothing
+    @test code_typed(
+        SciMLBase.solve, Tuple{typeof(prob), typeof(alg)}; optimize = true
+    )[1].second !== Any
+end
+
+# The `store_original` field is carried and defaults to `Val(false)`.
+@test HomotopySweep().store_original === Val(false)
+@test ArcLengthContinuation().store_original === Val(false)
+@test HomotopyPolyAlgorithm().store_original === Val(false)
+@test HomotopySweep(; store_original = Val(true)).store_original === Val(true)
+@test ArcLengthContinuation(; store_original = Val(true)).store_original === Val(true)
+@test HomotopyPolyAlgorithm(; store_original = Val(true)).store_original === Val(true)
+
+# Opting in keeps `original` reachable on the failure paths that populate it. A homotopy
+# whose target system has no real solution reachable from u0 fails the anchor solve, which
+# is where the driver attaches `original`. With `store_original = Val(true)` the payload is
+# retained; with the default it is dropped (slot pinned to `Nothing`).
+Hfail!(du, u, p, λ) = (du[1] = (1 - λ) * (u[1] - p[1]) + λ * (u[1]^2 + p[1]); nothing)
+failprob = HomotopyProblem(Hfail!, [1.0], [1.0])
+sfail_keep = solve(failprob, HomotopySweep(; store_original = Val(true)))
+@test !SciMLBase.successful_retcode(sfail_keep)
+@test sfail_keep.original !== nothing
+@test sfail_keep.original isa SciMLBase.AbstractNonlinearSolution
+
+sfail_drop = solve(failprob, HomotopySweep())
+@test !SciMLBase.successful_retcode(sfail_drop)
+@test sfail_drop.original === nothing
+@test fieldtype(typeof(sfail_drop), :original) === Nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,6 +86,7 @@ else
             @time @safetestset "HomotopySweep expands the step after consecutive successes" include("Core/homotopy_sweep_tests__item19.jl")
             @time @safetestset "HomotopySweep secant predictor reduces corrector work" include("Core/homotopy_sweep_tests__item20.jl")
             @time @safetestset "HomotopySweep regrows the step after bisecting a hard region" include("Core/homotopy_sweep_tests__item21.jl")
+            @time @safetestset "Continuation drivers return concretely-typed solutions (no Any-typed original)" include("Core/homotopy_sweep_tests__item22.jl")
             @time @safetestset "ArcLengthContinuation construction + defaults" include("Core/arclength_tests__item1.jl")
             @time @safetestset "ArcLengthContinuation happy path (fold-free, matches sweep)" include("Core/arclength_tests__item2.jl")
             @time @safetestset "ArcLengthContinuation rounds a fold (non-monotone λ)" include("Core/arclength_tests__item3.jl")


### PR DESCRIPTION
**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

Supersedes #1041 (accessor barriers) — the accessor barriers are unnecessary once the source type instability is fixed.

## Root cause

Profiling had attributed ~384 B/step of a continuation to solution `getproperty`, but `getproperty` is blameless (non-allocating for concrete solutions). The real instability: the drivers build their inner λ-fixed `NonlinearProblem` wrapping the residual in a `FixLambda`. Under the default `AutoSpecialize`, `FunctionWrappersWrapper` prototype inference bails on the wrapper-of-a-wrapper, so the fresh `solve(inner_prob, inner)` in `_sweep_exempt_solve` (anchor/landing/exempt) and `_arclength_fixed_solve` **infers as `Any`**. Storing that `Any`-typed solution as `original` pinned the driver's returned `NonlinearSolution`'s `original` slot to `Any`, so `solve(prob, HomotopySweep())` (and the arclength/polyalg drivers) inferred `Any`.

## Fix

1. `FullSpecialize` the inner `NonlinearFunction` in `_sweep_nonlinear_function` (covers the sweep exempt and arclength fixed solves).
2. Add a `store_original::Val` field (default `Val(false)`) to `HomotopySweep`, `ArcLengthContinuation`, **and** `HomotopyPolyAlgorithm`, routing their `original`-storing `build_solution` calls through the existing `build_solution_less_specialize` (which pins the `original` slot to `Nothing` when `Val(false)`, mirroring #878's polyalg pattern).

By default the drivers' returned solution is concretely typed. Pass `store_original = Val(true)` to recover `original` for introspection — **opt-in everywhere, including the `HomotopyPolyAlgorithm` warm handoff**, whose docstring and test (`homotopy_polyalg_tests__item2.jl`) are updated accordingly.

## Scope note

This is an **output-solution type-stability** fix (what downstream callers see), not a per-step allocation reduction: the per-step hot-loop `last_sol` reads already come from the concrete `solve!(cache)`, so the measured per-step allocation is unchanged (verified: 1629 B/step both before and after on Julia 1.10). The per-step allocation win is #1042 (read-once). The two are complementary.

## Behavior change

By default, failed/warm-handoff `HomotopySweep`/`ArcLengthContinuation`/`HomotopyPolyAlgorithm` solutions no longer carry `.original` (pass `store_original = Val(true)` to restore). No existing test relied on this except the warm-handoff introspection in item2, updated to opt in.

## Verification (local, Julia 1.10)

- `code_typed` return `=== Any`: `solve(prob, HomotopySweep())`, `_sweep_exempt_solve`, `_arclength_fixed_solve` all `true` → `false`; returned solution runtime-concrete with `original::Nothing` by default.
- `HomotopyPolyAlgorithm()` output: `original::Nothing`, `isconcretetype`; `store_original = Val(true)` recovers `original`.
- Full `test/Core/homotopy*.jl` + `arclength*.jl`: **459/459 pass**. New `homotopy_sweep_tests__item22.jl` (type-stability + store_original semantics for all three drivers). Runic clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)