### PR TITLE
Add optional post-update `corrector` hook to first-order solvers

### DIFF
--- a/lib/NonlinearSolveFirstOrder/src/raphson.jl
+++ b/lib/NonlinearSolveFirstOrder/src/raphson.jl
@@ -2,7 +2,7 @@
     NewtonRaphson(;
         concrete_jac = nothing, linsolve = nothing, linesearch = missing,
         autodiff = nothing, vjp_autodiff = nothing, jvp_autodiff = nothing,
-        forcing = nothing,
+        forcing = nothing, corrector = nothing,
     )
 
 An advanced NewtonRaphson implementation with support for efficient handling of sparse
@@ -26,11 +26,15 @@ for large-scale and numerically-difficult nonlinear systems.
     linear system is solved at each iteration. Use `EisenstatWalkerForcing2()` for the
     classical Eisenstat-Walker adaptive forcing strategy. Defaults to `nothing` (fixed
     tolerance from the termination condition).
+  - `corrector`: An optional post-update hook run once per iteration, immediately after the
+    Newton step and before the residual re-evaluation. Called as `corrector(u, u_prev, p)`,
+    expected to mutate `u` in place. Defaults to `nothing` (no-op). See
+    [`GeneralizedFirstOrderAlgorithm`](@ref) for the full contract.
 """
 function NewtonRaphson(;
         concrete_jac = nothing, linsolve = nothing, linesearch = missing,
         autodiff = nothing, vjp_autodiff = nothing, jvp_autodiff = nothing,
-        forcing = nothing,
+        forcing = nothing, corrector = nothing,
     )
     return GeneralizedFirstOrderAlgorithm(;
         linesearch,
@@ -38,6 +42,7 @@ function NewtonRaphson(;
         autodiff, vjp_autodiff, jvp_autodiff,
         concrete_jac,
         forcing,
+        corrector,
         name = :NewtonRaphson
     )
 end

--- a/lib/NonlinearSolveFirstOrder/src/solve.jl
+++ b/lib/NonlinearSolveFirstOrder/src/solve.jl
@@ -18,6 +18,16 @@ order of convergence.
     [`NonlinearSolveBase.AbstractTrustRegionMethod`](@ref) interface.
   - `descent`: The descent method to use to compute the step. This needs to follow the
     [`NonlinearSolveBase.AbstractDescentDirection`](@ref) interface.
+  - `corrector`: An optional post-update hook run once per iteration, immediately after the
+    state update (`u ← u + αδu`) and *before* the residual re-evaluation and termination
+    check. Called as `corrector(u, u_prev, p)` and expected to mutate `u` in place; the
+    corrected `u` is what the subsequent `f`/termination sees. `nothing` (the default) is a
+    no-op with byte-identical behavior to a solver without a corrector. Only supported for
+    the `:None` and `:LineSearch` globalizations — the `:TrustRegion` globalization produces
+    its update and residual together and offers no such seam, so a corrector is ignored
+    there. Useful for projected/limited Newton schemes (e.g. SPICE-style junction limiting)
+    where the iterate must be pulled onto a feasible manifold between the linear step and the
+    next function evaluation.
   - `max_shrink_times`: The maximum number of times the trust region radius can be shrunk
     before the algorithm terminates.
 """
@@ -26,6 +36,7 @@ order of convergence.
     trustregion
     descent
     forcing
+    corrector
     max_shrink_times::Int
 
     autodiff
@@ -39,12 +50,13 @@ end
 function GeneralizedFirstOrderAlgorithm(;
         descent, linesearch = missing, trustregion = missing, autodiff = nothing,
         vjp_autodiff = nothing, jvp_autodiff = nothing, max_shrink_times::Int = typemax(Int),
-        concrete_jac = Val(false), forcing = nothing, name::Symbol = :unknown
+        concrete_jac = Val(false), forcing = nothing, corrector = nothing,
+        name::Symbol = :unknown
     )
     concrete_jac = concrete_jac isa Bool ? Val(concrete_jac) :
         (concrete_jac isa Val ? concrete_jac : Val(concrete_jac !== nothing))
     return GeneralizedFirstOrderAlgorithm(
-        linesearch, trustregion, descent, forcing, max_shrink_times,
+        linesearch, trustregion, descent, forcing, corrector, max_shrink_times,
         autodiff, vjp_autodiff, jvp_autodiff,
         concrete_jac, name
     )
