### PR TITLE
Restore exact native inversion fast paths for strided dense J⁻¹ initialization

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.35.0"
+version = "2.35.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseSparseArraysExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseSparseArraysExt.jl
@@ -87,7 +87,9 @@ dense buffer before factorizing.
 """
 function Utils.linsolve_workspace(A::AbstractSparseMatrix)
     dense_A = Matrix(A)
-    workspace, _ = Utils.linsolve_workspace(dense_A)
+    # `lincache_linsolve_workspace` directly: `linsolve_workspace(dense_A)` would take the
+    # strided fast path and return no cache, but sparse `linsolve_identity!!` needs one
+    workspace, _ = Utils.lincache_linsolve_workspace(dense_A)
     return workspace, dense_A
 end
 

--- a/lib/NonlinearSolveBase/src/utils.jl
+++ b/lib/NonlinearSolveBase/src/utils.jl
@@ -227,13 +227,19 @@ end
 condition_number(::Any) = -1
 
 # Explicit inverse-Jacobian initialization for quasi-Newton update rules that store J⁻¹:
-# solve A * X = I with the default linear solver. Scalars, `Diagonal`s, and static
-# matrices take native fast paths (mirroring `construct_linear_solver`'s routing) instead
-# of the linear-solve cache.
+# solve A * X = I with the default linear solver. Scalars, `Diagonal`s, static and strided
+# dense matrices take native fast paths (mirroring `construct_linear_solver`'s routing)
+# instead of the linear-solve cache.
 linsolve_workspace(A) = nothing, A
 linsolve_workspace(A::Diagonal) = nothing, A
 linsolve_workspace(A::SMatrix) = nothing, A
+# Strided dense matrices invert through the exact native fast paths in
+# `linsolve_identity!!` below and need no linear-solve cache.
+linsolve_workspace(A::StridedMatrix) = nothing, A
 function linsolve_workspace(A::AbstractMatrix)
+    return lincache_linsolve_workspace(A)
+end
+function lincache_linsolve_workspace(A::AbstractMatrix)
     LinearAlgebra.checksquare(A)
     # the linear solve promotes e.g. integer eltypes; the buffers must hold the promoted
     # values. The `size` form of `similar` gives a dense buffer for structured input
@@ -279,6 +285,32 @@ function linsolve_identity!!(workspace, A::SMatrix{S1, S2, T, L}) where {S1, S2,
     return SciMLBase.solve(
         SciMLBase.LinearProblem(A, SMatrix{S1, S2, Tinv}(LinearAlgebra.I))
     ).u
+end
+# Strided dense matrices keep the exact native inversion fast paths: triangular input
+# inverts by exact back-substitution and general input by LU `inv!`, with `pinv` as the
+# singular fallback. These produce a bit-identical J⁻¹ to the pre-linsolve-workspace
+# initialization (a pivoted LU solve against an identity RHS differs at rounding level,
+# e.g. row pivoting reorders a triangular matrix), which matters because quasi-Newton
+# trajectories on hard problems are chaotic enough for last-bit differences in the
+# initial J⁻¹ to flip convergence outcomes.
+function linsolve_identity!!(workspace, A::StridedMatrix)
+    LinearAlgebra.checksquare(A)
+    if LinearAlgebra.istriu(A)
+        issingular = any(iszero, @view(A[diagind(A)]))
+        A_ = LinearAlgebra.UpperTriangular(A)
+        !issingular && return LinearAlgebra.triu!(parent(inv(A_)))
+    elseif LinearAlgebra.istril(A)
+        A_ = LinearAlgebra.LowerTriangular(A)
+        issingular = any(iszero, @view(A_[diagind(A_)]))
+        !issingular && return LinearAlgebra.tril!(parent(inv(A_)))
+    else
+        F = LinearAlgebra.lu(A; check = false)
+        if LinearAlgebra.issuccess(F)
+            Ai = LinearAlgebra.inv!(F)
+            return convert(typeof(parent(Ai)), Ai)
+        end
+    end
+    return pinv(A)
 end
 function linsolve_identity!!(workspace, A::AbstractMatrix)
     LinearAlgebra.checksquare(A)

--- a/lib/NonlinearSolveBase/test/linsolve_workspace.jl
+++ b/lib/NonlinearSolveBase/test/linsolve_workspace.jl
@@ -29,11 +29,11 @@ using Test
     end
 end
 
-@testset "singular input takes the pivoted-QR rescue" begin
-    # The result is the LinearSolve default algorithm's least-squares generalized
-    # inverse from its singular-LU → pivoted-QR rescue, NOT the SVD `pinv` (an
-    # intentional semantics change: same fitness for quasi-Newton initialization,
-    # different finite matrix).
+@testset "singular strided input falls back to the SVD pinv" begin
+    # Strided dense input takes the native fast paths, whose singular fallback is the
+    # SVD `pinv` — the same finite min-norm generalized inverse the pre-workspace
+    # `maybe_pinv!!` initialization produced. (Non-strided input still goes through the
+    # lincache, where singular A takes the default algorithm's pivoted-QR rescue.)
     n = 20
     A_singular = let B = rand(n, n)
         B[:, 1] .= 0
@@ -51,26 +51,29 @@ end
         # X is a least-squares generalized inverse: A * X projects onto range(A)
         @test A * X * A ≈ A atol = 1.0e-8 * norm(A)
         @test A == A_orig
+        @test X == pinv(A_orig)
         # a subsequent nonsingular solve with the same workspace is unaffected
         B = rand(n, n) + n * I
         @test Utils.linsolve_identity!!(workspace, B) ≈ inv(B)
     end
 end
 
-@testset "workspace reuse does not allocate a matrix copy" begin
-    n = 51
-    A = rand(n, n) + n * I
-    workspace, _ = Utils.linsolve_workspace(A)
-    Utils.linsolve_identity!!(workspace, A)  # compile
-    # Steady state is the LinearSolve refactorization floor (`lu!` ipiv + wrapper); the
-    # old code copied A (`lu`) and allocated a LAPACK getri work array, both O(n^2).
-    allocs = @allocated Utils.linsolve_identity!!(workspace, A)
-    @test allocs < sizeof(A)
-
-    A_triu = triu(A)
-    Utils.linsolve_identity!!(workspace, A_triu)  # compile
-    allocs_tri = @allocated Utils.linsolve_identity!!(workspace, A_triu)
-    @test allocs_tri < sizeof(A)
+@testset "strided input takes the exact native inversion fast paths" begin
+    # Strided dense matrices invert bit-identically to `inv` (exact triangular
+    # back-substitution, or LU `inv!`) and build no linear-solve cache — a pivoted
+    # solve against an identity RHS differs from `inv` at rounding level, and chaotic
+    # quasi-Newton trajectories that consume this J⁻¹ can flip convergence outcomes on
+    # last-bit differences.
+    n = 20
+    A_general = rand(n, n) + n * I
+    A_triu = triu(rand(n, n) + n * I)
+    A_tril = tril(rand(n, n) + n * I)
+    for A in (A_general, A_triu, A_tril)
+        workspace, A_ret = Utils.linsolve_workspace(A)
+        @test workspace === nothing && A_ret === A
+        @test Utils.linsolve_identity!!(workspace, A) == inv(A)
+        @test Utils.linsolve_identity!!(nothing, A) == inv(A)
+    end
 end
 
 @testset "sparse matrices route through the lincache (no sparse pinv)" begin

--- a/lib/NonlinearSolveBase/test/qa/qa.jl
+++ b/lib/NonlinearSolveBase/test/qa/qa.jl
@@ -38,8 +38,8 @@ run_qa(
         #   Base: add_sum;  Core(.Compiler): Compiler, return_type;  LinearAlgebra: inv!
         #   FunctionWrappers: FunctionWrapper
         #   NonlinearSolveBase(.Utils/.InternalAPI): additional_incompatible_backend_check,
-        #     condition_number, get_raw_f, get_u, linsolve_workspace,
-        #     is_extension_loaded, make_sparse, maybe_symmetric,
+        #     condition_number, get_raw_f, get_u, lincache_linsolve_workspace,
+        #     linsolve_workspace, is_extension_loaded, make_sparse, maybe_symmetric,
         #     nlls_generate_vjp_function, nodual_value, nonlinearsolve_∂f_∂p,
         #     nonlinearsolve_∂f_∂u, reinit!, restructure, safe_reshape, safe_similar,
         #     sparse_or_structured_prototype, structural_sparse
@@ -52,7 +52,8 @@ run_qa(
                 :Dual, :Partials, :Tag, :can_dual, :derivative, :gradient, :jacobian,
                 :partials, :pickchunksize, :value, :add_sum, :Compiler, :return_type, :inv!,
                 :FunctionWrapper, :additional_incompatible_backend_check, :condition_number,
-                :get_raw_f, :get_u, :linsolve_workspace, :is_extension_loaded,
+                :get_raw_f, :get_u, :lincache_linsolve_workspace, :linsolve_workspace,
+                :is_extension_loaded,
                 :make_sparse,
                 :maybe_symmetric, :nlls_generate_vjp_function, :nodual_value,
                 Symbol("nonlinearsolve_∂f_∂p"), Symbol("nonlinearsolve_∂f_∂u"),


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR should be ignored until reviewed by @ChrisRackauckas.**

## What happened

#1039 replaced the quasi-Newton inverse-Jacobian initialization (`Utils.maybe_pinv!!`, used by `Broyden`/`Klement` with `init_jacobian = Val(:true_jacobian)`) with `Utils.linsolve_identity!!`, which routes every dense matrix through a LinearSolve solve `A·X = I` on a workspace lincache. The old code had exact native fast paths:

- triangular input → `inv(UpperTriangular(A))` / `inv(LowerTriangular(A))` (exact back-substitution),
- general dense → `inv!(lu(A))`,
- singular fallback → `pinv(A)`.

A pivoted LU solve against an identity RHS produces a J⁻¹ that differs from these at **rounding level** (row pivoting reorders a triangular matrix; a multi-RHS `getrs` differs from `getri`). That is normally harmless — but the downstream Broyden robustness suite is not normal.

## Why it flipped downstream CI

LinearSolve.jl's IntegrationTest "NonlinearSolve.jl/Core" job started failing after NonlinearSolveQuasiNewton 1.14.0 / NonlinearSolveBase 2.34.x released (first bad main run 2026-07-13; the 2026-07-15 "green" runs had the same job soft-failed):

- `1: Generalized Rosenbrock function | alg #4` (`Broyden(; init_jacobian = Val(:true_jacobian), update_rule = Val(:bad_broyden))`): **Test Failed**, `norm(res, Inf) = 4.4`
- `8: Brown almost linear function | alg #4`: **Unexpected Pass**

Bisection by version-pinning exonerated LinearSolve (registered 4.3.0 vs 5.0.0-dev main: bit-identical results on all 23 problems), FiniteDiff, ADTypes, and NonlinearProblemLibrary; the flip is exactly QN 1.13.3 → 1.14.0 + NLSBase 2.33.0 → 2.34.1, and monkey-patching only `linsolve_identity!!` back to the old `maybe_pinv!!` logic inside the failing environment restores both old outcomes.

The mechanism is chaos, not a wrong answer: tracing problem 1 (whose initial and reset Jacobians are **lower triangular** — bidiagonal, diag 10 / subdiag −20) shows old and new iterates bit-identical through iter 4, ~1e−15 apart at iter 5, then both trajectories diverge violently to residual norms ~1e177–1e179 with `cond(J) = Inf`. The pre-#1039 trajectory then *happened* to land exactly on the root (fnorm 10.0 → 0.0 at iters 16–17); the post-#1039 one overflows (1e270 → Inf), trips the `!isfinite` protective break (`ReturnCode.Unstable`), and returns the initial guess. Problem 8 is the mirror image (dense Jacobian, `inv!(lu(A))` vs lincache solve). The last-bit difference in the initial J⁻¹ decides which side of the coin these known-marginal tests land on.

## The fix

Restore the pre-#1039 exact semantics for `StridedMatrix` (the common dense case), keeping #1039's lincache route for everything that needs it:

- `linsolve_identity!!(workspace, A::StridedMatrix)`: exact triangular inversion / LU `inv!` / `pinv` singular fallback — bit-identical to `inv(A)` for nonsingular input and to the pre-#1039 initialization in all cases.
- `linsolve_workspace(A::StridedMatrix) = nothing, A`: no linear-solve cache is built for strided dense input (pre-#1039 built none either).
- Sparse and structured (e.g. `Tridiagonal`) input still routes through the lincache; the SparseArrays ext now calls the extracted `lincache_linsolve_workspace` builder directly, since plain `linsolve_workspace(::Matrix)` no longer returns a cache.
- **No broken-list or robustness-test-expectation changes anywhere.**

**Deliberate trade-off, called out explicitly:** this gives back #1039's allocation win for the strided dense path (the restored path copies `A` in `lu` and allocates LAPACK work arrays). The `"workspace reuse does not allocate a matrix copy"` testset from #1039 asserted exactly that optimization, so it is replaced by a testset asserting the restored exact semantics (`linsolve_identity!! == inv` for nonsingular strided input, `== pinv` for singular, no workspace built). The init inversion runs once per solve plus once per Jacobian reset, so bit-stability of the J⁻¹ init was judged worth more than the per-init allocation win. If the allocation property is preferred instead, the alternative fix is updating the downstream broken lists (add 1 / remove 8 for alg #4) — happy to swap to that on review.

NonlinearSolveBase → 2.35.1 (bugfix, no API change). NonlinearSolveQuasiNewton needs no changes (its `NonlinearSolveBase = "2.34"` compat admits 2.35.1).

## Verification (Julia 1.10.11, x86-64 Linux)

Downstream repro env (registered NonlinearSolve 4.21.1 + NonlinearSolveQuasiNewton 1.14.1 + LinearSolve 5.0.0 + NonlinearProblemLibrary 0.1.7, NonlinearSolveBase dev'd at this branch), `Broyden(; init_jacobian = Val(:true_jacobian), update_rule = Val(:bad_broyden))`:

| stack | prob 1 (Gen. Rosenbrock) | prob 8 (Brown almost linear) |
|---|---|---|
| NLSBase 2.33.0 / QN 1.13.3 (pre-#1039) | Success, 17 steps, norm 0.0 | Unstable, 5 steps (broken as declared) |
| NLSBase 2.35.0 / QN 1.14.1 (current) | **Unstable, norm 4.4 → Test Failed** | **converges → Unexpected Pass** |
| **this branch** | Success, 17 steps, norm 0.0 | Unstable, 5 steps (broken as declared) |

Full `test/Core/23_test_problems_tests__item7.jl` (all 5 Broyden variants × 23 problems) against this branch:

```
Test Summary:                     | Pass  Broken  Total   Time
23 Test Problems: Broyden (item7) |   95      20    115  25.6s
```

0 failures, 0 errors, unchanged broken lists.

`lib/NonlinearSolveBase`:

```
GROUP=Core: Testing NonlinearSolveBase tests passed
            (incl. "linsolve_identity!! workspace (#1020)" 59/59 and
             "Dense LU refactorization allocations" 14/14 — the #1038 descent path is untouched)
GROUP=QA:   QA | 16 Pass | Total 16 — Testing NonlinearSolveBase tests passed
```

`lib/NonlinearSolveQuasiNewton` `GROUP=Core`: Testing NonlinearSolveQuasiNewton tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
