### PR TITLE
Preserve triangular solves for Broyden Jacobian inversion

### DIFF
--- a/lib/NonlinearSolveBase/src/utils.jl
+++ b/lib/NonlinearSolveBase/src/utils.jl
@@ -311,7 +311,7 @@ function linsolve_identity!!(workspace, A::AbstractMatrix)
             return LinearAlgebra.ldiv!(LinearAlgebra.LowerTriangular(A_solve), ws.rhs)
         end
     end
-    return ws.lincache(; A, b = ws.rhs).u
+    return ws.lincache(; A = A_solve, b = ws.rhs).u
 end
 
 function initial_jacobian_scaling_alpha(α, u, fu, ::Any)

--- a/lib/NonlinearSolveBase/src/utils.jl
+++ b/lib/NonlinearSolveBase/src/utils.jl
@@ -254,7 +254,7 @@ function linsolve_workspace(A::AbstractMatrix)
         stats = SciMLBase.NLStats(0, 0, 0, 0, 0),
         alias = SciMLBase.LinearAliasSpecifier(alias_A = true, alias_b = true)
     )
-    return (; lincache, rhs), A
+    return (; lincache, rhs, A_buf), A
 end
 
 # scalar analog of the default solver's least-squares rescue: a singular (zero) entry
@@ -290,7 +290,27 @@ function linsolve_identity!!(workspace, A::AbstractMatrix)
     # buffer, so A is never mutated and passing the previously returned inverse as A is
     # safe. On singular A the default algorithm's pivoted-QR rescue returns a finite
     # least-squares generalized inverse (not the SVD `pinv`).
+    # The triangular solve returns `rhs` itself, so a nested reinversion can pass that
+    # buffer back as `A`. Preserve its contents before refilling the identity RHS.
+    A_solve = if A === ws.rhs
+        copyto!(ws.A_buf, A)
+        ws.A_buf
+    else
+        A
+    end
     make_identity!!(ws.rhs, true)
+    if A_solve isa StridedMatrix
+        diagonal = @view A_solve[LinearAlgebra.diagind(A_solve)]
+        nonsingular = !any(iszero, diagonal)
+        # Preserve exact triangular structure instead of allowing pivoted LU roundoff to
+        # alter sensitive quasi-Newton trajectories. Singular matrices still need the
+        # default solver's pivoted-QR rescue below.
+        if nonsingular && LinearAlgebra.istriu(A_solve)
+            return LinearAlgebra.ldiv!(LinearAlgebra.UpperTriangular(A_solve), ws.rhs)
+        elseif nonsingular && LinearAlgebra.istril(A_solve)
+            return LinearAlgebra.ldiv!(LinearAlgebra.LowerTriangular(A_solve), ws.rhs)
+        end
+    end
     return ws.lincache(; A, b = ws.rhs).u
 end
 

--- a/lib/NonlinearSolveBase/test/linsolve_workspace.jl
+++ b/lib/NonlinearSolveBase/test/linsolve_workspace.jl
@@ -40,6 +40,10 @@ end
     expected_reset = Matrix{Float64}(I, 3, 3)
     ldiv!(LowerTriangular(A_reset), expected_reset)
     @test Utils.linsolve_identity!!(workspace, A_reset) == expected_reset
+
+    A_general = [2.0 1.0 0.0; 0.0 3.0 1.0; 1.0 0.0 4.0]
+    copyto!(workspace.rhs, A_general)
+    @test Utils.linsolve_identity!!(workspace, workspace.rhs) ≈ inv(A_general)
 end
 
 @testset "singular input takes the pivoted-QR rescue" begin

--- a/lib/NonlinearSolveBase/test/linsolve_workspace.jl
+++ b/lib/NonlinearSolveBase/test/linsolve_workspace.jl
@@ -29,6 +29,19 @@ using Test
     end
 end
 
+@testset "dense triangular input preserves triangular solve semantics" begin
+    A = [1.1 0.0 0.0; 3.2 2.2 0.0; -4.1 5.3 3.3]
+    expected = Matrix{Float64}(I, 3, 3)
+    ldiv!(LowerTriangular(A), expected)
+    workspace, _ = Utils.linsolve_workspace(A)
+    @test Utils.linsolve_identity!!(workspace, A) == expected
+
+    A_reset = [0.1 0.0 0.0; 100.3 0.2 0.0; -44.1 55.3 0.3]
+    expected_reset = Matrix{Float64}(I, 3, 3)
+    ldiv!(LowerTriangular(A_reset), expected_reset)
+    @test Utils.linsolve_identity!!(workspace, A_reset) == expected_reset
+end
+
 @testset "singular input takes the pivoted-QR rescue" begin
     # The result is the LinearSolve default algorithm's least-squares generalized
     # inverse from its singular-LU → pivoted-QR rescue, NOT the SVD `pinv` (an

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests.jl
@@ -7,3 +7,4 @@
 @safetestset "LimitedMemoryBroyden" include("core_tests__item7.jl")
 @safetestset "LimitedMemoryBroyden: Iterator Interface" include("core_tests__item8.jl")
 @safetestset "LimitedMemoryBroyden Termination Conditions" include("core_tests__item9.jl")
