### PR TITLE
Eliminate dense continuation step allocations on Julia 1.12

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.35.0"
+version = "2.35.2"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/arclength.jl
+++ b/lib/NonlinearSolveBase/src/arclength.jl
@@ -829,10 +829,10 @@ function CommonSolve.solve(
         # and discovers the winner) instead of re-failing the cheaper ladder members
         # on every warm-started step.
         reinit_retaining!(corr_cache, xpred)
-        last_sol = CommonSolve.solve!(corr_cache)
+        last_sol = _solve_without_solution!(corr_cache)
 
-        if SciMLBase.successful_retcode(last_sol)
-            xnew = last_sol.u
+        if _solve_result_successful(last_sol)
+            xnew = _solve_result_u(last_sol)
             # realized chord, built in the (currently free) secant scratch
             @. tscratch = xnew - xcur
             nchord = _theta_norm(tscratch, wu, wλ, n)
@@ -892,7 +892,8 @@ function CommonSolve.solve(
             # sweep — see `_effort_growth_factor`), giving the arclength driver an effort
             # signal alongside the purely geometric bend-angle test.
             if alg.adaptive
-                nit = last_sol.stats === nothing ? -1 : Int(last_sol.stats.nsteps)
+                result_stats = _solve_result_stats(last_sol)
+                nit = result_stats === nothing ? -1 : Int(result_stats.nsteps)
                 if _effort_wants_shrink(nit, budget)
                     ds / 2 >= min_ds && (ds = ds / 2)
                     streak = 0
@@ -913,7 +914,8 @@ function CommonSolve.solve(
         else
             return build_solution_less_specialize(
                 prob, alg, u, nothing;
-                retcode = last_sol.retcode, original = last_sol,
+                retcode = _solve_result_retcode(last_sol),
+                original = _solve_result_original(last_sol),
                 store_original = alg.store_original
             )
         end

--- a/lib/NonlinearSolveBase/src/forward_diff.jl
+++ b/lib/NonlinearSolveBase/src/forward_diff.jl
@@ -11,6 +11,9 @@ get_u(cache::NonlinearSolveForwardDiffCache) = get_u(cache.cache)
 get_fu(cache::NonlinearSolveForwardDiffCache) = get_fu(cache.cache)
 set_fu!(cache::NonlinearSolveForwardDiffCache, fu) = set_fu!(cache.cache, fu)
 SciMLBase.set_u!(cache::NonlinearSolveForwardDiffCache, u) = SciMLBase.set_u!(cache.cache, u)
+function _solve_without_solution!(cache::NonlinearSolveForwardDiffCache)
+    return CommonSolve.solve!(cache)
+end
 function NonlinearSolveBase.get_abstol(cache::NonlinearSolveForwardDiffCache)
     return NonlinearSolveBase.get_abstol(cache.cache)
 end

--- a/lib/NonlinearSolveBase/src/homotopy_sweep.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_sweep.jl
@@ -553,10 +553,10 @@ function _homotopy_sweep_solve(
         # won the previous solve (the anchor's full-ladder run discovers the winner)
         # instead of re-failing the cheaper ladder members on every warm-started step.
         reinit_retaining!(cache, guess)
-        last_sol = CommonSolve.solve!(cache)
+        last_sol = _solve_without_solution!(cache)
 
         if next_λ == λend
-            if cap_active && !SciMLBase.successful_retcode(last_sol)
+            if cap_active && !_solve_result_successful(last_sol)
                 # The final landing on λspan[2] is exempt from the tracking cap: give
                 # it the full user budget before letting the failure feed the
                 # bisection logic. The prediction is recomputed (never reuse `guess`:
@@ -571,19 +571,19 @@ function _homotopy_sweep_solve(
                 last_sol = _sweep_exempt_solve(
                     prob, alg.inner, retry_guess, next_λ, args...; kwargs...
                 )
-            elseif tol_active && SciMLBase.successful_retcode(last_sol)
+            elseif tol_active && _solve_result_successful(last_sol)
                 # The landing is exempt from the loose tracking tolerance: the loose
                 # cache solve above did the bulk of the convergence, now re-polish at
                 # the user's full tolerances warm-started from it (~1–2 corrector
                 # iterations), so the returned solution's accuracy semantics are
                 # unchanged. A failed polish feeds the ordinary bisection logic.
                 last_sol = _sweep_exempt_solve(
-                    prob, alg.inner, last_sol.u, next_λ, args...; kwargs...
+                    prob, alg.inner, _solve_result_u(last_sol), next_λ, args...; kwargs...
                 )
             end
         end
 
-        if SciMLBase.successful_retcode(last_sol)
+        if _solve_result_successful(last_sol)
             # The secant prediction error θ (relative to the recent solution movement)
             # is a cheap local error estimate: it grows with the path's curvature times
             # dλ², so a large θ means the path is turning and a stale tangent would
@@ -599,24 +599,26 @@ function _homotopy_sweep_solve(
                 # have iterated in place in the guess buffer when aliasing is forwarded
                 sv = (next_λ - λ) / (λ - λ_prev)
                 virtual = _sweep_extrapolate!(virtual, u, u_prev, sv)
-                correction = Utils.norm_op(L2_NORM, -, last_sol.u, virtual)
-                disp = Utils.norm_op(L2_NORM, -, last_sol.u, u)
-                scale = max(disp, disp_prev, sqrt(eps(λT)) * (1 + L2_NORM(last_sol.u)))
+                result_u = _solve_result_u(last_sol)
+                correction = Utils.norm_op(L2_NORM, -, result_u, virtual)
+                disp = Utils.norm_op(L2_NORM, -, result_u, u)
+                scale = max(disp, disp_prev, sqrt(eps(λT)) * (1 + L2_NORM(result_u)))
                 θ = correction / scale
                 # the secant only earns its keep when it predicts at least twice as
                 # well as the trivial constant prediction (whose θ is exactly 1)
                 trust = θ < 1 / 2 ? trust + 1 : 0
                 disp_prev = disp
             else
-                disp_prev = Utils.norm_op(L2_NORM, -, last_sol.u, u)
+                disp_prev = Utils.norm_op(L2_NORM, -, _solve_result_u(last_sol), u)
             end
             # accept: swap `u`↔`u_prev` and copy the solution into `u` (no allocation).
-            u, u_prev = _sweep_accept!(u, u_prev, last_sol.u)
+            u, u_prev = _sweep_accept!(u, u_prev, _solve_result_u(last_sol))
             λ_prev = λ
             λ = next_λ
             λ == λend && break
             if alg.adaptive
-                nit = last_sol.stats === nothing ? -1 : Int(last_sol.stats.nsteps)
+                result_stats = _solve_result_stats(last_sol)
+                nit = result_stats === nothing ? -1 : Int(result_stats.nsteps)
                 if _effort_wants_shrink(nit, budget)
                     # Proactive shrink on a straining success (see
                     # `_effort_wants_shrink`); the floor guard keeps the increment
@@ -657,15 +659,16 @@ function _homotopy_sweep_solve(
         else
             # on failure: u is the last converged iterate (λ<λ1); resid is from the failed step (advisory)
             return build_solution_less_specialize(
-                    prob, alg, u, last_sol.resid;
-                    retcode = last_sol.retcode, original = last_sol,
+                    prob, alg, u, _solve_result_resid(last_sol);
+                    retcode = _solve_result_retcode(last_sol),
+                    original = _solve_result_original(last_sol),
                     store_original = alg.store_original
                 ), λ
         end
     end
 
     return SciMLBase.build_solution(
-            prob, alg, u, last_sol.resid; retcode = ReturnCode.Success
+            prob, alg, u, _solve_result_resid(last_sol); retcode = ReturnCode.Success
         ), nothing
 end
 

--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -125,7 +125,8 @@ function construct_jacobian_cache(
         end
     end
 
-    return JacobianCache(J, f, fu, p, stats, autodiff, di_extras)
+    J_destination = jacobian_destination(J, autodiff)
+    return JacobianCache(J, J_destination, f, fu, p, stats, autodiff, di_extras)
 end
 
 function construct_jacobian_cache(
@@ -134,7 +135,7 @@ function construct_jacobian_cache(
         linsolve = missing
     )
     if SciMLBase.has_jac(f) || SciMLBase.has_vjp(f) || SciMLBase.has_jvp(f)
-        return JacobianCache(fu, f, fu, p, stats, autodiff, nothing)
+        return JacobianCache(fu, fu, f, fu, p, stats, autodiff, nothing)
     end
     if autodiff === nothing
         throw(ArgumentError("`autodiff` argument to `construct_jacobian_cache` must be \
@@ -145,11 +146,33 @@ function construct_jacobian_cache(
     @assert !(autodiff isa AutoSparse) "`autodiff` cannot be `AutoSparse` for scalar \
                                         nonlinear problems."
     di_extras = DI.prepare_derivative(f, autodiff, u, Constant(prob.p))
-    return JacobianCache(u, f, fu, p, stats, autodiff, di_extras)
+    return JacobianCache(u, u, f, fu, p, stats, autodiff, di_extras)
 end
+
+struct FixedShapeJacobianDestination{T, A <: Matrix{T}} <: AbstractMatrix{T}
+    parent::A
+end
+
+Base.size(destination::FixedShapeJacobianDestination) = size(destination.parent)
+Base.axes(destination::FixedShapeJacobianDestination) = axes(destination.parent)
+Base.IndexStyle(::Type{<:FixedShapeJacobianDestination}) = IndexLinear()
+@inline Base.getindex(destination::FixedShapeJacobianDestination, indices...) =
+    getindex(destination.parent, indices...)
+@inline Base.setindex!(destination::FixedShapeJacobianDestination, value, indices...) =
+    setindex!(destination.parent, value, indices...)
+function Base.reshape(destination::FixedShapeJacobianDestination, dims::Dims)
+    size(destination) == dims || throw(DimensionMismatch("cannot reshape Jacobian destination"))
+    return destination
+end
+Base.reshape(destination::FixedShapeJacobianDestination, dims::Int...) =
+    reshape(destination, dims)
+
+jacobian_destination(J::Matrix, ::AutoForwardDiff) = FixedShapeJacobianDestination(J)
+jacobian_destination(J, autodiff) = J
 
 @concrete mutable struct JacobianCache <: AbstractJacobianCache
     J
+    J_destination
     f <: NonlinearFunction
     fu
     p
@@ -218,12 +241,9 @@ function (cache::JacobianCache)(u)
         if SciMLBase.has_jac(f)
             f.jac(J, u, p)
         else
-            # ForwardDiff reshapes its destination internally. A full view preserves the
-            # matrix storage while letting Julia eliminate the temporary reshape wrapper.
-            J_dest = J isa Matrix && cache.autodiff isa AutoForwardDiff ?
-                view(J, axes(J)...) : J
             DI.jacobian!(
-                f, cache.fu, J_dest, cache.di_extras, cache.autodiff, u, Constant(p)
+                f, cache.fu, cache.J_destination, cache.di_extras, cache.autodiff, u,
+                Constant(p)
             )
         end
         return J

--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -218,8 +218,12 @@ function (cache::JacobianCache)(u)
         if SciMLBase.has_jac(f)
             f.jac(J, u, p)
         else
+            # ForwardDiff reshapes its destination internally. A full view preserves the
+            # matrix storage while letting Julia eliminate the temporary reshape wrapper.
+            J_dest = J isa Matrix && cache.autodiff isa AutoForwardDiff ?
+                view(J, axes(J)...) : J
             DI.jacobian!(
-                f, cache.fu, J, cache.di_extras, cache.autodiff, u, Constant(p)
+                f, cache.fu, J_dest, cache.di_extras, cache.autodiff, u, Constant(p)
             )
         end
         return J

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -304,14 +304,8 @@ function SciMLBase.__solve(
     return sol
 end
 
-function CommonSolve.solve!(cache::AbstractNonlinearSolveCache)
-    if cache.retcode == ReturnCode.InitialFailure
-        return SciMLBase.build_solution(
-            cache.prob, cache.alg, get_u(cache), get_fu(cache);
-            cache.retcode, cache.stats, cache.trace
-        )
-    end
-
+function _solve_without_solution!(cache::AbstractNonlinearSolveCache)
+    cache.retcode == ReturnCode.InitialFailure && return cache
     while not_terminated(cache)
         CommonSolve.step!(cache)
     end
@@ -330,6 +324,10 @@ function CommonSolve.solve!(cache::AbstractNonlinearSolveCache)
         last = Val(true)
     )
 
+    return cache
+end
+
+function _solution_from_cache(cache::AbstractNonlinearSolveCache; transform_bounds::Bool)
     sol = SciMLBase.build_solution(
         cache.prob, cache.alg, get_u(cache), get_fu(cache);
         cache.retcode, cache.stats, cache.trace
@@ -337,7 +335,7 @@ function CommonSolve.solve!(cache::AbstractNonlinearSolveCache)
 
     # Inverse bounds transform: if the problem function was wrapped with a
     # BoundedWrapper, map the solution back from unbounded to bounded space.
-    if hasfield(typeof(cache.prob), :f) &&
+    if transform_bounds && hasfield(typeof(cache.prob), :f) &&
             hasfield(typeof(cache.prob.f), :f) &&
             cache.prob.f.f isa BoundedWrapper
         bw = cache.prob.f.f
@@ -349,6 +347,36 @@ function CommonSolve.solve!(cache::AbstractNonlinearSolveCache)
     end
 
     return sol
+end
+
+function CommonSolve.solve!(cache::AbstractNonlinearSolveCache)
+    if cache.retcode == ReturnCode.InitialFailure
+        return _solution_from_cache(cache; transform_bounds = false)
+    end
+
+    _solve_without_solution!(cache)
+    return _solution_from_cache(cache; transform_bounds = true)
+end
+
+
+@inline _solve_result_u(result) = result.u
+@inline _solve_result_resid(result) = result.resid
+@inline _solve_result_retcode(result) = result.retcode
+@inline _solve_result_stats(result) = result.stats
+@inline _solve_result_original(result) = result
+
+@inline _solve_result_u(cache::AbstractNonlinearSolveCache) = get_u(cache)
+@inline _solve_result_resid(cache::AbstractNonlinearSolveCache) = get_fu(cache)
+@inline _solve_result_retcode(cache::AbstractNonlinearSolveCache) = cache.retcode
+@inline _solve_result_stats(cache::AbstractNonlinearSolveCache) = cache.stats
+@inline function _solve_result_original(cache::AbstractNonlinearSolveCache)
+    return _solution_from_cache(
+        cache; transform_bounds = cache.retcode != ReturnCode.InitialFailure
+    )
+end
+
+@inline function _solve_result_successful(result)
+    return SciMLBase.successful_retcode(_solve_result_retcode(result))
 end
 
 @generated function CommonSolve.solve!(cache::NonlinearSolvePolyAlgorithmCache{Val{N}}) where {N}
@@ -500,6 +528,10 @@ end
     )
 
     return Expr(:block, calls...)
+end
+
+function _solve_without_solution!(cache::NonlinearSolvePolyAlgorithmCache)
+    return CommonSolve.solve!(cache)
 end
 
 function SciMLBase.__solve(
@@ -774,6 +806,11 @@ function CommonSolve.solve!(cache::NonlinearSolveNoInitCache)
         )
     end
     return CommonSolve.solve(cache.prob, cache.alg, cache.args...; cache.kwargs...)
+end
+
+
+function _solve_without_solution!(cache::NonlinearSolveNoInitCache)
+    return CommonSolve.solve!(cache)
 end
 
 function _solve_adjoint(

--- a/lib/NonlinearSolveBase/src/utils.jl
+++ b/lib/NonlinearSolveBase/src/utils.jl
@@ -111,7 +111,7 @@ function restructure(
     @assert size(y) == size(x) "cannot restructure operators. ensure their sizes match."
     return x
 end
-restructure(y, x) = ArrayInterface.restructure(y, x)
+restructure(y, x) = y === x ? x : ArrayInterface.restructure(y, x)
 
 function safe_similar(x, args...; kwargs...)
     y = similar(x, args...; kwargs...)

--- a/lib/NonlinearSolveBase/test/allocation_fastpaths.jl
+++ b/lib/NonlinearSolveBase/test/allocation_fastpaths.jl
@@ -1,0 +1,47 @@
+using ADTypes: AutoForwardDiff
+using ForwardDiff
+using NonlinearSolveBase
+using SciMLBase
+using Test
+
+function dense_jacobian_cache_allocations()
+    function f!(du, u, p)
+        du[1] = u[1]^2 + u[2] + p
+        du[2] = u[1] + 3 * u[2] - p
+        return nothing
+    end
+
+    u = [2.0, 3.0]
+    p = 0.5
+    f = NonlinearFunction{true, SciMLBase.FullSpecialize}(f!)
+    prob = NonlinearProblem(f, u, p)
+    fu = similar(u)
+    f(fu, u, p)
+    cache = NonlinearSolveBase.construct_jacobian_cache(
+        prob, nothing, f, fu;
+        stats = SciMLBase.NLStats(0, 0, 0, 0, 0),
+        autodiff = AutoForwardDiff(; chunksize = 1),
+    )
+
+    cache(u)
+    cache(u)
+    J = copy(cache(u))
+    allocs = @allocated cache(u)
+    return J, allocs
+end
+
+J, jacobian_allocs = dense_jacobian_cache_allocations()
+@test J == [4.0 1.0; 1.0 3.0]
+@test jacobian_allocs == 0
+
+function same_buffer_restructure_allocations()
+    x = ones(4)
+    NonlinearSolveBase.Utils.restructure(x, x)
+    y = NonlinearSolveBase.Utils.restructure(x, x)
+    allocs = @allocated NonlinearSolveBase.Utils.restructure(x, x)
+    return x, y, allocs
+end
+
+x, y, restructure_allocs = same_buffer_restructure_allocations()
+@test y === x
+@test restructure_allocs == 0

--- a/lib/NonlinearSolveBase/test/allocation_fastpaths.jl
+++ b/lib/NonlinearSolveBase/test/allocation_fastpaths.jl
@@ -26,12 +26,16 @@ function dense_jacobian_cache_allocations()
     cache(u)
     cache(u)
     J = copy(cache(u))
-    allocs = @allocated cache(u)
-    return J, allocs
+    destination = cache.J_destination
+    reshape_allocs = @allocated reshape(destination, size(destination))
+    jacobian_allocs = @allocated cache(u)
+    return J, destination, reshape_allocs, jacobian_allocs
 end
 
-J, jacobian_allocs = dense_jacobian_cache_allocations()
+J, destination, reshape_allocs, jacobian_allocs = dense_jacobian_cache_allocations()
 @test J == [4.0 1.0; 1.0 3.0]
+@test reshape(destination, size(destination)) === destination
+@test reshape_allocs == 0
 @test jacobian_allocs == 0
 
 function same_buffer_restructure_allocations()

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -126,6 +126,10 @@ run_tests(;
 
         @safetestset "Linear solver routing" include("linear_solver_routing.jl")
 
+        @safetestset "Jacobian and restructure allocation fast paths" include(
+            "allocation_fastpaths.jl"
+        )
+
         @safetestset "Operator Jacobian cache dispatch" begin
             using NonlinearSolveBase, SciMLBase, SciMLOperators
 

--- a/test/Core/homotopy_alloc_tests__item1.jl
+++ b/test/Core/homotopy_alloc_tests__item1.jl
@@ -34,6 +34,25 @@ wrapped = NLB.maybe_wrap_nonlinear_f(inner_prob)
 @test NLB.is_fw_wrapped(wrapped)
 @test isconcretetype(only(Base.return_types(NLB.maybe_wrap_nonlinear_f, (typeof(inner_prob),))))
 
+# Measure the cache-only solve independently of the end-to-end continuation slopes below.
+function cache_only_solve_allocations(prob)
+    u0 = copy(prob.u0)
+    cache = SciMLBase.init(prob, NewtonRaphson())
+    result = NLB._solve_without_solution!(cache)
+    SciMLBase.reinit!(cache, u0)
+    NLB._solve_without_solution!(cache)
+    SciMLBase.reinit!(cache, u0)
+    GC.gc()
+    allocs = @allocated NLB._solve_without_solution!(cache)
+    return result, result === cache, allocs
+end
+
+cache_result, same_cache, cache_solve_allocs = cache_only_solve_allocations(inner_prob)
+@test cache_result isa NLB.AbstractNonlinearSolveCache
+@test same_cache
+@test SciMLBase.successful_retcode(cache_result.retcode)
+VERSION >= v"1.11" && @test cache_solve_allocs == 0
+
 # --- end-to-end per-step allocation with a clean `NewtonRaphson` inner. The slope between two
 # fixed-step runs cancels compile/one-time-init cost, leaving pure per-step allocation. Gated
 # on Julia 1.11+: the LinearSolve factorization-workspace reuse that removes the last


### PR DESCRIPTION
**Ignore this PR until reviewed by @ChrisRackauckas.**

## Summary

Remove the NonlinearSolve-owned dense continuation step allocations observed on Julia 1.12 x86_64 without weakening the existing allocation regression:

- keep a fixed-shape cached destination for dense `AutoForwardDiff` Jacobian evaluation
- return the input directly when `Utils.restructure` receives the same object
- run repeated sweep and arclength correctors directly to completion in their reused cache, without constructing a `NonlinearSolution` on every interior step
- preserve ordinary `solve!` results and construct full solutions for anchors, final landings, and reported failures
- add warmed allocation checks for the Jacobian destination, same-object restructure, and cache-only solve path
- bump `NonlinearSolveBase` to 2.35.2

The new solver helpers are private. No public API, threshold, tolerance, skip, broken-test designation, or failure behavior changes.

## Root cause and platform boundary

The standalone NonlinearSolve changes remove three independently observed sources:

1. ForwardDiff reshapes its already-matrix Jacobian destination.
2. `ArrayInterface.restructure` creates a wrapper when the target and source are already the same buffer.
3. Each interior continuation corrector called ordinary `solve!(cache)`, constructing a complete solution although the driver only needs cache state, residual, retcode, and stats.

Removing those sources produces the verified zero-allocation Julia 1.12 x86_64 result below. It does not, by itself, establish the Apple result.

Fresh combined-stack Apple ARM runs after all three changes still measured exactly 772.0/400.0 B per sweep/arclength step on prerelease Julia. A subsequent stable-macOS allocation profile measured 957.28/496.0 B per step and isolated the dominant remaining allocator upstream in LinearSolve's `AppleAccelerateLUFactorization`: repeated `LU{Float64, Matrix, Vector{Int32}}` construction contributed 25,984 bytes / 812 allocations in sweep and 11,648 bytes / 364 allocations in arclength, alongside tuple, `Ref`, range, and keyword-`NamedTuple` construction.

Focused draft [LinearSolve #1099](https://github.com/SciML/LinearSolve.jl/pull/1099) caches the factor, pivot, and LAPACK-status workspaces. Its direct Apple-silicon tests pass on Julia 1.10, 1.12, and 1.13 without changing the allocation ceiling. This standalone PR still makes no downstream cross-platform allocation claim until the LinearSolve PR is merged/released and the continuation regression is rerun against that dependency.

## Validation

Standalone head: `3d568afa132c4f27035622def12de95c30dec40f`.

- exact root allocation regression on Julia 1.12.6: cache-only solve `0` B and returns the same cache; sweep `0.0` B/step; arclength `0.0` B/step
- standalone `NonlinearSolveBase` Core: passed, including allocation fast paths 6/6, workspace 50/50, routing 12/12, operator dispatch 1/1, dampening 12/12, and dense-LU allocations 14/14
- final combined tree `NonlinearSolveBase` Core on Julia 1.12.6 and 1.10.11: passed
- all 39 unchanged homotopy/arclength test files: passed, including allocation, Jacobian, failure, tolerance, effort, retention, and polyalgorithm paths
- `NonlinearSolveBase` QA: 18/18
- ForwardDiff cache reinit regression: 1/1
- Runic 1.7.0 `--check --diff .`: passed over both final trees
- `git diff --check`: passed

The canonical root Core run still stops earlier at the separately audited clean-base Brown/Broyden unexpected-pass failure; no test was skipped or altered to continue past it.