### PR TITLE
Use public cache construction for ForwardDiff wrappers

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.35.0"
+version = "2.35.3"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]
@@ -78,7 +78,7 @@ EnzymeCore = "0.8.16"
 FastClosures = "0.3.2"
 ForwardDiff = "0.10.36, 1"
 FunctionWrappers = "1.1.2"
-FunctionWrappersWrappers = "1"
+FunctionWrappersWrappers = "1.9.3"
 InteractiveUtils = "<0.0.1, 1"
 LineSearch = "0.1.4"
 LinearAlgebra = "1.10"

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseForwardDiffExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseForwardDiffExt.jl
@@ -82,7 +82,12 @@ function _make_fww_iip(
         FW{Nothing, A1}(vff), FW{Nothing, A2}(vff),
         FW{Nothing, A3}(vff), FW{Nothing, A4}(vff),
     )
-    cs = FunctionWrappersWrappers.SingleCacheStorage()
+    cache_prototype = FunctionWrappersWrappers.FunctionWrappersWrapper(
+        vff, (A1,), (Nothing,);
+        cache = FunctionWrappersWrappers.SingleCache(),
+        policy = FunctionWrappersWrappers.AllowNonIsBits(),
+    )
+    cs = cache_prototype.cache_storage
     return FunctionWrappersWrappers.FunctionWrappersWrapper{
         typeof(fwt), FunctionWrappersWrappers.AllowNonIsBits, typeof(cs),
     }(fwt, cs)

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseForwardDiffExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseForwardDiffExt.jl
@@ -21,6 +21,20 @@ import NonlinearSolveBase: wrapfun_iip, standardize_forwarddiff_tag
 
 const DI = DifferentiationInterface
 
+_cache_storage_type(
+    ::FunctionWrappersWrappers.FunctionWrappersWrapper{FW, P, CS}
+) where {FW, P, CS} = CS
+
+# The concrete storage types are intentionally not public. Derive the type selected by the
+# public cache-mode API, then use the documented explicit-parameter constructor below.
+const FWW_SINGLE_CACHE_STORAGE_TYPE = _cache_storage_type(
+    FunctionWrappersWrappers.FunctionWrappersWrapper(
+        identity, (Tuple{Float64},), (Float64,);
+        cache = FunctionWrappersWrappers.SingleCache(),
+        policy = FunctionWrappersWrappers.AllowNonIsBits(),
+    )
+)
+
 # --- AutoSpecialize / norecompile infrastructure for ForwardDiff ---
 
 const dualT = ForwardDiff.Dual{
@@ -78,19 +92,13 @@ function _make_fww_iip(
         @nospecialize(vff), ::Type{A1}, ::Type{A2}, ::Type{A3}, ::Type{A4}
     ) where {A1, A2, A3, A4}
     FW = FunctionWrappers.FunctionWrapper
-    fwt = (
-        FW{Nothing, A1}(vff), FW{Nothing, A2}(vff),
-        FW{Nothing, A3}(vff), FW{Nothing, A4}(vff),
-    )
-    cache_prototype = FunctionWrappersWrappers.FunctionWrappersWrapper(
-        vff, (A1,), (Nothing,);
-        cache = FunctionWrappersWrappers.SingleCache(),
-        policy = FunctionWrappersWrappers.AllowNonIsBits(),
-    )
-    cs = cache_prototype.cache_storage
+    FWT = Tuple{
+        FW{Nothing, A1}, FW{Nothing, A2},
+        FW{Nothing, A3}, FW{Nothing, A4},
+    }
     return FunctionWrappersWrappers.FunctionWrappersWrapper{
-        typeof(fwt), FunctionWrappersWrappers.AllowNonIsBits, typeof(cs),
-    }(fwt, cs)
+        FWT, FunctionWrappersWrappers.AllowNonIsBits, FWW_SINGLE_CACHE_STORAGE_TYPE,
+    }(vff)
 end
 
 # IIP wrapfun: wraps f(du, u, p) with dual-aware type combinations.

--- a/lib/NonlinearSolveBase/src/utils.jl
+++ b/lib/NonlinearSolveBase/src/utils.jl
@@ -311,7 +311,7 @@ function linsolve_identity!!(workspace, A::AbstractMatrix)
             return LinearAlgebra.ldiv!(LinearAlgebra.LowerTriangular(A_solve), ws.rhs)
         end
     end
-    return ws.lincache(; A, b = ws.rhs).u
+    return ws.lincache(; A = A_solve, b = ws.rhs).u
 end
 
 function initial_jacobian_scaling_alpha(α, u, fu, ::Any)

