### PR TITLE
Restore NonlinearSolveBase version to 2.34.1 (fixes broken monorepo-wide local resolution)

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.33.0"
+version = "2.34.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
553e2a60 ("Downgrade version from 2.34.1 to 2.33.0") changed only the version label -- content since is byte-identical to what's already registered as 2.34.1 (verified via `compare`, only Project.toml differs). But 2.33.0 doesn't satisfy NonlinearSolveQuasiNewton's / NonlinearSolveHomotopyContinuation's correct `NonlinearSolveBase = "2.34.0 - 2"` floors, breaking local monorepo dependency resolution for essentially the entire test matrix (see PR #1051's CI: `Unsatisfiable requirements ... NonlinearSolveBase is fixed to version 2.33.0 ... restricted to versions 2.34.0 - 2`). Restoring to 2.34.1, already registered, no new release needed.