### PR TITLE
Support AbstractSciMLOperator Jacobians (matrix-free vs factorization by trait)

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.35.1"
+version = "2.36.0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
+++ b/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
@@ -29,7 +29,8 @@ using SciMLBase: SciMLBase, ReturnCode, AbstractODEIntegrator, AbstractNonlinear
 import SciMLBase: solve, init, __init, __solve, wrap_sol, get_root_indp, isinplace, remake
 
 using SciMLJacobianOperators: JacobianOperator, StatefulJacobianOperator
-using SciMLOperators: AbstractSciMLOperator, IdentityOperator
+using SciMLOperators: AbstractSciMLOperator, IdentityOperator, isconvertible, isconstant,
+    update_coefficients!
 using SciMLLogging: SciMLLogging, @SciMLMessage, @verbosity_specifier,
     AbstractVerbositySpecifier, AbstractVerbosityPreset, MessageLevel,
     None, Minimal, Standard, Detailed, All, Silent, InfoLevel, WarnLevel

--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -36,6 +36,10 @@ function construct_jacobian_cache(
         linsolve = missing
     )
     has_analytic_jac = SciMLBase.has_jac(f)
+    # A SciMLOperator `jac_prototype` is used as the Jacobian directly (matrix-free `mul!`
+    # for iterative solvers, lazy `convert` for factorizations) rather than being AD'd or
+    # `similar`'d, so it skips the concrete/di_extras machinery below.
+    op_jac = f.jac_prototype isa AbstractSciMLOperator ? f.jac_prototype : nothing
     linsolve_needs_jac = !concrete_jac(alg) && (
         linsolve === missing ||
             (linsolve === nothing || needs_concrete_A(linsolve))
@@ -44,7 +48,7 @@ function construct_jacobian_cache(
 
     fu_cache = Utils.safe_similar(fu)
 
-    if !has_analytic_jac && needs_jac
+    if op_jac === nothing && !has_analytic_jac && needs_jac
         if autodiff === nothing
             throw(ArgumentError("`autodiff` argument to `construct_jacobian_cache` must be \
                                  specified and cannot be `nothing`. Use \
@@ -70,7 +74,20 @@ function construct_jacobian_cache(
         di_extras = nothing
     end
 
-    J = if !needs_jac
+    J = if op_jac !== nothing
+        # Hand the operator straight through. An iterative solver applies it matrix-free
+        # via `mul!`; a factorization materializes it lazily with `convert(AbstractMatrix,
+        # ·)`. Guard the latter: a genuinely matrix-free (non-convertible) operator cannot
+        # be handed to a solver that needs a concrete `A`.
+        if needs_jac && !isconvertible(op_jac)
+            throw(ArgumentError("The supplied Jacobian operator `$(typeof(op_jac))` is \
+                not convertible to a concrete matrix, but the selected linear solver \
+                requires a concrete `A`. Use a matrix-free linear solver (e.g. \
+                `KrylovJL_GMRES()`) or supply a convertible operator / concrete \
+                `jac_prototype`."))
+        end
+        op_jac
+    elseif !needs_jac
         # Standardize JVP/VJP autodiff tags to match FunctionWrapper signatures
         _jvp_ad = standardize_forwarddiff_tag(jvp_autodiff, prob)
         _vjp_ad = standardize_forwarddiff_tag(vjp_autodiff, prob)
@@ -171,6 +188,13 @@ initialization.
 """
 reused_jacobian(cache::JacobianCache, u) = cache.J
 reused_jacobian(cache::JacobianCache{<:JacobianOperator}, u) = StatefulJacobianOperator(cache.J, u, cache.p)
+function reused_jacobian(cache::JacobianCache{<:AbstractSciMLOperator}, u)
+    # Refresh only a genuinely state-dependent operator. A constant operator (a
+    # `MatrixOperator`, or an externally-maintained `WOperator` whose state the caller
+    # owns) is skipped; `t = nothing` because a `NonlinearProblem` has no time.
+    isconstant(cache.J) || update_coefficients!(cache.J, u, cache.p, nothing)
+    return cache.J
+end
 
 # Core Computation
 ## Numbers
@@ -215,6 +239,11 @@ end
 
 function (cache::JacobianCache{<:JacobianOperator})(u)
     return StatefulJacobianOperator(cache.J, u, cache.p)
+end
+
+function (cache::JacobianCache{<:AbstractSciMLOperator})(u)
+    isconstant(cache.J) || update_coefficients!(cache.J, u, cache.p, nothing)
+    return cache.J
 end
 
 # Sparse Automatic Differentiation

--- a/lib/NonlinearSolveBase/src/linear_solve.jl
+++ b/lib/NonlinearSolveBase/src/linear_solve.jl
@@ -90,6 +90,12 @@ function construct_linear_solver(
         # caller-forced aliasing: the caller owns A/b outright (e.g. the inverse-Jacobian
         # workspace), so no defensive copy of A is made
         linprob = LinearProblem(A, b, LinearSolveParameters(u_fixed, p); u0 = u_cache)
+    elseif A isa AbstractSciMLOperator
+        # A SciMLOperator `A` is externally maintained (refreshed in place by
+        # `update_coefficients!`), so alias it: copying would sever those in-place updates
+        # and, for some operators, change the concrete type (breaking the later `A`-rebind).
+        linprob = LinearProblem(A, b, LinearSolveParameters(u_fixed, p); u0 = u_cache)
+        alias = LinearAliasSpecifier(alias_A = true, alias_b = false)
     elseif alias_A_for_refactorization(linsolve, A)
         # Hand LinearSolve a NonlinearSolve-owned copy of `A` with `alias_A = true`:
         # one O(n²) copy here at init instead of one per refactorization inside

--- a/lib/NonlinearSolveBase/test/operator_jacobian.jl
+++ b/lib/NonlinearSolveBase/test/operator_jacobian.jl
@@ -1,0 +1,50 @@
+using NonlinearSolveBase, NonlinearSolve, LinearSolve, SciMLOperators, SciMLBase
+using LinearAlgebra, SparseArrays, Test
+using SciMLOperators: AbstractSciMLOperator, isconvertible
+
+# A `jac_prototype` that is an `AbstractSciMLOperator` is handed to the solver as the
+# Jacobian directly: an iterative solver applies it matrix-free via `mul!`, while a
+# factorization materializes it lazily via `convert(AbstractMatrix, ·)`. The choice is
+# routed by `needs_concrete_A(linsolve)` (like NLNewton); `isconvertible(op)` guards the
+# factorization path.
+
+const N = 40
+const Wmat = sparse(Tridiagonal(fill(-1.0, N - 1), fill(4.0, N), fill(-1.0, N - 1)))
+const bvec = collect(1.0:N)
+resid!(F, z, p) = (mul!(F, Wmat, z); F .-= bvec; return nothing)
+const xref = Wmat \ bvec
+
+@testset "convertible operator (MatrixOperator): matrix-free Krylov, materialized direct" begin
+    mop = MatrixOperator(copy(Wmat))
+    @test isconvertible(mop)
+    prob = NonlinearProblem(NonlinearFunction(resid!; jac_prototype = mop), zeros(N))
+
+    for ls in (KrylovJL_GMRES(), LUFactorization(), KLUFactorization())
+        cache = init(prob, NewtonRaphson(linsolve = ls))
+        # The cache holds the operator itself, never a residual-derived JacobianOperator.
+        @test cache.jac_cache.J isa AbstractSciMLOperator
+        sol = solve!(cache)
+        @test SciMLBase.successful_retcode(sol)
+        @test sol.u ≈ xref
+    end
+end
+
+@testset "non-convertible operator: Krylov ok, factorization guarded" begin
+    fop = FunctionOperator(
+        (w, v, u, p, t) -> mul!(w, Wmat, v), zeros(N), zeros(N);
+        islinear = true
+    )
+    @test !isconvertible(fop)
+    prob = NonlinearProblem(NonlinearFunction(resid!; jac_prototype = fop), zeros(N))
+
+    # A concrete-A solver on a non-convertible operator errors clearly at construction
+    # (rather than deep in LinearSolve's `convert`).
+    @test_throws ArgumentError init(prob, NewtonRaphson(linsolve = LUFactorization()))
+end
+
+@testset "operator-free problems are unaffected" begin
+    f!(F, z, p) = (@. F = z^2 - 2; nothing)
+    sol = solve(NonlinearProblem(NonlinearFunction(f!), ones(3)), NewtonRaphson())
+    @test SciMLBase.successful_retcode(sol)
+    @test all(x -> abs(x - sqrt(2)) < 1.0e-8, sol.u)
+end

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -126,9 +126,11 @@ run_tests(;
 
         @safetestset "Linear solver routing" include("linear_solver_routing.jl")
 
-        return @safetestset "Dense LU refactorization allocations" include(
+        @safetestset "Dense LU refactorization allocations" include(
             "lu_refactorization_allocs.jl"
         )
+
+        return @safetestset "SciMLOperator Jacobians" include("operator_jacobian.jl")
     end,
     # QA (Aqua/ExplicitImports via SciMLTesting.run_qa) is a dep-adding group: it runs
     # in its own isolated sub-env under test/qa (excluded from the base/Core/All run).


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Draft opened by an agent.

## What

A `NonlinearFunction` can now carry an `AbstractSciMLOperator` as its `jac_prototype`, and NonlinearSolve uses it as the Jacobian directly — matrix-free for iterative solvers, materialized for factorizations — choosing between them with the SciMLOperators convertibility trait, the way OrdinaryDiffEq's NLNewton handles its `WOperator`.

## Why

Today, when the linear solver is matrix-free (`needs_concrete_A == false`, e.g. `KrylovJL_GMRES`), `construct_jacobian_cache` **always** builds a residual-derived AD `JacobianOperator`, ignoring any operator the caller could supply. That means (a) a user-provided operator Jacobian is never reused, and (b) with ForwardDiff it differentiates the residual — which, for OrdinaryDiffEq's `NonlinearSolveAlg` inner solve over a `FullSpecialize`-FunctionWrapped ODE residual, crashes with `No matching function wrapper was found!`.

## How

In `construct_jacobian_cache` (`jacobian.jl`):
- Detect `op = f.jac_prototype isa AbstractSciMLOperator`.
- **Matrix-free path** (`needs_jac == false`): return `op` as `J`. The descent forwards it to LinearSolve as `A`; GMRES applies it via `mul!`. No AD JVP is built over the residual → the ForwardDiff crash disappears.
- **Concrete/factorization path** (`needs_jac == true`): also return `op`; LinearSolve materializes it lazily via `convert(AbstractMatrix, ·)`. Guarded by `isconvertible(op)` — a genuinely matrix-free operator handed to a concrete-A solver raises a clear `ArgumentError` instead of failing deep in LinearSolve.
- Routing stays on `needs_concrete_A(linsolve)` (like NLNewton); `isconvertible` is the guard, not the router (it is vacuously `true` for a `WOperator`, so it can't route).
- `reused_jacobian`/the per-iteration cache callable refresh a state-dependent operator via `update_coefficients!(op, u, p, nothing)`, skipped when `isconstant(op)` (a `MatrixOperator`, or an externally-maintained `WOperator` whose state the caller owns; `t = nothing` because a `NonlinearProblem` has no time).

In `construct_linear_solver` (`linear_solve.jl`): alias a SciMLOperator `A` (`alias_A = true`) instead of copying it — the operator is refreshed in place, and copying can change its concrete type, which would break the later in-place `A` rebind.

## Backward compatibility

Every new branch is gated on `f.jac_prototype isa AbstractSciMLOperator`. A `nothing` or concrete-`AbstractMatrix` prototype is byte-identical to before (residual-AD path and concrete `similar` path unchanged). NonlinearSolveBase minor version bump (new additive public behavior). `isconvertible`/`isconstant`/`update_coefficients!` are public in SciMLOperators since v0.3.5, so the existing `"1.7"` compat is fine.

## Tests + verification

New `lib/NonlinearSolveBase/test/operator_jacobian.jl`:
- `MatrixOperator` jac_prototype + `KrylovJL_GMRES` → Success, `jac_cache.J isa AbstractSciMLOperator` (matrix-free); + `LUFactorization`/`KLUFactorization` → Success (materialized), solution matches reference.
- non-convertible `FunctionOperator` + `LUFactorization` → the `ArgumentError` guard fires at construction.
- operator-free problems unchanged.

Verified locally (Julia 1.12): the new test passes on this branch, and the **full NonlinearSolveBase suite passes** with the change. End-to-end against OrdinaryDiffEq (companion PR): the `NonlinearSolveAlg(NewtonRaphson(autodiff=AutoForwardDiff())) + KrylovJL_GMRES` crash becomes `Success` with the ODE's `WOperator` reused matrix-free; all six `{FiniteDiff,ForwardDiff} × {GMRES,KLU,LU}` combos converge identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)