### PR TITLE
Fix operator jac_prototype Jacobian cache (follow-up to #1047)

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.34.0"
+version = "2.34.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
+++ b/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
@@ -29,7 +29,7 @@ using SciMLBase: SciMLBase, ReturnCode, AbstractODEIntegrator, AbstractNonlinear
 import SciMLBase: solve, init, __init, __solve, wrap_sol, get_root_indp, isinplace, remake
 
 using SciMLJacobianOperators: JacobianOperator, StatefulJacobianOperator
-using SciMLOperators: AbstractSciMLOperator, IdentityOperator, isconvertible, isconstant,
+using SciMLOperators: AbstractSciMLOperator, IdentityOperator, isconvertible,
     update_coefficients!
 using SciMLLogging: SciMLLogging, @SciMLMessage, @verbosity_specifier,
     AbstractVerbositySpecifier, AbstractVerbosityPreset, MessageLevel,

--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -188,13 +188,8 @@ initialization.
 """
 reused_jacobian(cache::JacobianCache, u) = cache.J
 reused_jacobian(cache::JacobianCache{<:JacobianOperator}, u) = StatefulJacobianOperator(cache.J, u, cache.p)
-function reused_jacobian(cache::JacobianCache{<:AbstractSciMLOperator}, u)
-    # Refresh only a genuinely state-dependent operator. A constant operator (a
-    # `MatrixOperator`, or an externally-maintained `WOperator` whose state the caller
-    # owns) is skipped; `t = nothing` because a `NonlinearProblem` has no time.
-    isconstant(cache.J) || update_coefficients!(cache.J, u, cache.p, nothing)
-    return cache.J
-end
+# A reused operator Jacobian is returned as-is (the generic `reused_jacobian` returns
+# `cache.J`); no special method is needed.
 
 # Core Computation
 ## Numbers
@@ -242,7 +237,23 @@ function (cache::JacobianCache{<:JacobianOperator})(u)
 end
 
 function (cache::JacobianCache{<:AbstractSciMLOperator})(u)
-    isconstant(cache.J) || update_coefficients!(cache.J, u, cache.p, nothing)
+    (; f, p) = cache
+    if SciMLBase.has_jac(f) && f.jac !== update_coefficients!
+        # A user-supplied analytic Jacobian that returns/updates an operator (e.g.
+        # `jac(u, p)` returning a `MatrixOperator`). Mirror the concrete `has_jac` path.
+        cache.stats.njacs += 1
+        if SciMLBase.isinplace(f)
+            f.jac(cache.J, u, p)
+        else
+            cache.J = f.jac(u, p)
+        end
+    end
+    # Otherwise the operator is used as-is, held fixed across the solve's Newton iterations
+    # (as NLNewton holds `W` fixed). This covers a constant operator and the case where
+    # SciMLBase auto-wired `f.jac = update_coefficients!` for an operator `jac_prototype`:
+    # NonlinearSolve does not refresh it, since a `NonlinearProblem` has no time and its `p`
+    # may be `NullParameters`. Its owner — e.g. the ODE integrator via `_update_nlsolvealg_W!`
+    # — refreshes the operator's coefficients with the correct `t`/`gamma` between solves.
     return cache.J
 end
 

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -126,11 +126,9 @@ run_tests(;
 
         @safetestset "Linear solver routing" include("linear_solver_routing.jl")
 
-        @safetestset "Dense LU refactorization allocations" include(
+        return @safetestset "Dense LU refactorization allocations" include(
             "lu_refactorization_allocs.jl"
         )
-
-        return @safetestset "SciMLOperator Jacobians" include("operator_jacobian.jl")
     end,
     # QA (Aqua/ExplicitImports via SciMLTesting.run_qa) is a dep-adding group: it runs
     # in its own isolated sub-env under test/qa (excluded from the base/Core/All run).

--- a/lib/NonlinearSolveFirstOrder/test/operator_jacobian.jl
+++ b/lib/NonlinearSolveFirstOrder/test/operator_jacobian.jl
@@ -1,4 +1,4 @@
-using NonlinearSolveBase, NonlinearSolve, LinearSolve, SciMLOperators, SciMLBase
+using NonlinearSolveFirstOrder, LinearSolve, SciMLOperators, SciMLBase
 using LinearAlgebra, SparseArrays, Test
 using SciMLOperators: AbstractSciMLOperator, isconvertible
 

--- a/lib/NonlinearSolveFirstOrder/test/runtests.jl
+++ b/lib/NonlinearSolveFirstOrder/test/runtests.jl
@@ -15,7 +15,8 @@ run_tests(;
         include("least_squares_tests.jl")
         include("misc_tests.jl")
         include("rootfind_tests.jl")
-        return include("sparsity_tests.jl")
+        include("sparsity_tests.jl")
+        return @safetestset "SciMLOperator Jacobians" include("operator_jacobian.jl")
     end,
     # QA (Aqua/ExplicitImports via SciMLTesting.run_qa) is a dep-adding group: it runs
     # in its own isolated sub-env under test/qa (excluded from the base/Core/All run).


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Follow-up to #1047, which merged with two sublibrary test regressions now failing on `master`:

### 1. `NonlinearSolveBase` Core — test-file dependency
`lib/NonlinearSolveBase/test/operator_jacobian.jl` did `using NonlinearSolve` (the umbrella package), which is not a dependency of the `NonlinearSolveBase` sublibrary test environment, so the file failed to load. Moved it to `NonlinearSolveFirstOrder` (which actually provides `NewtonRaphson`) and switched the import to `using NonlinearSolveFirstOrder`.

### 2. `NonlinearSolveFirstOrder` Core — operator `jac_prototype` handling
`rootfind_tests__item2.jl`'s *"NewtonRaphson with SciMLOperator jac_prototype"* failed because the `JacobianCache{<:AbstractSciMLOperator}` callable called `update_coefficients!(cache.J, u, cache.p, nothing)` unconditionally, ignoring a user-supplied `jac` and leaving the operator at its (zero) prototype.

The callable now:

- calls a **genuine user `jac`** (`f.jac !== update_coefficients!`) with the concrete `(J, u, p)` / `(u, p)` convention, mirroring the concrete `has_jac` path;
- otherwise returns the operator **as-is**, held fixed across a solve's Newton iterations (as `NLNewton` holds `W` fixed). NonlinearSolve does not refresh it — a `NonlinearProblem` has no time and its `p` may be `NullParameters`. The operator's owner — e.g. the ODE integrator via `_update_nlsolvealg_W!` — refreshes its coefficients with the correct `t`/`gamma` between solves. (A state-dependent Jacobian for a standalone `NonlinearProblem` is expressed via `f.jac`, the user-jac path above.)

For an operator `jac_prototype`, SciMLBase auto-wires `f.jac = update_coefficients!` — an in-place updater with signature `(J, u, p, t)`; the previous callable's `f.jac(J, u, p)` (3-arg, no time) is what crashed. The `f.jac !== update_coefficients!` guard skips it.

Also drops the now-unused `reused_jacobian`/`isconstant` operator special-casing.

### Tests
`NonlinearSolveFirstOrder/test/operator_jacobian.jl` covers matrix-free Krylov vs materialized-factorization routing (`MatrixOperator` + GMRES/LU/KLU) and the non-convertible guard (`FunctionOperator` + factorization → clean `ArgumentError`).

### Local verification (Julia 1.12, this branch)
- `rootfind_tests__item2.jl`: **309/309 pass**
- `operator_jacobian.jl`: **14/14 pass**

Patch bump `NonlinearSolveBase` 2.34.0 → 2.34.1 (bugfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)