### PR TITLE
Develop NonlinearSolve sublibraries in downstream CI

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -19,17 +19,18 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - {user: SciML, repo: ModelingToolkit.jl, group: InterfaceI}
-          - {user: SciML, repo: ModelingToolkit.jl, group: InterfaceII}
-          - {user: SciML, repo: ModelingToolkit.jl, group: Initialization}
-          - {user: SciML, repo: OrdinaryDiffEq.jl, group: Interface}
-          - {user: SciML, repo: OrdinaryDiffEq.jl, group: Regression}
-          - {user: SciML, repo: BoundaryValueDiffEq.jl, group: All}
-          - {user: SciML, repo: DiffEqCallbacks.jl, group: Core}
+          - {user: SciML, repo: ModelingToolkit.jl, group: InterfaceI, upstream_subdirs: "."}
+          - {user: SciML, repo: ModelingToolkit.jl, group: InterfaceII, upstream_subdirs: "."}
+          - {user: SciML, repo: ModelingToolkit.jl, group: Initialization, upstream_subdirs: "."}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, group: Interface, upstream_subdirs: "."}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, group: Regression, upstream_subdirs: "."}
+          - {user: SciML, repo: BoundaryValueDiffEq.jl, group: All, upstream_subdirs: "lib/NonlinearSolveBase,lib/SciMLJacobianOperators,lib/NonlinearSolveFirstOrder"}
+          - {user: SciML, repo: DiffEqCallbacks.jl, group: Core, upstream_subdirs: "."}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       owner: "${{ matrix.package.user }}"
       repo: "${{ matrix.package.repo }}"
+      upstream-subdirs: "${{ matrix.package.upstream_subdirs }}"
       group: "${{ matrix.package.group }}"
       julia-version: "1"
     secrets: "inherit"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- make every downstream matrix row declare the caller project paths developed into the target
- develop `NonlinearSolveBase`, `SciMLJacobianOperators`, and `NonlinearSolveFirstOrder` for the BoundaryValueDiffEq target
- keep the existing root-package behavior for the other downstream targets

BoundaryValueDiffEq exercises these NonlinearSolve sublibraries rather than the monorepo root package. Developing only the root project could therefore leave that job green while testing registry releases instead of this checkout.

This depends on SciML/.github#115 and on publishing that merged reusable workflow at the moving `v1` tag before this caller job can start.

## Local verification

- `actionlint .github/workflows/Downstream.yml`
- `julia +1.12 --startup-file=no -m Runic --check .`
- `git diff --check`
- exact local replay against BoundaryValueDiffEq with `GROUP=All`: all three selected local projects resolved and precompiled as path dependencies

The exact downstream test suite itself did not run because of a legitimate current dependency incompatibility: `NonlinearSolveFirstOrder` requires LinearSolve 5 while BoundaryValueDiffEq's test project restricts LinearSolve to 3.12–3. I did not alter compatibility or suppress the resolver failure; this PR is limited to correcting which source projects the downstream job develops.