### PR TITLE
Homotopy drivers: read the interior corrector solution through typed barriers (drop last_sol union boxing)

### DIFF
--- a/lib/NonlinearSolveBase/src/arclength.jl
+++ b/lib/NonlinearSolveBase/src/arclength.jl
@@ -542,6 +542,18 @@ function _arclength_fixed_solve(
     return solve(inner_prob, inner, args...; prob.kwargs..., kwargs...)
 end
 
+# Read the interior corrector solution's fields through @noinline type-specializing
+# barriers, exactly as in the sweep (see `_sweep_sol_u`): `last_sol` is union-typed
+# across the concrete interior `solve!(corr_cache)` and the fresh `solve` of the
+# λ-fixed start/landing solves, so the bare `xnew = last_sol.u` interior read boxes on
+# every step. The barrier forces the union-split at its CALL so the value the chord
+# arithmetic consumes is concrete.
+@noinline _arclength_sol_u(sol) = sol.u
+@noinline function _arclength_sol_nsteps(sol)
+    stats = sol.stats
+    return stats === nothing ? -1 : Int(stats.nsteps)
+end
+
 # Build the reusable Jacobian cache for the `:tangent` predictor's augmented Jacobian,
 # using NonlinearSolve's own `construct_jacobian_cache` (backend selection, tag handling,
 # and AD-extras preparation shared with every other solver) rather than a bespoke DI call.
@@ -832,7 +844,8 @@ function CommonSolve.solve(
         last_sol = CommonSolve.solve!(corr_cache)
 
         if SciMLBase.successful_retcode(last_sol)
-            xnew = last_sol.u
+            # read once through the typed barrier so the interior chord read doesn't box
+            xnew = _arclength_sol_u(last_sol)
             # realized chord, built in the (currently free) secant scratch
             @. tscratch = xnew - xcur
             nchord = _theta_norm(tscratch, wu, wλ, n)
@@ -892,7 +905,7 @@ function CommonSolve.solve(
             # sweep — see `_effort_growth_factor`), giving the arclength driver an effort
             # signal alongside the purely geometric bend-angle test.
             if alg.adaptive
-                nit = last_sol.stats === nothing ? -1 : Int(last_sol.stats.nsteps)
+                nit = _arclength_sol_nsteps(last_sol)
                 if _effort_wants_shrink(nit, budget)
                     ds / 2 >= min_ds && (ds = ds / 2)
                     streak = 0

--- a/lib/NonlinearSolveBase/src/homotopy_sweep.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_sweep.jl
@@ -330,6 +330,22 @@ function _sweep_accept!(u, u_prev, sol_u)
     end
 end
 
+# Read the interior-step solution's fields through @noinline type-specializing barriers.
+# `last_sol` is union-typed across the concrete interior `solve!(cache)` and the fresh
+# `solve(inner_prob, inner)` of the exempt anchor/landing solves, so a bare `last_sol.u`
+# read in the accept/quality block boxes on every step: the two-member union is not
+# union-split at the non-inlined `norm_op`/`_sweep_accept!` call sites the value flows
+# into. Reading it here forces the union-split at the barrier CALL (a two-member union is
+# always split) and each specialized method returns a concrete value the downstream
+# non-inlined calls consume allocation-free. A plain same-scope local does NOT suffice —
+# it stays inferred as the union `.u` and still boxes downstream (this is why the
+# read-once collapse in the closed PR #1042 did not remove the box).
+@noinline _sweep_sol_u(sol) = sol.u
+@noinline function _sweep_sol_nsteps(sol)
+    stats = sol.stats
+    return stats === nothing ? -1 : Int(stats.nsteps)
+end
+
 # Resolve the iteration budget the inner corrector runs under for interior tracking
 # steps, returning `(budget, cap_active)`. An explicit user `maxiters` always wins
 # (solve kwargs shadow problem kwargs, matching the splat order of the inner solves),
@@ -581,7 +597,7 @@ function _homotopy_sweep_solve(
                 # iterations), so the returned solution's accuracy semantics are
                 # unchanged. A failed polish feeds the ordinary bisection logic.
                 last_sol = _sweep_exempt_solve(
-                    prob, alg.inner, last_sol.u, next_λ, args...; kwargs...
+                    prob, alg.inner, _sweep_sol_u(last_sol), next_λ, args...; kwargs...
                 )
             end
         end
@@ -596,30 +612,33 @@ function _homotopy_sweep_solve(
             # points lie past a sharp turn. The scale includes the previous step's
             # displacement and an absolute floor so that a flat stretch of the path
             # (where the displacement is rounding noise) doesn't read as distrust.
+            # Read the union-typed solution's iterate once through the typed barrier so
+            # the accept/quality reads below don't box (see `_sweep_sol_u`).
+            solu = _sweep_sol_u(last_sol)
             θ = nothing
             if λ_prev != λ
                 # recomputed from scratch (never reuse `guess`): the inner solver may
                 # have iterated in place in the guess buffer when aliasing is forwarded
                 sv = (next_λ - λ) / (λ - λ_prev)
                 virtual = _sweep_extrapolate!(virtual, u, u_prev, sv)
-                correction = Utils.norm_op(L2_NORM, -, last_sol.u, virtual)
-                disp = Utils.norm_op(L2_NORM, -, last_sol.u, u)
-                scale = max(disp, disp_prev, sqrt(eps(λT)) * (1 + L2_NORM(last_sol.u)))
+                correction = Utils.norm_op(L2_NORM, -, solu, virtual)
+                disp = Utils.norm_op(L2_NORM, -, solu, u)
+                scale = max(disp, disp_prev, sqrt(eps(λT)) * (1 + L2_NORM(solu)))
                 θ = correction / scale
                 # the secant only earns its keep when it predicts at least twice as
                 # well as the trivial constant prediction (whose θ is exactly 1)
                 trust = θ < 1 / 2 ? trust + 1 : 0
                 disp_prev = disp
             else
-                disp_prev = Utils.norm_op(L2_NORM, -, last_sol.u, u)
+                disp_prev = Utils.norm_op(L2_NORM, -, solu, u)
             end
             # accept: swap `u`↔`u_prev` and copy the solution into `u` (no allocation).
-            u, u_prev = _sweep_accept!(u, u_prev, last_sol.u)
+            u, u_prev = _sweep_accept!(u, u_prev, solu)
             λ_prev = λ
             λ = next_λ
             λ == λend && break
             if alg.adaptive
-                nit = last_sol.stats === nothing ? -1 : Int(last_sol.stats.nsteps)
+                nit = _sweep_sol_nsteps(last_sol)
                 if _effort_wants_shrink(nit, budget)
                     # Proactive shrink on a straining success (see
                     # `_effort_wants_shrink`); the floor guard keeps the increment

--- a/test/Core/arclength_tests__item8.jl
+++ b/test/Core/arclength_tests__item8.jl
@@ -28,37 +28,46 @@ end
 cbig = [1.0 + 0.25 * ((i > 1) + (i < nbig)) + 1.0 for i in 1:nbig]
 prob_big = HomotopyProblem(Hbig!, ones(nbig), (c = cbig,); λspan = (0.0, 1.0))
 
-function run_fixed(prob, predictor, N)
+function run_fixed(prob, predictor, N; inner = nothing)
     alg = ArcLengthContinuation(;
-        predictor, adaptive = false, initial_step_factor = 1.0e-4, maxsteps = N
+        inner, predictor, adaptive = false, initial_step_factor = 1.0e-4, maxsteps = N
     )
     return solve(prob, alg)
 end
 
-function per_step_bytes(prob, predictor; N1 = 50, N2 = 250)
-    sol = run_fixed(prob, predictor, 5)   # warm up compilation
+function per_step_bytes(prob, predictor; inner = nothing, N1 = 50, N2 = 250)
+    sol = run_fixed(prob, predictor, 5; inner)   # warm up compilation
     @test sol.retcode == SciMLBase.ReturnCode.MaxIters
-    run_fixed(prob, predictor, 5)
+    run_fixed(prob, predictor, 5; inner)
     GC.gc()
-    a1 = @allocated run_fixed(prob, predictor, N1)
+    a1 = @allocated run_fixed(prob, predictor, N1; inner)
     GC.gc()
-    a2 = @allocated run_fixed(prob, predictor, N2)
+    a2 = @allocated run_fixed(prob, predictor, N2; inner)
     return (a2 - a1) / (N2 - N1)
 end
 
-# Measured ≈ 56 KB (secant) / 77 KB (tangent) per step at n = 50 with the cache
-# driver; the driver's own glue profiles at < 1 KB/step. The remainder is the shared
-# Newton stack, attributed by Profile.Allocs: ~21.5 KB/step is LinearSolve's
-# `lu(A, check = false)` copy on refactorization (skippable via its in-place `lu!`
-# path, gated on `alias_A = true` at init — a `construct_linear_solver` follow-up,
-# not driver work), ~21.5 KB/step was Broyden's initial J⁻¹ (a fresh `lu(A)` per step,
-# since replaced by the reusable `Utils.linsolve_workspace` linear-solve
-# cache), and ~10 KB/step is Klement/termination internals of the default
-# inner polyalgorithm. The pre-cache driver measured ≈ 274 KB / 295 KB. Bounds sit
-# at roughly 2× the cached cost, well under half the uncached cost, and hold
-# regardless of whether the Newton-stack follow-ups land.
-@test per_step_bytes(prob_big, :secant) < 128_000
-@test per_step_bytes(prob_big, :tangent) < 160_000
+# With the corrector cache (built once, re-driven via `reinit!`/`solve!`) plus the Newton
+# stack's own allocation-free reuse (#1038 dense-LU alias, #1039 `linsolve_workspace`)
+# landed, the DEFAULT polyalgorithm inner measures ≈ 2.5 KB/step (secant) / 3.0 KB/step
+# (tangent) at n = 50 on Julia 1.10 (lower on 1.11, where LinearSolve's ipiv reuse is
+# already active). These bounds sit at roughly 2× that, well under the pre-cache driver's
+# ≈ 274/295 KB, so they guard the cache-reuse invariant while tolerating CI variance.
+@test per_step_bytes(prob_big, :secant) < 6_000
+@test per_step_bytes(prob_big, :tangent) < 7_000
+
+# Driver-isolating guard with a single-method NewtonRaphson inner (one LU solve/step, no
+# polyalgorithm ladder), so the per-step number is dominated by the driver glue and one
+# linear solve. This is what the `last_sol` union-boxing fix (reading the interior
+# corrector solution through `@noinline` typed field barriers so the union-typed
+# `last_sol.u`/`.stats` reads do not box) directly bounds: on master the boxing added
+# ~96 B/step here. Measured ≈ 720 B/step (secant) / 1250 B/step (tangent) on Julia 1.10
+# (≈ 224/256 B/step on 1.11); the ~500 B/step 1.10 gap is LinearSolve's Julia-1.10-only
+# refactorization ipiv (a fresh pivot vector per `lu!`, reused only on Julia ≥ 1.11 or
+# with the LinearSolve backport). Bounds catch a return of the union boxing while holding
+# across both Julia versions.
+newton_inner = NewtonRaphson()
+@test per_step_bytes(prob_big, :secant; inner = newton_inner) < 1_100
+@test per_step_bytes(prob_big, :tangent; inner = newton_inner) < 1_700
 
 # the fixed-step measurement configuration must not change the answer: the standard
 # adaptive solve still lands on u = ones(n)

--- a/test/Core/homotopy_sweep_tests__item23.jl
+++ b/test/Core/homotopy_sweep_tests__item23.jl
@@ -1,0 +1,69 @@
+using NonlinearSolve
+
+using SciMLBase
+
+# Per-step allocation regression for the HomotopySweep driver, mirroring
+# `arclength_tests__item8.jl`. The inner solver's cache (Newton cache, Jacobian cache,
+# linear-solve cache) is built ONCE and re-driven via `reinit!`/`solve!` every
+# continuation step, so post-warmup per-step allocation is bounded by the inner solver's
+# own internals plus the driver's own glue — reconstructing the inner problem/cache per
+# step (the pre-cache behavior) costs several hundred KB per step at n = 50.
+#
+# In addition, this guards the `last_sol` union-boxing fix: the interior accept/quality
+# block reads the converged corrector iterate through `@noinline` typed field barriers
+# (`_sweep_sol_u`/`_sweep_sol_nsteps`) instead of bare `last_sol.u`/`last_sol.stats`
+# reads. `last_sol` is union-typed across the concrete `solve!(cache)` and the fresh
+# `solve(inner_prob, inner)` exempt anchor/landing solves, so the bare reads boxed a fresh
+# getproperty on every step (four reads/step in the sweep, ~384 B/step at n = 50). The
+# barriers force the union-split at the call so the reads no longer box.
+#
+# The measurement takes the SLOPE between two fixed-step runs of different lengths so
+# compile-time and one-time init allocations cancel, leaving pure per-step cost.
+# `adaptive = false` with an explicit `nsteps` makes the step count exactly `nsteps`.
+nbig = 50
+function Hbig!(r, u, p, λ)
+    n = length(u)
+    for i in 1:n
+        acc = u[i]
+        i > 1 && (acc += 0.25 * u[i - 1])
+        i < n && (acc += 0.25 * u[i + 1])
+        r[i] = acc + λ * u[i]^3 - p.c[i]
+    end
+    return nothing
+end
+cbig = [1.0 + 0.25 * ((i > 1) + (i < nbig)) + 1.0 for i in 1:nbig]
+prob_big = HomotopyProblem(Hbig!, ones(nbig), (c = cbig,); λspan = (0.0, 1.0))
+
+function run_fixed(prob, N; inner = nothing)
+    alg = HomotopySweep(; inner, adaptive = false, nsteps = N)
+    return solve(prob, alg)
+end
+
+function per_step_bytes(prob; inner = nothing, N1 = 50, N2 = 250)
+    run_fixed(prob, 5; inner)   # warm up compilation
+    run_fixed(prob, 5; inner)
+    GC.gc()
+    a1 = @allocated run_fixed(prob, N1; inner)
+    GC.gc()
+    a2 = @allocated run_fixed(prob, N2; inner)
+    return (a2 - a1) / (N2 - N1)
+end
+
+# DEFAULT polyalgorithm inner: ≈ 2.9 KB/step at n = 50 on Julia 1.10 (lower on 1.11).
+# The bound sits at roughly 2× that, well under the pre-cache several-hundred-KB level.
+@test per_step_bytes(prob_big) < 7_000
+
+# Driver-isolating guard with a single-method NewtonRaphson inner (one LU solve/step, no
+# polyalgorithm ladder). This is what the `last_sol` union-boxing fix directly bounds:
+# on master the four boxed `last_sol.u` reads added ~384 B/step here. Measured ≈ 1245
+# B/step on Julia 1.10 (≈ 96 B/step on 1.11); the ~1150 B/step 1.10 gap is LinearSolve's
+# Julia-1.10-only refactorization ipiv (reused on 1.11 / with the LinearSolve backport).
+# The bound catches a return of the union boxing (which would push this back to ~1629
+# B/step on 1.10) while holding across both Julia versions.
+@test per_step_bytes(prob_big; inner = NewtonRaphson()) < 1_500
+
+# the fixed-step measurement configuration must not change the answer: the standard
+# adaptive solve still lands on u = ones(n)
+sol = solve(prob_big, HomotopySweep())
+@test SciMLBase.successful_retcode(sol)
+@test maximum(abs, sol.u .- 1.0) < 1.0e-6

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,6 +87,7 @@ else
             @time @safetestset "HomotopySweep secant predictor reduces corrector work" include("Core/homotopy_sweep_tests__item20.jl")
             @time @safetestset "HomotopySweep regrows the step after bisecting a hard region" include("Core/homotopy_sweep_tests__item21.jl")
             @time @safetestset "Continuation drivers return concretely-typed solutions (no Any-typed original)" include("Core/homotopy_sweep_tests__item22.jl")
+            @time @safetestset "HomotopySweep per-step allocations" include("Core/homotopy_sweep_tests__item23.jl")
             @time @safetestset "ArcLengthContinuation construction + defaults" include("Core/arclength_tests__item1.jl")
             @time @safetestset "ArcLengthContinuation happy path (fold-free, matches sweep)" include("Core/arclength_tests__item2.jl")
             @time @safetestset "ArcLengthContinuation rounds a fold (non-monotone λ)" include("Core/arclength_tests__item3.jl")


### PR DESCRIPTION
Part of the homotopy allocation-reduction effort; gets stepping toward zero.

## Root causes

Two independent per-step allocation sources were profiled for the continuation drivers (`HomotopySweep`, `ArcLengthContinuation`), measured with the SLOPE method inside a function (n = 50 coupled cubic, `adaptive = false` fixed-step, `nsteps`/`maxsteps` 50 vs 250, `NewtonRaphson` inner, per-step = (allocated@250 − allocated@50)/200):

**(1) `last_sol` union boxing (this PR).** The drivers build one inner-solver cache and re-drive it every continuation step. In the interior accept/quality block, `last_sol` is union-typed: it is assigned from both the concrete interior `solve!(cache)` and the fresh `solve(inner_prob, inner)` of the exempt anchor/landing solves (`_sweep_exempt_solve` / `_arclength_fixed_solve`), whose two `NonlinearSolution` members differ in type parameters. Reading the converged iterate as a bare `last_sol.u` — four times per step in the sweep (the correction/disp/scale norms and `_sweep_accept!`), once per step in arclength (`xnew = last_sol.u`) — boxed a fresh SciMLBase `getproperty` on every step (`solution_interface.jl` getproperty, ~384 B/step sweep, ~96 B/step arclength), because the two-member union is not split at the non-inlined `norm_op`/`_sweep_accept!` / chord-arithmetic call sites the value flows into.

The fix reads the needed fields (`.u`, `.stats.nsteps`) once through `@noinline` type-specializing field barriers (`_sweep_sol_u`/`_sweep_sol_nsteps`, `_arclength_sol_u`/`_arclength_sol_nsteps`) so the union-split happens at the barrier *call* (a two-member union is always split) and each specialization returns a concrete value the downstream non-inlined calls consume allocation-free. A plain same-scope `solu = last_sol.u` local does **not** suffice — it stays inferred as the union `.u` and still boxes downstream (this is why the read-once collapse in the closed #1042 did not remove the box; #1044 fixed the *returned*-solution reads at the source but not these *interior*-loop reads).

**(2) LinearSolve refactorization ipiv (out of scope here — upstream LinearSolve, Julia 1.10 only).** On Julia 1.10 each interior `lu!` allocates a fresh `ipiv` pivot vector (~900 B/step) because LinearSolve's in-place ipiv-reuse path (`_reusable_lu_cacheval` / `_lu_reusing_ipiv!`, `factorization.jl`) is `VERSION >= v"1.11"`-gated — the preallocated-`ipiv` `LAPACK.getrf!(A, ipiv)` overload only exists in Julia 1.11+. On **Julia 1.11 this is already 0 B/step**; standalone `NewtonRaphson` and a direct `reinit!`/`solve!` loop both allocate 0 there. This is a LinearSolve.jl concern (no in-tree NonlinearSolve lever) and is reported separately; it is the entire ~900 B/step gap between the Julia-1.10 and Julia-1.11 numbers below.

## Before / after (per-step)

| driver (NewtonRaphson inner) | Julia 1.10.11 before | after | Julia 1.11.9 before | after |
|---|---|---|---|---|
| HomotopySweep | 1629.28 B | **1245.28 B** (−384.0) | 96.0 B | 96.0 B |
| ArcLengthContinuation (secant) | 816.0 B | **720.0 B** (−96.0) | 320.0 B | **224.0 B** (−96.0) |
| ArcLengthContinuation (tangent) | 1344.0 B | **1248.0 B** (−96.0) | 352.0 B | **256.0 B** (−96.0) |

Default polyalgorithm inner also improves (the same interior union reads boxed there): sweep 4901.76 → 2917.76 B/step and arclength secant 2988.0 → 2492.0 B/step on Julia 1.10.

The −384.0 (sweep) / −96.0 (arclength) deltas are *exactly* the count of boxed getproperty reads removed (four vs one per step), confirmed by Profile.Allocs attribution to `SciMLBase .../solution_interface.jl` getproperty at the sweep lines (correction/disp/scale/accept) and the arclength `xnew = last_sol.u` line: 384.0 → 0.77 B/step (sweep, now one-time) and 96.0 → 0.0 B/step (arclength).

**Timing (ns/step, same config):** unchanged-to-improved — HomotopySweep 72.4 → 70.4 µs/step and ArcLengthContinuation secant 48.1 → 47.8 µs/step on Julia 1.10; no regression on 1.11.

## Irreducible floor after this PR

On **Julia 1.11** the remaining per-step allocation is **96 B/step (sweep) / 224 B/step (arclength secant)**, attributed by Profile.Allocs to a single site: `last_sol = solve!(cache)` (the interior corrector solve). The cache is union-typed because `init` on a fully-concrete `NonlinearProblem{true, FullSpecialize, …}` with `NewtonRaphson` has a return type that widens to a two-member `{FullSpecialize, AutoSpecialize}` cache union (verified: `Base.return_types(init, …)` returns a 2-member union even with no kwargs and a concrete FullSpecialize input). Calling `solve!` on that union boxes the returned `NonlinearSolution` (whose two members differ in size) once per step. This is a **NonlinearSolveFirstOrder/SciMLBase `init` return-type-inference limitation upstream of these drivers** — the driver already constructs a concrete FullSpecialize problem (per #1044) and does everything right; there is no driver-level lever that removes it without changing `original`/failure-path semantics. On **Julia 1.10** this same box (~96 B) plus LinearSolve's ~900 B ipiv (cause 2) make up the residual 1245 B/step.

## Behavior

Byte-identical: the adaptive sweep and arclength both still land on `u = ones(50)` with max error 6.66e-16 (identical to master). The failure-path reads (`last_sol.resid`/`.retcode`, `original = last_sol`) are left as-is — they are O(1) per solve, not per interior step, and are already gated concretely by #1044's `store_original`.

## Tests

- All existing `test/Core/homotopy_sweep_tests*.jl` + `arclength_tests*.jl` + `*_jac_tests*.jl` pass unmodified: **273/273** on Julia 1.10.11 and **273/273** on Julia 1.11.9.
- Tightened `arclength_tests__item8.jl`: the default-inner bounds drop from 128 KB/160 KB (a pre-cache-driver artifact) to 6 KB/7 KB, and a NewtonRaphson-inner guard (< 1.1 KB secant / < 1.7 KB tangent) directly bounds the union-boxing regression.
- Added `homotopy_sweep_tests__item23.jl`: the sweep equivalent (default-inner < 7 KB, NewtonRaphson-inner < 1.5 KB, plus the land-on-ones correctness check).

Both regression files pass on Julia 1.10 and 1.11. Runic `--check` is clean on all changed files.

**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