--- a/lib/NonlinearSolveBase/src/utils.jl
+++ b/lib/NonlinearSolveBase/src/utils.jl
@@ -254,7 +254,7 @@ function linsolve_workspace(A::AbstractMatrix)
         stats = SciMLBase.NLStats(0, 0, 0, 0, 0),
         alias = SciMLBase.LinearAliasSpecifier(alias_A = true, alias_b = true)
     )
-    return (; lincache, rhs), A
+    return (; lincache, rhs, A_buf), A
 end
 
 # scalar analog of the default solver's least-squares rescue: a singular (zero) entry
@@ -290,7 +290,27 @@ function linsolve_identity!!(workspace, A::AbstractMatrix)
     # buffer, so A is never mutated and passing the previously returned inverse as A is
     # safe. On singular A the default algorithm's pivoted-QR rescue returns a finite
     # least-squares generalized inverse (not the SVD `pinv`).
+    # The triangular solve returns `rhs` itself, so a nested reinversion can pass that
+    # buffer back as `A`. Preserve its contents before refilling the identity RHS.
+    A_solve = if A === ws.rhs
+        copyto!(ws.A_buf, A)
+        ws.A_buf
+    else
+        A
+    end
     make_identity!!(ws.rhs, true)
+    if A_solve isa StridedMatrix
+        diagonal = @view A_solve[LinearAlgebra.diagind(A_solve)]
+        nonsingular = !any(iszero, diagonal)
+        # Preserve exact triangular structure instead of allowing pivoted LU roundoff to
+        # alter sensitive quasi-Newton trajectories. Singular matrices still need the
+        # default solver's pivoted-QR rescue below.
+        if nonsingular && LinearAlgebra.istriu(A_solve)
+            return LinearAlgebra.ldiv!(LinearAlgebra.UpperTriangular(A_solve), ws.rhs)
+        elseif nonsingular && LinearAlgebra.istril(A_solve)
+            return LinearAlgebra.ldiv!(LinearAlgebra.LowerTriangular(A_solve), ws.rhs)
+        end
+    end
     return ws.lincache(; A, b = ws.rhs).u
 end
 

--- a/lib/NonlinearSolveBase/test/linsolve_workspace.jl
+++ b/lib/NonlinearSolveBase/test/linsolve_workspace.jl
@@ -40,6 +40,10 @@ end
     expected_reset = Matrix{Float64}(I, 3, 3)
     ldiv!(LowerTriangular(A_reset), expected_reset)
     @test Utils.linsolve_identity!!(workspace, A_reset) == expected_reset
+
+    A_general = [2.0 1.0 0.0; 0.0 3.0 1.0; 1.0 0.0 4.0]
+    copyto!(workspace.rhs, A_general)
+    @test Utils.linsolve_identity!!(workspace, workspace.rhs) ≈ inv(A_general)
 end
 
 @testset "singular input takes the pivoted-QR rescue" begin

--- a/lib/NonlinearSolveBase/test/linsolve_workspace.jl
+++ b/lib/NonlinearSolveBase/test/linsolve_workspace.jl
@@ -29,6 +29,19 @@ using Test
     end
 end
 