+@safetestset "Bad Broyden with a triangular true Jacobian" include("core_tests__item10.jl")

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests__item10.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests__item10.jl
@@ -1,0 +1,20 @@
+using NonlinearSolveQuasiNewton
+using SciMLBase
+using Test
+
+function generalized_rosenbrock!(out, x, p)
+    out[1] = 1.0 - x[1]
+    @views @. out[2:end] = 10.0 * (x[2:end] - x[1:(end - 1)]^2)
+    return nothing
+end
+
+x0 = ones(10)
+x0[1] = -1.2
+prob = NonlinearProblem(generalized_rosenbrock!, x0)
+alg = Broyden(; init_jacobian = Val(:true_jacobian), update_rule = Val(:bad_broyden))
+sol = solve(prob, alg; maxiters = 10_000)
+residual = similar(sol.u)
+generalized_rosenbrock!(residual, sol.u, nothing)
+
+@test SciMLBase.successful_retcode(sol)
+@test maximum(abs, residual) ≤ 1.0e-3


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- Preserve triangular solve semantics when initializing an inverse Jacobian from a nonsingular CPU strided triangular matrix.
- Preserve an aliased prior inverse before refilling the reusable identity RHS, so direct resets and nested reinversion remain correct.
- Keep general matrices and singular triangular matrices on LinearSolve's existing default path, including its pivoted-QR rescue.
- Add direct workspace/reset coverage and the exact generalized-Rosenbrock bad-Broyden regression.
- Preserve all existing expected-broken coverage; this does not adopt #1069's broken-test change.

## Root cause

The current master Core suite at `247a8bfcb` fails generalized Rosenbrock with:

    Broyden(init_jacobian = Val(:true_jacobian), update_rule = Val(:bad_broyden))

A clean adjacent-commit reproduction and `git bisect` identified `6a7687f542cde52b4bfeef5b473c6156c8d453a1` (#1039) as the first bad commit:

- `d616cd994` (its parent): `Success`, 17 iterations, residual 0.0
- `6a7687f542` and affected master: `Unstable`, 24 iterations, residual 4.4

The persistent workspace itself was not the cause. The true Jacobian is dense lower triangular, and the generic pivoted-LU solve introduced different roundoff than the previous structure-preserving triangular inverse. Bad Broyden is sensitive to that perturbation. Solving the identity RHS through `LowerTriangular` restores the prior trajectory without reinstating matrix-sized allocations.

The fast path is restricted to `StridedMatrix` inputs with a nonzero diagonal. GPU/non-strided inputs, general matrices, and singular triangular matrices retain the existing LinearSolve route. The workspace-owned coefficient buffer handles the case where a prior triangular result aliases the identity RHS during reset.

This implementation uses exported `LinearAlgebra` API only: `diagind`, `istriu`, `istril`, `UpperTriangular`, `LowerTriangular`, and `ldiv!`. It does not add, remove, or change any public NonlinearSolve API.

## Verification

The branch was safely rebased onto current master at `247a8bfcb`, after re-fetching the remote branch and verifying that its two commits still contained no intervening contributor work. The following commands were then run locally on Julia 1.10.11 with current compatible dependencies, including LinearSolve 5.0.0:

- Clean current-master root Core reproduction: generalized Rosenbrock algorithm #4 failed with residual 4.4 and `ReturnCode.Unstable`; the Broyden block reported 94 passed, 1 failed, 1 errored, and 19 broken.
- Exact patched target: generalized Rosenbrock algorithm #4 returned residual 0.0, `ReturnCode.Success`, and the original 17-iteration trajectory.
- `GROUP=Core` for `NonlinearSolveBase` passed. The expanded `linsolve_identity!!` workspace/reset/alias block passed 53/53, routing 12/12, operator-Jacobian 1/1, and dense-LU 14/14.
- `GROUP=Core` for `NonlinearSolveQuasiNewton` passed in full: Broyden 810/810, iterator 2/2, termination 27/27; Klement 297/297, iterator 2/2, termination 27/27; LimitedMemoryBroyden 135/135, iterator 2/2, termination 27/27; and the new triangular true-Jacobian regression 2/2.
- Patched root Core reached the independently reproduced clean-master Brown expected-broken unexpected pass tracked in #1056. Before that stop, generalized Rosenbrock algorithm #4 passed and the Broyden block reported 95 passed, 1 errored, and 19 broken. The sole error was Brown algorithm #4; no broken-test bookkeeping was changed.
- Full-repository Runic check passed all 374 Julia files.
- `git diff --check` passed and the tracked worktree was clean.

No assertions were loosened, and no tests were skipped, disabled, silenced, deleted, or converted to broken.

## Investigation/process log

I reproduced the failure on a clean detached checkout of current master with the latest compatible graph, reproduced its immediate good and bad revisions on a common historical dependency graph, and ran an actual `git bisect`. I compared the old structure-preserving inversion with the reusable LinearSolve workspace, checked the first step and inverse numerics, and tested generic LU, SVD, pseudoinverse, and triangular identity solves. That reduced the fix to the CPU-strided nonsingular triangular path. I then adopted the existing focused draft rather than opening a duplicate, rebased it onto current master, reran the exact target and both affected sublibrary Core groups, ran the root Core group through the known unrelated Brown stop, checked the LinearAlgebra exports, and ran Runic.
