### PR TITLE
Raise SciMLOperators public API floors and resolve cache ambiguity

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.34.1"
+version = "2.34.2"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]
@@ -96,7 +96,7 @@ ReverseDiff = "1.15"
 SciMLBase = "3.19"
 SciMLJacobianOperators = "0.1.1"
 SciMLLogging = "1.10.1, 2"
-SciMLOperators = "1.7"
+SciMLOperators = "1.24"
 SciMLStructures = "1.5"
 Setfield = "1.1.2"
 SparseArrays = "1.10"

--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.34.2"
+version = "2.34.3"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -165,6 +165,7 @@ end
 # Deprecations
 (cache::JacobianCache{<:Number})(::Nothing) = error("Please report a bug to NonlinearSolve.jl")
 (cache::JacobianCache{<:JacobianOperator})(::Nothing) = error("Please report a bug to NonlinearSolve.jl")
+(cache::JacobianCache{<:AbstractSciMLOperator})(::Nothing) = error("Please report a bug to NonlinearSolve.jl")
 (cache::JacobianCache)(::Nothing) = error("Please report a bug to NonlinearSolve.jl")
 
 """

--- a/lib/NonlinearSolveBase/test/qa/qa.jl
+++ b/lib/NonlinearSolveBase/test/qa/qa.jl
@@ -66,8 +66,8 @@ run_qa(
         #     NonSolverError, _concrete_solve_adjoint, _concrete_solve_forward, checkkwargs,
         #     extract_alg, get_concrete_p, get_concrete_u0, get_root_indp, has_kwargs,
         #     promote_u0, wrap_sol
-        #   ForwardDiff: Dual, pickchunksize;  SciMLOperators: AbstractSciMLOperator
-        #   SparseArrays: AbstractSparseMatrixCSC;  StaticArraysCore: StaticArray
+        #   ForwardDiff: Dual, pickchunksize;  SparseArrays: AbstractSparseMatrixCSC
+        #   StaticArraysCore: StaticArray
         #   NonlinearSolveBase (own internal): NonlinearSolveForwardDiffCache,
         #     NonlinearSolveTag, Utils, is_fw_wrapped, standardize_forwarddiff_tag,
         #     wrapfun_iip
@@ -77,7 +77,7 @@ run_qa(
                 :NoDefaultAlgorithmError, :NonSolverError,
                 :_concrete_solve_adjoint, :_concrete_solve_forward, :checkkwargs,
                 :extract_alg, :get_concrete_p, :get_concrete_u0, :get_root_indp, :has_kwargs,
-                :promote_u0, :wrap_sol, :Dual, :pickchunksize, :AbstractSciMLOperator,
+                :promote_u0, :wrap_sol, :Dual, :pickchunksize,
                 :AbstractSparseMatrixCSC, :StaticArray, :NonlinearSolveForwardDiffCache,
                 :NonlinearSolveTag, :Utils, :is_fw_wrapped, :standardize_forwarddiff_tag,
                 :wrapfun_iip,

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -126,6 +126,20 @@ run_tests(;
 
         @safetestset "Linear solver routing" include("linear_solver_routing.jl")
 
+        @safetestset "Operator Jacobian cache dispatch" begin
+            using NonlinearSolveBase, SciMLBase, SciMLOperators
+
+            f! = (du, u, p) -> (du .= u; nothing)
+            f = NonlinearFunction(f!; jac_prototype = MatrixOperator(ones(1, 1)))
+            prob = NonlinearProblem(f, [1.0])
+            stats = SciMLBase.NLStats(0, 0, 0, 0, 0)
+            cache = NonlinearSolveBase.construct_jacobian_cache(
+                prob, nothing, f, [1.0]; stats
+            )
+
+            @test_throws ErrorException cache(nothing)
+        end
+
         return @safetestset "Dense LU refactorization allocations" include(
             "lu_refactorization_allocs.jl"
         )

--- a/lib/NonlinearSolveFirstOrder/Project.toml
+++ b/lib/NonlinearSolveFirstOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveFirstOrder"
 uuid = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "2.2.0"
+version = "2.2.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -52,7 +52,7 @@ Reexport = "1.2.2"
 SciMLBase = "3.19"
 SciMLJacobianOperators = "0.1.0"
 SciMLLogging = "1.10.1, 2"
-SciMLOperators = "1.7"
+SciMLOperators = "1.24"
 Setfield = "1.1.2"
 SparseArrays = "1.10"
 SparseConnectivityTracer = "1"

--- a/lib/NonlinearSolveQuasiNewton/Project.toml
+++ b/lib/NonlinearSolveQuasiNewton/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveQuasiNewton"
 uuid = "9a2c21bd-3a47-402d-9113-8faf9a0ee114"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.14.0"
+version = "1.14.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -48,7 +48,7 @@ PrecompileTools = "1.2"
 Reexport = "1.2.2"
 SciMLBase = "3.19"
 SciMLLogging = "1.10.1, 2"
-SciMLOperators = "1.7"
+SciMLOperators = "1.24"
 StableRNGs = "1"
 StaticArrays = "1.9.8"
 StaticArraysCore = "1.4.3"

--- a/lib/NonlinearSolveQuasiNewton/test/qa/qa.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/qa/qa.jl
@@ -47,8 +47,7 @@ run_qa(
         #     AbstractNonlinearSolveAlgorithm, AbstractNonlinearSolveCache,
         #     AbstractResetCondition, AbstractResetConditionCache, Utils, get_timer_output,
         #     update_trace!
-        #   SciMLBase: NoSpecialize;  SciMLOperators: AbstractSciMLOperator
-        #   StaticArraysCore: StaticArray
+        #   SciMLBase: NoSpecialize;  StaticArraysCore: StaticArray
         all_explicit_imports_are_public = (;
             ignore = (
                 Symbol("@static_timeit"),
@@ -56,8 +55,8 @@ run_qa(
                 :AbstractApproximateJacobianUpdateRuleCache, :AbstractDescentDirection,
                 :AbstractJacobianCache, :AbstractJacobianInitialization,
                 :AbstractNonlinearSolveAlgorithm, :AbstractNonlinearSolveCache,
-                :AbstractResetCondition, :AbstractResetConditionCache, :AbstractSciMLOperator,
-                :NoSpecialize, :StaticArray, :Utils, :get_timer_output, :update_trace!,
+                :AbstractResetCondition, :AbstractResetConditionCache, :NoSpecialize,
+                :StaticArray, :Utils, :get_timer_output, :update_trace!,
             ),
         ),
     ),

--- a/lib/SciMLJacobianOperators/Project.toml
+++ b/lib/SciMLJacobianOperators/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLJacobianOperators"
 uuid = "19f34311-ddf3-4b8b-af20-060888a46c0e"
-version = "0.1.15"
+version = "0.1.16"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]
@@ -28,7 +28,7 @@ InteractiveUtils = "<0.0.1, 1"
 LinearAlgebra = "1.10"
 ReverseDiff = "1.15"
 SciMLBase = "2.153, 3"
-SciMLOperators = "1.7"
+SciMLOperators = "1.24"
 Test = "1.10"
 Tracker = "0.2.35"
 Zygote = "0.6.70, 0.7"

--- a/lib/SciMLJacobianOperators/test/qa/qa.jl
+++ b/lib/SciMLJacobianOperators/test/qa/qa.jl
@@ -4,10 +4,10 @@ run_qa(
     SciMLJacobianOperators;
     explicit_imports = true,
     ei_kwargs = (;
-        # Still non-public in their owning packages after the make-public round:
-        #   SciMLBase: AbstractNonlinearFunction;  SciMLOperators: AbstractSciMLOperator
+        # Still non-public in its owning package after the make-public round:
+        #   SciMLBase: AbstractNonlinearFunction
         all_explicit_imports_are_public = (;
-            ignore = (:AbstractNonlinearFunction, :AbstractSciMLOperator),
+            ignore = (:AbstractNonlinearFunction,),
         ),
     ),
 )


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- require SciMLOperators 1.24, the first registered release that declares `AbstractSciMLOperator` public, in every subpackage that directly imports it
- remove the now-obsolete ExplicitImports allowlist entries from NonlinearSolveBase, NonlinearSolveQuasiNewton, and SciMLJacobianOperators
- add the missing `Nothing` specialization for `JacobianCache{<:AbstractSciMLOperator}`, resolving its intersection with the generic deprecated call method
- cover the operator-cache dispatch with an in-place `MatrixOperator` regression test
- patch-bump NonlinearSolveBase to 2.34.3, NonlinearSolveFirstOrder to 2.2.1, NonlinearSolveQuasiNewton to 1.14.1, and SciMLJacobianOperators to 0.1.16

SciMLOperators commit `a28a25ac5f81e3922351fecc2535e2b264ec8f2c` made `AbstractSciMLOperator` public. Registry and tree-history verification show that release 1.23.0 predates that commit and release 1.24.0 contains it. Establishing that public API floor permits the operator-specific disambiguation without relying on dependency internals.

The minimum-compatible sublibrary environments also depend on [julia-actions/julia-downgrade-compat#55](https://github.com/julia-actions/julia-downgrade-compat/pull/55), stacked on [#54](https://github.com/julia-actions/julia-downgrade-compat/pull/54), so direct local runtime dependencies are retained and resolved while producing the downgraded manifest.

## Process

1. Reproduced NonlinearSolveBase QA on exact upstream `579761dd26ccd522fae20b29cef8e9ed945569c5`.
2. Traced the owner-package public declaration and mapped it to the first registered release.
3. Located every direct `AbstractSciMLOperator` consumer and raised its SciMLOperators floor.
4. Removed only the corresponding QA exceptions and patch-bumped the affected subpackages.
5. Added the operator-cache method required to make the dispatch lattice unambiguous and exercised it directly.
6. Exercised minimum-compatible and latest-compatible environments locally.

## Local verification

- Final combined head, Julia 1.10.11 minimum-compatible NonlinearSolveBase `Core`: 112/112 passed, including the operator-cache regression 1/1.
- Julia 1.10 minimum-compatible downgrade (`alldeps`), with SciMLOperators 1.24.0:
  - SciMLJacobianOperators `Core` passed.
  - NonlinearSolveQuasiNewton `Core` passed.
  - NonlinearSolveFirstOrder `Core` passed with NonlinearSolveBase 2.34.2 and SciMLJacobianOperators 0.1.16; its largest matrix, TrustRegion, passed 1596/1596 and the final SciMLOperator Jacobian set passed 14/14.
- Julia 1.12 latest-compatible NonlinearSolveBase `Core`: 112/112 passed, including the operator-cache regression 1/1.
- SciMLJacobianOperators `QA`: 16/16 passed.
- NonlinearSolveQuasiNewton `QA`: 16/16 passed.
- Final combined head, whole-repository Runic: all 372 tracked Julia files passed.
- Final combined head, NonlinearSolveBase `QA`: method ambiguity passed 1/1 and `all_explicit_imports_are_public` passed 1/1. The complete result is 17 passed / 1 errored because upstream master independently accesses the non-public `FunctionWrappersWrappers.SingleCacheStorage`; that public-API migration remains separate work.