+@testset "dense triangular input preserves triangular solve semantics" begin
+    A = [1.1 0.0 0.0; 3.2 2.2 0.0; -4.1 5.3 3.3]
+    expected = Matrix{Float64}(I, 3, 3)
+    ldiv!(LowerTriangular(A), expected)
+    workspace, _ = Utils.linsolve_workspace(A)
+    @test Utils.linsolve_identity!!(workspace, A) == expected
+
+    A_reset = [0.1 0.0 0.0; 100.3 0.2 0.0; -44.1 55.3 0.3]
+    expected_reset = Matrix{Float64}(I, 3, 3)
+    ldiv!(LowerTriangular(A_reset), expected_reset)
+    @test Utils.linsolve_identity!!(workspace, A_reset) == expected_reset
+end
+
 @testset "singular input takes the pivoted-QR rescue" begin
     # The result is the LinearSolve default algorithm's least-squares generalized
     # inverse from its singular-LU → pivoted-QR rescue, NOT the SVD `pinv` (an

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -89,9 +89,17 @@ run_tests(;
 
             # Vector{Float64} u0 — wraps.
             prob_f64 = NonlinearProblem(f, [1.0, 2.0], [0.5, 0.25])
-            @test NonlinearSolveBase.is_fw_wrapped(
-                NonlinearSolveBase.maybe_wrap_nonlinear_f(prob_f64)
-            )
+            wrapped_f64 = NonlinearSolveBase.maybe_wrap_nonlinear_f(prob_f64)
+            @test NonlinearSolveBase.is_fw_wrapped(wrapped_f64)
+
+            du_big = zeros(BigFloat, 2)
+            u_big = BigFloat[3, 5]
+            p_big = BigFloat[1, 2]
+            wrapped_f64(du_big, u_big, p_big)
+            @test du_big == u_big
+            fill!(du_big, 0)
+            wrapped_f64(du_big, u_big, p_big)
+            @test du_big == u_big
 
             # Vector{Dual} u0 — must NOT wrap.
             DualF = ForwardDiff.Dual{ForwardDiff.Tag{typeof(identity), Float64}, Float64, 2}

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests.jl
@@ -7,3 +7,4 @@
 @safetestset "LimitedMemoryBroyden" include("core_tests__item7.jl")
 @safetestset "LimitedMemoryBroyden: Iterator Interface" include("core_tests__item8.jl")
 @safetestset "LimitedMemoryBroyden Termination Conditions" include("core_tests__item9.jl")
+@safetestset "Bad Broyden with a triangular true Jacobian" include("core_tests__item10.jl")

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests__item10.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests__item10.jl
@@ -1,0 +1,20 @@
+using NonlinearSolveQuasiNewton
+using SciMLBase
+using Test
+
+function generalized_rosenbrock!(out, x, p)
+    out[1] = 1.0 - x[1]
+    @views @. out[2:end] = 10.0 * (x[2:end] - x[1:(end - 1)]^2)
+    return nothing
+end
+
+x0 = ones(10)
+x0[1] = -1.2
+prob = NonlinearProblem(generalized_rosenbrock!, x0)
+alg = Broyden(; init_jacobian = Val(:true_jacobian), update_rule = Val(:bad_broyden))
+sol = solve(prob, alg; maxiters = 10_000)
+residual = similar(sol.u)
+generalized_rosenbrock!(residual, sol.u, nothing)
+
+@test SciMLBase.successful_retcode(sol)
+@test maximum(abs, residual) ≤ 1.0e-3


### PR DESCRIPTION
> **Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Summary

- stop naming the non-public `FunctionWrappersWrappers.SingleCacheStorage` type
- derive the cache-storage type selected by the public `SingleCache()` constructor through documented type parameters
- use the documented explicit-parameter wrapper constructor without inference widening
- exercise first use and cached reuse through the non-isbits `BigFloat` fallback path
- require FunctionWrappersWrappers 1.9.3, the first release providing the public constructor, and bump NonlinearSolveBase to 2.35.3

## Root cause

`NonlinearSolveBaseForwardDiffExt` directly constructed `FunctionWrappersWrappers.SingleCacheStorage`, which is intentionally not public. ExplicitImports therefore failed the NonlinearSolveBase QA job with `NonPublicQualifiedAccessException`.

The first public-constructor prototype removed that violation but widened both continuation driver return types to `Any`. The final implementation asks the public cache-mode constructor which documented `CS` type it selected, then uses the public `FunctionWrappersWrapper{FW,P,CS}(f)` constructor with a concrete heterogeneous wrapper tuple.

The compat floor matters: the explicit public constructor is absent in FunctionWrappersWrappers 1.0 and first appears in 1.9.3. Version 2.35.3 avoids the independently reserved NonlinearSolveBase 2.35.1 and #1061 version 2.35.2.

## Investigation

- reproduced the original QA failure on clean upstream with FunctionWrappersWrappers 1.10.1 and ExplicitImports 1.15.0
- bisected the QA transition to `0343930c2e53b47da8fa35d06379b12f5875b584` (#1046)
- reproduced the continuation inference regression independently of the Jacobian-reuse feature
- inspected released FunctionWrappersWrappers tags to establish 1.9.3 as the first valid public-API floor
- kept all access on documented public API

## Validation

- Julia 1.10.11, FunctionWrappersWrappers pinned exactly to 1.9.3, `GROUP=Core Pkg.test()` for `lib/NonlinearSolveBase`: passed
  - wrapper fallback: 6/6
  - linsolve workspace: 53/53
  - linear routing: 12/12
  - dense LU allocation coverage: 14/14
  - remaining Base Core testsets passed
- Julia 1.12.6 Base Core: passed
- Julia 1.12.6 Base QA: 18/18
- exact repository continuation inference regression: 26/26
- Runic 1.7.0 repository check: passed
- `git diff --check`: passed

No assertion was loosened, skipped, disabled, or converted to broken.