### PR TITLE
Restore GPU Broyden inverse initialization

### DIFF
--- a/lib/NonlinearSolveBase/src/utils.jl
+++ b/lib/NonlinearSolveBase/src/utils.jl
@@ -235,6 +235,9 @@ linsolve_workspace(A::Diagonal) = nothing, A
 linsolve_workspace(A::SMatrix) = nothing, A
 function linsolve_workspace(A::AbstractMatrix)
     LinearAlgebra.checksquare(A)
+    # Backends without fast scalar indexing may not implement factorization solves with
+    # a matrix right-hand side. Leave those arrays on their native `pinv` path.
+    ArrayInterface.fast_scalar_indexing(A) || return nothing, A
     # the linear solve promotes e.g. integer eltypes; the buffers must hold the promoted
     # values. The `size` form of `similar` gives a dense buffer for structured input
     # (e.g. Tridiagonal), which the generically-dense inverse and identity RHS need.
@@ -283,15 +286,20 @@ end
 function linsolve_identity!!(workspace, A::AbstractMatrix)
     LinearAlgebra.checksquare(A)
     # a `nothing` workspace (the preinverted-init path in NonlinearSolveQuasiNewton)
-    # builds a transient linear-solve cache; it allocates, but runs at most once per solve
-    ws = workspace === nothing ? first(linsolve_workspace(A)) : workspace
+    # builds a transient linear-solve cache; it allocates, but runs at most once per solve.
+    # Sparse dispatch gets a chance to construct its dense workspace here, while backend
+    # arrays that cannot use the cached matrix-RHS solve stay on their native `pinv`.
+    if workspace === nothing
+        workspace, workspace_A = linsolve_workspace(A)
+        workspace === nothing && return pinv(workspace_A)
+    end
     # the previous solve may have consumed the RHS buffer, so refill it with I. The
     # lincache call copies A into its internal buffer before overwriting the solution
     # buffer, so A is never mutated and passing the previously returned inverse as A is
     # safe. On singular A the default algorithm's pivoted-QR rescue returns a finite
     # least-squares generalized inverse (not the SVD `pinv`).
-    make_identity!!(ws.rhs, true)
-    return ws.lincache(; A, b = ws.rhs).u
+    make_identity!!(workspace.rhs, true)
+    return workspace.lincache(; A, b = workspace.rhs).u
 end
 
 function initial_jacobian_scaling_alpha(α, u, fu, ::Any)

--- a/lib/NonlinearSolveBase/test/linsolve_workspace.jl
+++ b/lib/NonlinearSolveBase/test/linsolve_workspace.jl
@@ -1,7 +1,17 @@
 using NonlinearSolveBase: NonlinearSolveBase, Utils
+using ArrayInterface
 using LinearSolve  # linsolve_identity!! routes matrices through the LinearSolve default
 using LinearAlgebra
 using Test
+
+struct NoFastScalarMatrix{T} <: AbstractMatrix{T}
+    data::Matrix{T}
+end
+
+Base.size(A::NoFastScalarMatrix) = size(A.data)
+Base.getindex(A::NoFastScalarMatrix, i::Int, j::Int) = A.data[i, j]
+Base.copy(A::NoFastScalarMatrix) = copy(A.data)
+ArrayInterface.fast_scalar_indexing(::Type{<:NoFastScalarMatrix}) = false
 
 @testset "nonsingular input matches inv" begin
     n = 20
@@ -27,6 +37,13 @@ using Test
         @test Utils.linsolve_identity!!(workspace, Utils.linsolve_identity!!(workspace, A)) ≈
             A_orig
     end
+end
+
+@testset "arrays without fast scalar indexing use pinv" begin
+    A = NoFastScalarMatrix(rand(5, 5))
+    workspace, A_ret = Utils.linsolve_workspace(A)
+    @test workspace === nothing && A_ret === A
+    @test Utils.linsolve_identity!!(workspace, A) ≈ pinv(A.data)
 end
 
 @testset "singular input takes the pivoted-QR rescue" begin

--- a/test/gpu/cuda_tests__item1.jl
+++ b/test/gpu/cuda_tests__item1.jl
@@ -1,6 +1,7 @@
 using NonlinearSolve
 
 using CUDA, NonlinearSolve, LinearSolve, StableRNGs, ADTypes