@@ -293,6 +305,18 @@ function SciMLBase.__init(
     return cache
 end
 
+# Post-update corrector hook. Runs at the seam between the state update and the
+# residual re-evaluation (see the `corrector` docstring on
+# `GeneralizedFirstOrderAlgorithm`). At the call site `cache.u` holds the freshly
+# proposed iterate and `cache.u_cache` still holds the previous one. `nothing` is
+# a no-op, so a solver constructed without a corrector behaves identically.
+function maybe_apply_corrector!(cache::GeneralizedFirstOrderAlgorithmCache)
+    corrector = cache.alg.corrector
+    corrector === nothing && return nothing
+    corrector(cache.u, cache.u_cache, cache.p)
+    return nothing
+end
+
 function InternalAPI.step!(
         cache::GeneralizedFirstOrderAlgorithmCache;
         recompute_jacobian::Union{Nothing, Bool} = nothing
@@ -364,6 +388,7 @@ function InternalAPI.step!(
             end
             @static_timeit cache.timer "step" begin
                 @bb axpy!(α, δu, cache.u)
+                maybe_apply_corrector!(cache)
                 Utils.evaluate_f!(cache, cache.u, cache.p)
             end
         elseif cache.globalization isa Val{:TrustRegion}
@@ -389,6 +414,7 @@ function InternalAPI.step!(
         elseif cache.globalization isa Val{:None}
             @static_timeit cache.timer "step" begin
                 @bb axpy!(1, δu, cache.u)
+                maybe_apply_corrector!(cache)
                 Utils.evaluate_f!(cache, cache.u, cache.p)
             end
             α = true

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests.jl
@@ -3,3 +3,5 @@
 @safetestset "TrustRegion reinit! resets trust_region" include("misc_tests__item3.jl")
 @safetestset "Line search uses forward-mode autodiff: Issue #837" include("misc_tests__item4.jl")
 @safetestset "Default NLLS polyalg is forward-mode only: Issue #837" include("misc_tests__item5.jl")
+@safetestset "Post-update corrector hook: :None globalization" include("misc_tests__item6.jl")
+@safetestset "Post-update corrector hook: :LineSearch honored, :TrustRegion inert" include("misc_tests__item7.jl")

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests__item6.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests__item6.jl
@@ -1,0 +1,63 @@
+using NonlinearSolveFirstOrder
+
+# The `corrector` post-update hook runs at the seam between the Newton update
+# (u ← u + αδu) and the residual re-evaluation. It is called as
+# `corrector(u_proposed, u_prev, p)`, mutates `u` in place, and the corrected
+# `u` is what the subsequent residual and termination check observe.
+#
+# Slaved-variable system (the shape SPICE junction limiting / PCNR produces):
+# u[1] is free, u[2] is slaved to u[1]^3 by a linear tracking row. A corrector
+# that overwrites u[2] := u[1]^3 keeps that row satisfied right after the step.
+function f!(F, u, p)
+    F[1] = u[1] - p[1]
+    F[2] = u[2] - u[1]^3
+    return nothing
+end
+
+u0 = [0.0, 0.0]
+p = [1.0]
+prob = NonlinearProblem(NonlinearFunction(f!), u0, p)
+
+# --- corrector invoked with the right arguments, in the right order ---
+calls = Vector{Tuple{Vector{Float64}, Vector{Float64}}}()
+function corrector!(u, u_prev, p)
+    push!(calls, (copy(u), copy(u_prev)))  # record BEFORE mutating
+    u[2] = u[1]^3
+    return nothing
+end
+
+sol = solve(prob, NewtonRaphson(; corrector = corrector!); abstol = 1e-12)
+
+@test sol.retcode == ReturnCode.Success
+@test sol.u[1] ≈ 1.0 atol = 1e-10
+@test sol.u[2] ≈ 1.0 atol = 1e-10
+# the corrector enforced the slaving exactly on the returned iterate
+@test sol.u[2] == sol.u[1]^3
+# called exactly once per Newton step
+@test length(calls) == sol.stats.nsteps
+@test sol.stats.nsteps ≥ 1
+# ordering: the `u` handed to the corrector is the POST-update iterate — on the
+# first step it differs from `u_prev`, which is the initial guess `u0`
+u_first, uprev_first = calls[1]
+@test uprev_first == u0
+@test u_first != u0                       # axpy! ran before the corrector fired
+# every subsequent call sees the slaving the previous call applied
+for (_, up) in calls[2:end]
+    @test up[2] == up[1]^3
+end
+
+# --- `nothing` (the default) is a genuine no-op ---
+sol_default = solve(prob, NewtonRaphson(); abstol = 1e-12)
+sol_nothing = solve(prob, NewtonRaphson(; corrector = nothing); abstol = 1e-12)
+@test sol_nothing.u == sol_default.u
+@test sol_nothing.stats.nsteps == sol_default.stats.nsteps
+
+# an inert (identity) corrector must not change the result vs no corrector
+inert_corrector!(u, u_prev, p) = nothing
+sol_inert = solve(prob, NewtonRaphson(; corrector = inert_corrector!); abstol = 1e-12)
+@test sol_inert.u ≈ sol_default.u
+@test sol_inert.stats.nsteps == sol_default.stats.nsteps
+
+# the slaving corrector converges the augmented system in fewer steps than plain
+# Newton (it removes the slaved variable's lag) — evidence the hook does work
+@test sol.stats.nsteps < sol_default.stats.nsteps

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests__item7.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests__item7.jl
@@ -1,0 +1,50 @@
+using NonlinearSolveFirstOrder, LineSearch
+
+# The corrector seam is honored under the :LineSearch globalization too, and is
+# documented-unsupported (must be inert, never called) under :TrustRegion, which
+# produces its update and residual together and offers no post-update seam.
+function f!(F, u, p)
+    F[1] = u[1] - p[1]
+    F[2] = u[2] - u[1]^3
+    return nothing
+end
+
+u0 = [0.0, 0.0]
+p = [1.0]
+prob = NonlinearProblem(NonlinearFunction(f!), u0, p)
+
+called = Ref(0)
+function corrector!(u, u_prev, p)
+    called[] += 1
+    u[2] = u[1]^3
+    return nothing
+end
+
+# --- :LineSearch globalization honors the corrector ---
+called[] = 0
+sol_ls = solve(
+    prob, NewtonRaphson(; linesearch = BackTracking(), corrector = corrector!);
+    abstol = 1e-12
+)
+@test sol_ls.retcode == ReturnCode.Success
+@test sol_ls.u[2] == sol_ls.u[1]^3          # corrector applied on the returned iterate
+@test called[] == sol_ls.stats.nsteps
+@test called[] ≥ 1
+
+# --- :TrustRegion ignores the corrector (documented unsupported) ---
+# Build a trust-region GeneralizedFirstOrderAlgorithm carrying a corrector by
+# reusing the descent/trustregion from a stock TrustRegion() (public fields) and
+# the exported keyword constructor. The corrector must never fire, and the solve
+# must converge exactly as a corrector-less trust-region run would.
+tr = TrustRegion()
+tr_with_corrector = GeneralizedFirstOrderAlgorithm(;
+    trustregion = tr.trustregion, descent = tr.descent, corrector = corrector!,
+    name = :TrustRegionWithCorrector
+)
+
+called[] = 0
+sol_tr = solve(prob, tr_with_corrector; abstol = 1e-12)
+sol_tr_ref = solve(prob, TrustRegion(); abstol = 1e-12)
+@test called[] == 0                          # corrector never invoked under :TrustRegion
+@test sol_tr.retcode == ReturnCode.Success
+@test sol_tr.u ≈ sol_tr_ref.u


### PR DESCRIPTION
## Add an optional post-update `corrector` hook to first-order solvers

### What

Adds an optional `corrector` slot to `GeneralizedFirstOrderAlgorithm`, threaded
through `NewtonRaphson(; corrector = ...)`. When set, it runs **once per
iteration, at the seam between the state update (`u ← u + αδu`) and the residual
re-evaluation** — i.e. immediately after `axpy!` and before `evaluate_f!` — in
the `:None` and `:LineSearch` globalizations. It is called as

```julia
corrector(u, u_prev, p)   # mutates u in place
```

so the corrected `u` is what the subsequent function evaluation and termination
check observe.

- **Default `nothing` is a byte-identical no-op** (guarded `=== nothing` return;
  no allocation, no call). Behavior of every existing solver is unchanged.
- **`:TrustRegion` is unsupported** and documented as such: it produces its update
  and residual together inside the trust-region cache, so there is no post-update
  seam. A corrector passed to a trust-region algorithm is simply never invoked.

### Why

Projected / limited Newton schemes need to pull the proposed iterate onto a
feasible manifold *between* the linear step and the next residual evaluation.
The motivating case is **SPICE-style junction limiting** (the "correct" phase of
the Predictor/Corrector Newton-Raphson scheme of Aadithya, Keiter & Mei,
*"Achieving Robust and High-Fidelity Circuit Simulation…"*, Sandia
SAND2018-5689C): after each Newton update, the limiting components of the state
are replaced by the limited branch voltages the devices recorded during
stamping, which then act as the linearization point (`vold`) for the next
iteration. There is currently no hook at this point — `callback_into_cache!`
fires *after* the residual and termination check, and Eisenstat–Walker forcing
fires *pre*-update and only tunes the linear-solve tolerance — so this is a
genuinely new insertion point.

### Consumer evidence

Downstream in [Cadnip.jl](https://github.com/NyanCAD/Cadnip.jl) (an MNA circuit
simulator) this hook replaces a hand-rolled predictor/corrector Newton loop. The
Cadnip corrector copies the devices' recorded limited voltages into the trailing
"limit" slots of the state; `p` carries the simulator workspace holding them.
Driving the diode/BJT DC-operating-point benchmarks through
`NewtonRaphson(corrector = ...)` reproduces the hand-rolled loop **iteration-for-
iteration**, with solutions agreeing to the solve's conditioning-limited floor:

| circuit (Vsrc) | hand-rolled iters | corrector-hook iters | rel. soln. agreement |
|----------------|------------------:|---------------------:|---------------------:|
| rectifier (5 V)   | 7  | 7  | exact |
| rectifier (50 V)  | 6  | 6  | exact |
| chain3 (50 V)     | 6  | 6  | exact |
| graetz (20 V)     | 14 | 14 | 1.0e-11 |
| graetz (325 V)    | 14 | 14 | 5.5e-10 |
| mul4 (50 V)       | 14 | 14 | 5.7e-16 |
| darlington (3 V)  | 12 | 12 | 1.7e-15 |
| darlington (5 V)  | 12 | 12 | 2.8e-15 |

(All converge with `‖F‖ < 1e-10`. The 325 V case's `~5e-10` relative difference
is the floor of a `abstol=1e-10` solve on a matrix with 1 MΩ ground resistors,
and stems only from the linear-solver rounding, not the hook.)

### Tests

`lib/NonlinearSolveFirstOrder/test/misc_tests.jl` gains two items:
- `:None` globalization — verifies the corrector is invoked once per step with
  `(u_proposed, u_prev, p)` in the right order, that its in-place mutation is seen
  by the subsequent residual, that `nothing`/an inert corrector are no-ops
  matching a corrector-less run, and that the projecting corrector converges the
  slaved system in fewer steps.
- `:LineSearch` honors the seam; `:TrustRegion` leaves the corrector inert.

### Notes / follow-up

This PR ships only the generic hook. A follow-up will propose a flagship
`PCNR`-style algorithm instantiation and an increment-based (`‖u_{n+1}−u_n‖ ≤
tol`) `Success` termination mode, which together let a recorded-`w` corrector
terminate without the one-iterate residual lag inherent to reading the
*previous* stamp.
