### PR TITLE
Overload `init_similar_array!!` for sparse arrays

### DIFF
--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseSparseArraysExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseSparseArraysExt.jl
@@ -1,7 +1,8 @@
 module NonlinearSolveBaseSparseArraysExt
 
 using ArrayInterface: ArrayInterface
-using SparseArrays: AbstractSparseMatrix, AbstractSparseMatrixCSC, nonzeros, sparse
+using SparseArrays: AbstractSparseArray, AbstractSparseMatrix, AbstractSparseMatrixCSC,
+    nonzeros, sparse
 
 using NonlinearSolveBase: NonlinearSolveBase, Utils
 
@@ -41,6 +42,20 @@ This is more efficient than checking all entries including structural zeros.
 """
 function NonlinearSolveBase.NAN_CHECK(x::AbstractSparseMatrixCSC)
     return any(NonlinearSolveBase.NAN_CHECK, nonzeros(x))
+end
+
+"""
+    init_similar_array!!(x::AbstractSparseArray{<:Number})
+
+Zero a freshly `similar`ed sparse array through its stored values.
+
+The generic method zeroes with `fill!` which is not supported by sparse GPU arrays, so
+we `fill!` the `nonzero`s in this case.
+"""
+function Utils.init_similar_array!!(x::AbstractSparseArray{<:Number})
+    nzs = nonzeros(x)
+    ArrayInterface.ismutable(nzs) && fill!(nzs, zero(eltype(x)))
+    return x
 end
 
 """

--- a/lib/NonlinearSolveBase/test/qa/qa.jl
+++ b/lib/NonlinearSolveBase/test/qa/qa.jl
@@ -41,7 +41,7 @@ run_qa(
         #   FunctionWrappers: FunctionWrapper
         #   NonlinearSolveBase(.Utils/.InternalAPI): additional_incompatible_backend_check,
         #     condition_number, get_raw_f, get_u, linsolve_workspace,
-        #     is_extension_loaded, make_sparse, maybe_symmetric,
+        #     is_extension_loaded, make_sparse, maybe_symmetric, init_similar_array!!,
         #     nlls_generate_vjp_function, nodual_value, nonlinearsolve_∂f_∂p,
         #     nonlinearsolve_∂f_∂u, reinit!, restructure, safe_reshape, safe_similar,
         #     sparse_or_structured_prototype, structural_sparse
@@ -55,7 +55,7 @@ run_qa(
                 :partials, :pickchunksize, :value, :add_sum, :Compiler, :return_type, :inv!,
                 :FunctionWrapper, :additional_incompatible_backend_check, :condition_number,
                 :get_raw_f, :get_u, :linsolve_workspace, :is_extension_loaded,
-                :make_sparse,
+                :make_sparse, :init_similar_array!!,
                 :maybe_symmetric, :nlls_generate_vjp_function, :nodual_value,
                 Symbol("nonlinearsolve_∂f_∂p"), Symbol("nonlinearsolve_∂f_∂u"),
                 :reinit!, :restructure, :safe_reshape, :safe_similar,

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -186,6 +186,7 @@ run_tests(;
         @safetestset "dampen_jacobian!! touches only the diagonal" include(
             "dampen_jacobian.jl"
         )
+        @safetestset "safe_similar hands out zeroed buffers" include("safe_similar.jl")
 
         return @safetestset "Dense LU refactorization allocations" include(
             "lu_refactorization_allocs.jl"

--- a/lib/NonlinearSolveBase/test/safe_similar.jl
+++ b/lib/NonlinearSolveBase/test/safe_similar.jl
@@ -1,0 +1,48 @@
+using NonlinearSolveBase
+using NonlinearSolveBase: Utils
+using ArrayInterface
+using SparseArrays
+using Test
+
+@testset "dense buffers are zeroed" begin
+    @test all(iszero, Utils.safe_similar(rand(4)))
+    @test all(iszero, Utils.safe_similar(rand(4), 2, 3))
+    # BigFloat is the original motivation: unfilled, these entries are undef *references* and
+    # `iszero` on them throws rather than returning garbage.
+    @test all(iszero, Utils.safe_similar(BigFloat[1, 2, 3]))
+end
+
+@testset "sparse buffers are zeroed through their stored values" begin
+    A = sprand(20, 20, 0.2)
+    B = Utils.safe_similar(A)
+    @test all(iszero, nonzeros(B))
+    # The structural pattern must survive: it is what the prototype exists to carry, and sparse
+    # AD coloring decompresses into exactly these entries.
+    @test nnz(B) == nnz(A)
+    @test rowvals(B) == rowvals(A)
+    @test SparseArrays.getcolptr(B) == SparseArrays.getcolptr(A)
+    @test all(iszero, nonzeros(Utils.safe_similar(sprand(20, 0.2))))
+end
+
+# GPU sparse matrices (`CuSparseMatrixCSC`, ...) implement no `setindex!` at all, so the generic
+# `fill!` is skipped for them, but they are mutable through `nonzeros` — which is all the zeroing
+# needs. Stand in for them with a sparse type that behaves the same way, so this is covered
+# off-GPU. Plain `SparseMatrixCSC` would not: its `fill!` already goes through `nonzeros`.
+struct NoSetindexSparseMatrix{Tv, Ti} <: AbstractSparseMatrix{Tv, Ti}
+    m::Int
+    n::Int
+    vals::Vector{Tv}
+end
+Base.size(A::NoSetindexSparseMatrix) = (A.m, A.n)
+SparseArrays.nonzeros(A::NoSetindexSparseMatrix) = A.vals
+function Base.similar(A::NoSetindexSparseMatrix{Tv, Ti}) where {Tv, Ti}
+    # NaN stands in for uninitialized memory, so a skipped zeroing fails the test reliably.
+    return NoSetindexSparseMatrix{Tv, Ti}(A.m, A.n, fill!(similar(A.vals), NaN))
+end
+ArrayInterface.can_setindex(::Type{<:NoSetindexSparseMatrix}) = false
+
+@testset "sparse buffers that cannot `setindex!` are still zeroed" begin
+    A = NoSetindexSparseMatrix{Float64, Int}(4, 4, [1.0, 2.0, 3.0])
+    @test !ArrayInterface.can_setindex(A)
+    @test all(iszero, nonzeros(Utils.safe_similar(A)))
+end


### PR DESCRIPTION
This PR has two changes:
1. It drops the `can_setindex(x)` guard in `init_similar_array!!` (used by `safe_similar`) which would -- other than the name implies -- NOT return a zeroed out similar array. This guard was introduced way back for sanitizing BigFloat arrays, the function then slowly became a general `safe_similar`. I think in this context it is better to error loud rather than returning non-initialized similars. This would, for example, return uninitialized jacobian buffers after the (truthfull) https://github.com/JuliaArrays/ArrayInterface.jl/pull/495#event-27947734569
2. `fill!` does work on CPU sparse arrays but not on GPU sparse arrays. So we overload `init_simliar_array!!` for AbstractSparseArrays by filling on `nonzeros`. 

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