+using LinearAlgebra: norm
 
 if CUDA.functional()
     CUDA.allowscalar(false)
@@ -12,6 +13,7 @@ if CUDA.functional()
     linear_f(du, u, p) = (du .= A * u .+ b)
 
     prob = NonlinearProblem(linear_f, u0)
+    iip_prob = prob
 
     # ForwardDiff uses scalar indexing which doesn't work on GPU
     # Use AutoFiniteDiff for GPU-compatible Jacobian computation
@@ -39,10 +41,21 @@ if CUDA.functional()
     linear_f(u, p) = A * u .+ b
 
     prob = NonlinearProblem{false}(linear_f, u0)
+    oop_prob = prob
 
     @testset "[OOP] GPU Solvers" begin
         @testset "$(nameof(typeof(alg)))" for alg in SOLVERS
             @test_nowarn sol = solve(prob, alg; abstol = 1.0f-5, reltol = 1.0f-5)
+        end
+    end
+
+    @testset "Broyden inverse initialization" begin
+        for prob in (iip_prob, oop_prob)
+            sol = solve(
+                prob, Broyden(; linesearch = LiFukushimaLineSearch());
+                abstol = 1.0f-5, reltol = 1.0f-5
+            )
+            @test norm(A * sol.u + b) < 1.0f-4
         end
     end
 end


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## Summary

- avoid constructing the cached `A * X = I` inverse workspace for array backends that do not support fast scalar indexing
- retain sparse-matrix dispatch before falling back to the backend's native `pinv`
- cover the fallback with a CPU backend wrapper and add explicit CUDA Broyden residual checks for both in-place and out-of-place problems

## Root cause

PR #1039 changed QuasiNewton inverse initialization from the backend-native `pinv(A)` path to a cached LinearSolve factorization with a matrix identity right-hand side. On `CuArray`, the cuSOLVER QR matrix-RHS path throws `DimensionMismatch: array could not be broadcast to match destination`, which breaks both Broyden variants in the CUDA job.

`linsolve_workspace` now reports no generic cached workspace for backends where `ArrayInterface.fast_scalar_indexing` is false. `linsolve_identity!!` first calls the dispatched workspace constructor, so the existing sparse specialization still builds its dense workspace; it uses `pinv` only when dispatch returns no workspace.

## Adjacent CI boundary

- parent `d616cd994` passed the root CUDA suite 20/20: https://github.com/SciML/NonlinearSolve.jl/actions/runs/29179879552/job/86615528686
- merge `6a7687f542` failed the root CUDA suite 18/20 with the same two Broyden `DimensionMismatch` errors: https://github.com/SciML/NonlinearSolve.jl/actions/runs/29180426325/job/86616954929
- PR #1039 contained the sole feature commit `9f4a985acea68aef65915dcf261cb2105c814709`
- the current failure is visible in https://github.com/SciML/NonlinearSolve.jl/actions/runs/29281131540/job/86923811735

The adjacent jobs also resolved LinearSolve 4.3 and 5.0 respectively, so this is an exact failing-state boundary rather than a claim that the source diff was tested locally against an otherwise frozen GPU environment. The current failure uses LinearSolve 5.0.

## Local validation

- `GROUP=Core NONLINEARSOLVE_TEST_GROUP=Core julia +1.12 --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test()'` (passed; workspace 52/52)
- `GROUP=Core NONLINEARSOLVE_TEST_GROUP=Core julia +1.12 --project=lib/NonlinearSolveQuasiNewton -e 'using Pkg; Pkg.test()'` (passed; Broyden 594/594, Klement 216/216, LimitedMemoryBroyden 99/99, and associated interface/termination tests)
- direct LinearSolve 5.0 Broyden regression in `test/gpu` environment (passed 2/2 for in-place/out-of-place residuals)
- `julia +1.12 --project=../runic-format-env -m Runic --check .` (passed)

This machine has no functional CUDA driver (`CUDA.functional() == false`), so the CuArray regression is intentionally asserted in the CUDA CI test rather than claimed as locally executed.
