### PR TITLE
Make AutoSpecialize infer through functor residuals; zero-alloc homotopy stepping

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.35.0"
+version = "2.35.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseForwardDiffExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseForwardDiffExt.jl
@@ -63,6 +63,31 @@ function standardize_forwarddiff_tag(
     return _wrapped_forwarddiff_ad(eltype(prob.u0))
 end
 
+# Construct the `FunctionWrappersWrapper` bypassing the convenience constructor, mirroring
+# DiffEqBase's `_make_fww` (ext/DiffEqBaseForwardDiffExt.jl). The convenience constructor
+# builds its wrapper tuple with `map(argtypes, rettypes) do A, R; …; end`, whose closure
+# leaves `A`/`R` inferred as the join of the heterogeneous `argtypes` tuple, so the wrapper
+# type — and every cache built from the wrapped problem — widens to abstract whenever the
+# wrapped callable is one inference cannot see through: a functor such as the homotopy
+# drivers' `FixLambda` / `AugmentedHomotopy` / `HomotopyResidual` residuals (the same reason
+# DiffEqBase hit this with many-parameter `ODEFunction`s). Binding each arglist as a
+# `::Type{A}` type parameter makes `FunctionWrapper{Nothing, A}(vff)` fully inferrable, so
+# `typeof(fwt)` — and the wrapper — stays concrete. `vff` is `@nospecialize`d because it is
+# already type-erased through `Void` (that is what makes the norecompile path precompile).
+function _make_fww_iip(
+        @nospecialize(vff), ::Type{A1}, ::Type{A2}, ::Type{A3}, ::Type{A4}
+    ) where {A1, A2, A3, A4}
+    FW = FunctionWrappers.FunctionWrapper
+    fwt = (
+        FW{Nothing, A1}(vff), FW{Nothing, A2}(vff),
+        FW{Nothing, A3}(vff), FW{Nothing, A4}(vff),
+    )
+    cs = FunctionWrappersWrappers.SingleCacheStorage()
+    return FunctionWrappersWrappers.FunctionWrappersWrapper{
+        typeof(fwt), FunctionWrappersWrappers.AllowNonIsBits, typeof(cs),
+    }(fwt, cs)
+end
+
 # IIP wrapfun: wraps f(du, u, p) with dual-aware type combinations.
 # Works for any `AbstractArray` state; the Dual-eltype array type `VdT` is
 # derived via `typeof(similar(u0, dT))` so signatures follow the user's
@@ -78,15 +103,12 @@ end
     T = eltype(T1)
     dT = dualgen(T)
     VdT = typeof(similar(inputs[1], dT))
-    iip_arglists = (
+    return _make_fww_iip(
+        SciMLBase.Void(ff),
         Tuple{T1, T2, T3},
         Tuple{VdT, VdT, T3},
         Tuple{VdT, VdT, VdT},
         Tuple{VdT, T2, VdT},
-    )
-    iip_returnlists = (Nothing, Nothing, Nothing, Nothing)
-    return FunctionWrappersWrappers.FunctionWrappersWrapper(
-        SciMLBase.Void(ff), iip_arglists, iip_returnlists
     )
 end
 

--- a/lib/NonlinearSolveBase/src/homotopy_sweep.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_sweep.jl
@@ -278,22 +278,19 @@ end
 # the construction is exactly the bare positional one (the branch is decided by the
 # problem's type, so the unused arm is compiled away).
 #
-# `FullSpecialize` is required, not the `AutoSpecialize` default: the residual is a
-# `FixLambda` wrapper, and `AutoSpecialize`'s `FunctionWrappersWrapper` prototype
-# inference gives up on a wrapper-of-a-wrapper, so inference of the inner `solve` on the
-# resulting problem widens to `Any`. That `Any` reaches the drivers through the fresh
-# `solve(inner_prob, inner)` used for the exempt/anchor/landing solves
-# (`_sweep_exempt_solve`) and the arclength start/corrector solves — whose results are
-# stored into the driver's returned solution as `original`, pinning its `original`
-# type-slot to `Any` and making the whole driver `solve` infer as `Any`. `FullSpecialize`
-# keeps the residual concretely typed so those inner solves infer.
+# The default `AutoSpecialize` is kept: it wraps the `FixLambda` residual in a
+# `FunctionWrappersWrapper` whose fixed chunksize-1 `NonlinearSolveTag` dual signatures let
+# `init(inner_prob, inner)` infer to a concrete cache, so the driver's reused inner cache and
+# every per-step `solve!` are allocation-free (the `FunctionWrappersWrapper` is built through
+# the type-parameter-bound `_make_fww_iip` in the ForwardDiff extension — the naive
+# convenience constructor would have widened a functor residual's wrapper to `Any`).
 function _sweep_nonlinear_function(::Val{iip}, f, fixλ::FixLambda) where {iip}
     if f.jac === nothing && f.jac_prototype === nothing && f.sparsity === nothing &&
             f.colorvec === nothing
-        return SciMLBase.NonlinearFunction{iip, SciMLBase.FullSpecialize}(fixλ)
+        return SciMLBase.NonlinearFunction{iip}(fixλ)
     end
     jac = f.jac === nothing ? nothing : FixLambdaJac(fixλ)
-    return SciMLBase.NonlinearFunction{iip, SciMLBase.FullSpecialize}(
+    return SciMLBase.NonlinearFunction{iip}(
         fixλ; jac, jac_prototype = f.jac_prototype,
         sparsity = f.sparsity, colorvec = f.colorvec
     )

--- a/test/Core/homotopy_alloc_tests__item1.jl
+++ b/test/Core/homotopy_alloc_tests__item1.jl
@@ -1,0 +1,92 @@
+using NonlinearSolve
+
+using SciMLBase
+
+import NonlinearSolveBase as NLB
+
+# The continuation drivers wrap their residual in a `FixLambda` (sweep) / `AugmentedHomotopy`
+# / `HomotopyResidual` (arclength) *functor* and build the inner `NonlinearFunction` at the
+# `AutoSpecialize` default. `AutoSpecialize` wraps an in-place residual in a chunksize-1
+# `FunctionWrappersWrapper` whose fixed dual signatures let `init(inner_prob, inner)` infer to
+# a concrete cache, so the driver's reused inner cache and every per-step `solve!` are
+# allocation-free. That wrapper must be constructed with its arglist types bound as type
+# parameters (`_make_fww_iip`, ForwardDiff ext, mirroring DiffEqBase's `_make_fww`); the naive
+# `FunctionWrappersWrapper(f, argtypes, rettypes)` convenience constructor's `map` closure
+# instead widens a functor's wrapper — and every cache built from the wrapped problem — to
+# `Any`, boxing every field read of every interior solve. These tests pin that guarantee.
+
+Hiip!(du, u, p, λ) = (du[1] = (1 - λ) * (u[1] - p[1]) + λ * (u[1]^2 - p[1]); nothing)
+prob = HomotopyProblem(Hiip!, [4.0], [4.0])
+
+# --- the wrapped inner problem infers a concrete cache (the property that makes stepping
+# allocation-free); a functor residual must not widen `init` to `Any` ---
+fixλ = NLB.FixLambda(prob.f, 0.3)
+fλ = NLB._sweep_nonlinear_function(Val(true), prob.f, fixλ)
+@test SciMLBase.specialization(fλ) === SciMLBase.AutoSpecialize
+inner_prob = NonlinearProblem(fλ, [4.0], [4.0])
+inner_rts = Base.return_types(SciMLBase.init, (typeof(inner_prob), typeof(NewtonRaphson())))
+@test length(inner_rts) == 1
+@test inner_rts[1] !== Any
+@test isconcretetype(inner_rts[1])
+
+# --- the wrapper itself is concretely inferred for a functor (the direct unit under test) ---
+wrapped = NLB.maybe_wrap_nonlinear_f(inner_prob)
+@test NLB.is_fw_wrapped(wrapped)
+@test isconcretetype(only(Base.return_types(NLB.maybe_wrap_nonlinear_f, (typeof(inner_prob),))))
+
+# --- end-to-end per-step allocation with a clean `NewtonRaphson` inner. The slope between two
+# fixed-step runs cancels compile/one-time-init cost, leaving pure per-step allocation. Gated
+# on Julia 1.11+: the LinearSolve factorization-workspace reuse that removes the last
+# per-step bytes is only active there (v1.10 is allowed to allocate the pivot vector). ---
+nbig = 50
+function Hbig!(r, u, p, λ)
+    n = length(u)
+    for i in 1:n
+        acc = u[i]
+        i > 1 && (acc += 0.25 * u[i - 1])
+        i < n && (acc += 0.25 * u[i + 1])
+        r[i] = acc + λ * u[i]^3 - p.c[i]
+    end
+    return nothing
+end
+cbig = [1.0 + 0.25 * ((i > 1) + (i < nbig)) + 1.0 for i in 1:nbig]
+prob_big = HomotopyProblem(Hbig!, ones(nbig), (c = cbig,); λspan = (0.0, 1.0))
+
+function sweep_per_step(prob; N1 = 50, N2 = 250)
+    mk = M -> HomotopySweep(; inner = NewtonRaphson(), adaptive = false, nsteps = M)
+    solve(prob, mk(5))
+    solve(prob, mk(5))
+    GC.gc()
+    a1 = @allocated solve(prob, mk(N1))
+    GC.gc()
+    a2 = @allocated solve(prob, mk(N2))
+    return (a2 - a1) / (N2 - N1)
+end
+
+function arclength_per_step(prob; N1 = 50, N2 = 250)
+    mk = M -> ArcLengthContinuation(;
+        inner = NewtonRaphson(), adaptive = false, initial_step_factor = 1.0e-4, maxsteps = M
+    )
+    solve(prob, mk(5))
+    solve(prob, mk(5))
+    GC.gc()
+    a1 = @allocated solve(prob, mk(N1))
+    GC.gc()
+    a2 = @allocated solve(prob, mk(N2))
+    return (a2 - a1) / (N2 - N1)
+end
+
+if VERSION >= v"1.11"
+    # The pre-fix functor-boxing cost 96 B/step (sweep) / 320 B/step (arclength); with the
+    # concrete wrapper both are 0. A small nonzero budget absorbs allocator noise while still
+    # failing loudly if the `Any`-widening regresses.
+    @test sweep_per_step(prob_big) < 48
+    @test arclength_per_step(prob_big) < 48
+end
+
+# --- the fixed-step measurement configuration must not change the answer ---
+@test SciMLBase.successful_retcode(solve(prob_big, HomotopySweep(; inner = NewtonRaphson())))
+let sol = solve(prob_big, ArcLengthContinuation(; inner = NewtonRaphson()))
+    @test SciMLBase.successful_retcode(sol)
+    @test maximum(abs, sol.u .- 1.0) < 1.0e-6
+end

--- a/test/Core/homotopy_jac_tests__item1.jl
+++ b/test/Core/homotopy_jac_tests__item1.jl
@@ -120,15 +120,16 @@ resid_proto = zeros(n)
 f_band(resid_proto, sol_proto.u, 1.0, 1.0)
 @test maximum(abs, resid_proto) < 1.0e-8
 
-# --- No derivative fields: the inner function is the bare positional construction,
-# built `FullSpecialize` so the inner `solve` on the FixLambda-wrapped problem infers
-# (the `AutoSpecialize` default's FunctionWrappersWrapper prototype inference bails on the
-# wrapper-of-a-wrapper, widening the driver's returned solution type to `Any`). ---
+# --- No derivative fields: the inner function is the bare positional construction, left at
+# the `AutoSpecialize` default so the FixLambda-wrapped residual is wrapped in a chunksize-1
+# `FunctionWrappersWrapper` and the inner `solve` infers to a concrete cache (allocation-free
+# stepping). The wrapper is built through the type-parameter-bound `_make_fww_iip` in the
+# ForwardDiff extension, so the functor residual no longer widens its wrapper to `Any`. ---
 import NonlinearSolveBase
 fixλ = NonlinearSolveBase.FixLambda(prob_ad.f, 0.0)
 fλ_plain = NonlinearSolveBase._sweep_nonlinear_function(Val(false), prob_ad.f, fixλ)
-@test typeof(fλ_plain) ==
-    typeof(SciMLBase.NonlinearFunction{false, SciMLBase.FullSpecialize}(fixλ))
+@test typeof(fλ_plain) == typeof(SciMLBase.NonlinearFunction{false}(fixλ))
+@test SciMLBase.specialization(fλ_plain) === SciMLBase.AutoSpecialize
 @test fλ_plain.jac === nothing
 @test fλ_plain.jac_prototype === nothing
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,6 +97,7 @@ else
             @time @safetestset "ArcLengthContinuation corrector cache per-step allocations" include("Core/arclength_tests__item8.jl")
             @time @safetestset "Homotopy sweeps consume jac/jac_prototype/sparsity/colorvec" include("Core/homotopy_jac_tests__item1.jl")
             @time @safetestset "ArcLengthContinuation consumes jac/jac_prototype/sparsity/colorvec" include("Core/arclength_jac_tests__item1.jl")
+            @time @safetestset "Continuation drivers infer a concrete inner cache (AutoSpecialize functor wrapper) + zero-alloc stepping" include("Core/homotopy_alloc_tests__item1.jl")
             @time @safetestset "Homotopy tracking_maxiters caps interior corrector work" include("Core/homotopy_effort_tests__item1.jl")
             @time @safetestset "Homotopy maxsteps guard + effort-band step control" include("Core/homotopy_effort_tests__item2.jl")
             @time @safetestset "Homotopy tracking_abstol loosens interior tracking only" include("Core/homotopy_tolerance_tests__item1.jl")


### PR DESCRIPTION
**Note: This PR should be ignored until reviewed by @ChrisRackauckas.**

## Summary

The homotopy continuation drivers (`HomotopySweep`, `ArcLengthContinuation`) wrap their residual in a *functor* — `FixLambda` for the sweep, `AugmentedHomotopy`/`HomotopyResidual` for arclength — and build the inner `NonlinearFunction` at the `AutoSpecialize` default. `AutoSpecialize` wraps an in-place residual in a chunksize-1 `FunctionWrappersWrapper`, whose fixed dual signatures should let `init(inner_prob, inner)` infer a **concrete** cache so the driver's reused inner cache and every per-step `solve!` are allocation-free.

For a **functor** residual the inferred wrapper type instead widened to `Any`, so every interior `solve!` and every `.u`/`.resid`/`.retcode`/`.stats` read boxed. Measured on Julia 1.11, N = 50:

| driver | before | after |
|---|---|---|
| `HomotopySweep` (inner `NewtonRaphson`) | 96 B/step | **0 B/step** |
| `ArcLengthContinuation` (inner `NewtonRaphson`) | 320 B/step | **0 B/step** |

## Root cause

`FunctionWrappersWrapper`'s `(f, argtypes, rettypes)` convenience constructor builds its wrapper tuple with `map(argtypes, rettypes) do A, R; FunctionWrapper{R, A}(f); end`. The closure leaves `A`/`R` inferred as the *join* of the heterogeneous `argtypes` tuple, so `typeof(fwt)` — and hence the wrapper, and every cache built from the wrapped problem — widens to abstract whenever the wrapped callable is one inference cannot see through. A functor is exactly such a callable (DiffEqBase hit the identical problem with many-parameter `ODEFunction`s). The *runtime* wrapper value is concrete and identical to the plain-function case; only its inferred type differed.

## Fix

`wrapfun_iip` (ForwardDiff extension) now builds the wrapper through a `_make_fww_iip` helper that binds each arglist as a `::Type{A}` type parameter, exactly mirroring [DiffEqBase's `_make_fww`](https://github.com/SciML/DiffEqBase.jl/blob/master/ext/DiffEqBaseForwardDiffExt.jl). That keeps `typeof(fwt)` concrete, so the wrapped functor problem's `init` infers concretely and the drivers step allocation-free.

With that in place the sweep no longer needs to opt into `FullSpecialize` (which had been added only to dodge the `Any`-widening at the cost of extra specialization / no wrapper reuse): the sweep and arclength both use the `AutoSpecialize` default again, and **arclength drops from 320 → 0 B/step with no arclength source change** — purely from the `wrapfun_iip` fix.

The `wrapfun_iip` change is a pure inference improvement (the runtime `FunctionWrappersWrapper` value/type is unchanged), so it benefits every in-place `AutoSpecialize` functor residual, not just the homotopy drivers.

## Scope / notes

- 0 B/step is on **Julia 1.11+**; v1.10 may still allocate the LinearSolve pivot vector (out of scope here).
- `SimpleNewtonRaphson` as a homotopy inner remains ~100 KB/step — it implements no cache-reuse interface and cold-re-solves each step (a SimpleNonlinearSolve limitation, scoped to scalar/StaticArray problems; unaffected by this PR).

## Tests

- **`homotopy_alloc_tests__item1.jl`** (new): pins the inference guarantee (the functor's wrapper no longer widens `init` to `Any`; deterministic) and the zero-alloc stepping for both drivers with a clean `NewtonRaphson` inner (gated on v1.11+).
- **`homotopy_jac_tests__item1.jl`**: updated to assert the inner function is now built `AutoSpecialize`.
- Full `Core` homotopy/arclength suite (incl. `*_jac`, `*_tests__item22`, polyalg warm-handoff) passes locally on Julia 1.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)