### PR TITLE
Reuse analytic Jacobians for line-search JVPs

### DIFF
--- a/lib/NonlinearSolveFirstOrder/Project.toml
+++ b/lib/NonlinearSolveFirstOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveFirstOrder"
 uuid = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "2.3.1"
+version = "2.3.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -50,7 +50,7 @@ PrecompileTools = "1.2"
 Random = "1.10"
 Reexport = "1.2.2"
 SciMLBase = "3.37"
-SciMLJacobianOperators = "0.1.1"
+SciMLJacobianOperators = "0.1.17"
 SciMLLogging = "1.10.1, 2"
 SciMLOperators = "1.24"
 Setfield = "1.1.2"

--- a/lib/NonlinearSolveFirstOrder/src/solve.jl
+++ b/lib/NonlinearSolveFirstOrder/src/solve.jl
@@ -246,16 +246,17 @@ function SciMLBase.__init(
             NonlinearSolveBase.supports_line_search(alg.descent) ||
                 error("Line Search not supported by $(alg.descent).")
             # The line search only needs the directional derivative
-            # ϕ'(α) = ⟨fu, J⋅δu⟩, a single JVP, so prefer the forward-mode
-            # backend. Only use the reverse-mode backend when explicitly
-            # requested via `vjp_autodiff` or a reverse-mode `autodiff`, so
-            # that loading a reverse-mode AD package cannot change the
-            # behavior of an explicitly configured solver.
+            # ϕ'(α) = ⟨fu, J⋅δu⟩, a single JVP. Honor explicit derivative
+            # backends first, then reuse an analytic Jacobian before falling back
+            # to forward mode. Loading a reverse-mode AD package must not change
+            # the behavior of an explicitly configured solver.
             ls_ad = if provided_jvp_autodiff
                 alg.jvp_autodiff
             elseif provided_vjp_autodiff ||
                     ADTypes.mode(alg.autodiff) isa ADTypes.ReverseMode
                 alg.vjp_autodiff
+            elseif SciMLBase.has_jac(_ad_prob.f)
+                nothing
             else
                 alg.jvp_autodiff
             end

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests__item4.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests__item4.jl
@@ -32,3 +32,27 @@ if isempty(VERSION.prerelease) && VERSION < v"1.12"
     sol = solve(prob, alg)
     @test SciMLBase.successful_retcode(sol)
 end
+
+struct AnalyticJacResidual end
+function (::AnalyticJacResidual)(res, u, p)
+    eltype(u) === Float64 || error("residual must not be differentiated")
+    @. res = u^2 - p
+    return nothing
+end
+function analytic_jacobian!(J, u, p)
+    fill!(J, 0)
+    for i in eachindex(u)
+        J[i, i] = 2 * u[i]
+    end
+    return nothing
+end
+
+analytic_prob = NonlinearLeastSquaresProblem(
+    NonlinearFunction(
+        AnalyticJacResidual(); jac = analytic_jacobian!, jac_prototype = zeros(n, n),
+        resid_prototype = zeros(n)
+    ), u0, p
+)
+analytic_sol = solve(analytic_prob, GaussNewton(; linesearch = BackTracking()))
+@test SciMLBase.successful_retcode(analytic_sol)
+@test analytic_sol.u ≈ sqrt.(p)


### PR DESCRIPTION
> [!IMPORTANT]
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- Preserve explicitly selected JVP, VJP, and reverse-mode line-search backends.
- When no derivative backend was explicitly selected, let `SciMLJacobianOperators` form the line-search JVP from a supplied analytic Jacobian.
- Add a regression whose residual rejects differentiated inputs.
- Bump NonlinearSolveFirstOrder to 2.3.2 and raise the `SciMLJacobianOperators` floor to 0.1.17.

## Root cause

This follows the direct `ModelingToolkitBase` InterfaceII failures reported while working on [ModelingToolkit.jl#4742](https://github.com/SciML/ModelingToolkit.jl/pull/4742#issuecomment-4957270773). Both failures entered a boundary residual with `ForwardDiff.Dual` values from the nonlinear line-search JVP.

Commit `c6b26f4a` began always passing the automatically selected forward-mode JVP backend to `LineSearch`, which bypasses the analytic-Jacobian fallback in `SciMLJacobianOperators.prepare_jvp` (that fallback only fires when `autodiff === nothing`). The introducing boundary was checked against the minimal reproducer: `c6b26f4a^` (`d21952c3`) exits successfully, `c6b26f4a` errors with `Vector{ForwardDiff.Dual}` reaching the residual.

The fix passes `nothing` only when the problem has an analytic Jacobian *and* no JVP, VJP, or reverse-mode backend was explicitly selected. That preserves the explicit-backend behavior `c6b26f4a` added while restoring the analytic derivative path.

## Prerequisite (resolved)

This depended on a rectangular-output bug in the analytic JVP implementation, split out as #1063. That is now merged (`01891bcd`) and **SciMLJacobianOperators 0.1.17 is registered in General** ([JuliaRegistries/General#163962](https://github.com/JuliaRegistries/General/pull/163962)), so the `0.1.17` compat floor here resolves — including on downgrade CI.

## Verification

Rebased onto master at `01891bcd`. Julia 1.12.4, with `lib/` path sources so both local `SciMLJacobianOperators` 0.1.17 and local `NonlinearSolveFirstOrder` are exercised (asserted via `pathof`).

**The regression discriminates.** With `lib/NonlinearSolveFirstOrder/src/solve.jl` reverted to master and the test left in place:

```text
item4: Error During Test
  Got exception outside of a @test
  LoadError: residual must not be differentiated
  Stacktrace:
   [1] error(s::String)
     @ Base ./error.jl:44
   [2] (::AnalyticJacResidual)(res::Vector{ForwardDiff.Dual{ForwardDiff.Tag{NonlinearSolveBase.NonlinearSolveTag, Float64}, Float64, 1}}, u::Vector{ForwardDiff.Dual{...}}, p::Vector{Float64})
     @ Main .../test/misc_tests__item4.jl:38
   ...
Test Summary: | Pass  Error  Total  Time
item4         |    1      1      2   8.2s
ERROR: LoadError: Some tests did not pass: 1 passed, 0 failed, 1 errored, 0 broken.
```

With the fix restored, same file, same environment:

```text
Test Summary: | Pass  Total  Time
item4         |    3      3   7.3s
```

**Full `GROUP=Core` suite** for `NonlinearSolveFirstOrder` — `Pkg.test()` exited 0, zero failures and zero errors across every testset:

```text
General NLLS Solvers   |  480 pass |  480 total |  3m06.7s
NewtonRaphson          |  309 pass |  309 total |  7m39.3s
PseudoTransient        |   51 pass |   51 total |  1m18.1s
TrustRegion            | 1176 pass | 1176 total | 17m53.0s
LevenbergMarquardt     |   33 pass |   33 total |    58.0s
Custom JVP             |    4 pass |    4 total |     9.1s
Structured Jacobians   |   16 pass |   16 total |    23.6s
SciMLOperator Jacobians|   14 pass |   14 total |     6.2s
Line search uses forward-mode autodiff: Issue #837 | 3 pass | 3 total
     Testing NonlinearSolveFirstOrder tests passed
```

`Structured Jacobians` and `SciMLOperator Jacobians` matter here specifically: the restored `prepare_jvp` fallback materializes a dense `jac_cache` and calls `f.jac` into it, so those groups are what exercise non-dense `jac_prototype`s through the new path.

Also run clean: Runic 1.7.0 (`--check`, exit 0), `typos` (exit 0), `git diff --check` (exit 0).

## Not verified

- QA group, docs build, and the other subpackages — this touches no docstring, no public API, and no other `lib/`.
- Julia LTS and `pre`; only 1.12.4 was run locally.
- The original `ModelingToolkitBase` `bvproblem.jl` integration was verified on the pre-rebase branch, not re-run after this rebase. The code change is identical; only the `Project.toml` conflict resolution differs.

## For a reviewer to push back on

- `SciMLBase.has_jac(f)` is the whole trigger condition. A problem that supplies `jac` but whose `jac` is more expensive per call than a single forward-mode pushforward now pays that cost in the line search. The prior behavior (before `c6b26f4a`) was the same, so this is a restoration, not a new tradeoff — but it is a performance-relevant default.
- The compat floor jumps `0.1.1` → `0.1.17`, dropping a wide range of resolvable older versions. That is required for correctness (the rectangular-output fix), not cosmetic.
