### PR TITLE
Preserve residual shape in analytic JVPs

### DIFF
--- a/lib/SciMLJacobianOperators/Project.toml
+++ b/lib/SciMLJacobianOperators/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLJacobianOperators"
 uuid = "19f34311-ddf3-4b8b-af20-060888a46c0e"
-version = "0.1.16"
+version = "0.1.17"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/SciMLJacobianOperators/src/SciMLJacobianOperators.jl
+++ b/lib/SciMLJacobianOperators/src/SciMLJacobianOperators.jl
@@ -387,7 +387,7 @@ function prepare_jvp(
                 return
             end
         else
-            return @closure (v, u, p) -> reshape(f.jac(u, p) * vec(v), size(u))
+            return @closure (v, u, p) -> reshape(f.jac(u, p) * vec(v), size(fu))
         end
     end
 

--- a/lib/SciMLJacobianOperators/test/core_tests__item3.jl
+++ b/lib/SciMLJacobianOperators/test/core_tests__item3.jl
@@ -104,3 +104,23 @@ prob = NonlinearProblem(
         @test JᵀJv ≈ JᵀJv_analytic atol = 1.0e-5
     end
 end
+
+rectangular_residual(u, p) = reshape(
+    [u[1] + u[2], 2 * u[1] - u[2], u[1] - 3 * u[2]], 3, 1
+)
+rectangular_jacobian(u, p) = [1 1; 2 -1; 1 -3]
+rectangular_u = [2.0, 1.0]
+rectangular_fu = rectangular_residual(rectangular_u, nothing)
+rectangular_prob = NonlinearLeastSquaresProblem(
+    NonlinearFunction{false}(rectangular_residual; jac = rectangular_jacobian), rectangular_u
+)
+
+@testset "Rectangular Analytic Jacobian" begin
+    jac_op = JacobianOperator(rectangular_prob, rectangular_fu, rectangular_u)
+    sop = StatefulJacobianOperator(jac_op, rectangular_u, rectangular_prob.p)
+    v = [3.0, 2.0]
+
+    Jv = sop * v
+    @test size(Jv) == size(rectangular_fu)
+    @test Jv ≈ reshape(rectangular_jacobian(rectangular_u, nothing) * v, 3, 1)
+end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- reshape out-of-place analytic Jacobian-vector products to the residual shape, not the unknown shape
- cover a rectangular matrix-valued least-squares residual
- bump SciMLJacobianOperators from 0.1.16 to 0.1.17 for the bug-fix release

For a rectangular Jacobian, the product has one entry per residual. Reshaping it to `size(u)` only worked when residual and unknown shapes happened to match.

## Verification

- `NONLINEARSOLVE_TEST_GROUP=Core julia +1.10 --project=lib/SciMLJacobianOperators -e "using Pkg; Pkg.instantiate(); Pkg.test()"`
  - Scalar Ops: 1248/1248
  - Inplace Problems: 864/864
  - Out-of-place Problems: 1250/1250
  - Copy with Tuple parameters: 11/11
- Runic 1.7 repository check: exit 0
- `git diff --check upstream/master...HEAD`: exit 0

This is the release prerequisite for #1062.