### PR TITLE
Bump NonlinearSolveBase to v2.35.1 for release

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.35.0"
+version = "2.35.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
Bumps `NonlinearSolveBase` 2.35.0 → 2.35.1 so the unreleased bug fix on master gets registered.

Unreleased since v2.35.0:
- c223b21f — fix oop `dampen_jacobian!!` for scalar damping (#1068)

## Verification
Detected by comparing the `git-tree-sha1` of the latest registered version in the General registry against the `src` tree on `master`: they differ, so the code above is on master but not in any released version.

**No test suite was run locally for this PR** — it changes only the `version` field in `Project.toml` and adds no code. CI on this PR is the check that matters.

Please ignore until reviewed by @ChrisRackauckas.