### PR TITLE
Bump NonlinearSolveBase to 2.35.1 and NonlinearSolveFirstOrder to 2.2.2 (release unreleased #1051/#1055 fixes)

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.35.0"
+version = "2.35.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveFirstOrder/Project.toml
+++ b/lib/NonlinearSolveFirstOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveFirstOrder"
 uuid = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "2.2.1"
+version = "2.2.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR should be ignored until reviewed by @ChrisRackauckas.**

## The version-hygiene gap

Recent PRs shipped sublibrary source/ext changes **plus tests that depend on them** without bumping the sublibrary versions, so master's `test/Core` group now fails wherever it runs against the registered packages — which includes LinearSolve.jl's downstream IntegrationTest "NonlinearSolve.jl/Core" job. This was latent since 2026-07-15 (#1055) and got unmasked when #1051 fixed the Broyden robustness suite that previously aborted the run before reaching the affected file.

Concretely, `test/Core/forward_ad_tests__item2.jl`'s "NLLS Hessian SciML/NonlinearSolve.jl#445" testset (added by #1055) exercises ForwardDiff implicit sensitivities on a singular NLLS Hessian. Registered NonlinearSolveBase 2.35.0's ForwardDiff ext still does `H \ b` → `Diagonal \` → hard error:

```
NLLS Hessian SciML/NonlinearSolve.jl#445: Error During Test at test/Core/forward_ad_tests__item2.jl:141 (and :142)
  Expression: ForwardDiff.gradient(singular_nlls_sum, [1.0]) ≈ [1.0]
  LinearAlgebra.SingularException(2)
  Stacktrace:
    [1] ldiv!(B::Matrix{Float64}, D::LinearAlgebra.Diagonal{Float64, Vector{Float64}}, A::Matrix{Float64})
    ...
    [4] solve!(cache::NonlinearSolveBase.NonlinearSolveForwardDiffCache{...})
      @ NonlinearSolveBaseForwardDiffExt ~/.julia/packages/NonlinearSolveBase/yoCxi/ext/NonlinearSolveBaseForwardDiffExt.jl:305
Test Summary:    | Pass  Error  Total
forward_ad item2 |    8      2     10
```

With master's `lib/NonlinearSolveBase` dev'd instead (same env, Julia 1.10.11), the same file passes `10/10` — #1055's `_forwarddiff_implicit_solve` (LinearSolve route with singular rescue) is the fix; it just was never released.

## Full latent-failure sweep

Because the Core group runs files sequentially and aborts at the first erroring file, more mismatches could hide behind item2. Sweep of the **entire** master Core group against the registered stack (Julia 1.10.11; NonlinearSolve 4.21.1 — whose root `src/` is byte-identical to master — + NonlinearSolveBase 2.35.0, NonlinearSolveFirstOrder 2.2.1, NonlinearSolveQuasiNewton 1.14.1, LinearSolve 5.0.0, SciMLBase 3.36.0):

- The 24 files ordered before `forward_ad_tests__item2.jl` (core_tests, all eight 23-test-problems suites incl. Broyden `95 Pass / 20 Broken` post-#1051, default_alg): **all pass**.
- The 49 files at/after it (forward_ad, reinit, issue, bounds, all 22 homotopy_sweep, all 8 arclength, jac/alloc/effort/tolerance/retention/polyalg files): **only `forward_ad_tests__item2.jl` fails** (the `SingularException` above), everything else passes.

So there is exactly **one** master-tests-vs-registered-libs mismatch, and it is fixed by releasing NonlinearSolveBase. No other class of failure was found.

## Unreleased changes per sublibrary (master vs registered copies, `src`+`ext`)

| lib | registered | unreleased changes | bump |
|---|---|---|---|
| NonlinearSolveBase | 2.35.0 | #1055 `ext/NonlinearSolveBaseForwardDiffExt.jl` (LinearSolve-backed `_forwarddiff_implicit_solve`); #1051 `descent/newton.jl` (undefined `N` → `shared`), `descent/dogleg.jl` (Cauchy-point `δuJᵀJδu`), `descent/damped_newton.jl` (non-setindex `J + D*I`) | **2.35.1** (bugfixes only) |
| NonlinearSolveFirstOrder | 2.2.1 | #1051 `eisenstat_walker.jl` (reinit! reset η + rnorm refresh), `pseudo_transient.jl` (`SwitchedEvolutionRelaxation` reinit! + state reset), `solve.jl` (drop stray `step!` kwargs) | **2.2.2** (bugfixes only) |
| BracketingNonlinearSolve, NonlinearSolveQuasiNewton, NonlinearSolveSpectralMethods, SCCNonlinearSolve, SciMLJacobianOperators, SimpleNonlinearSolve | current | none (`src`/`ext` byte-identical to registered) | none |
| root NonlinearSolve | 4.21.1 | none (`src` byte-identical) | none |

(#1051's new `lib/NonlinearSolveFirstOrder/test` files depend on the FirstOrder fixes; they run against path-dev'd sources in SublibraryCI, but the fixes should be released so registered consumers get them and future test/PkgEval runs stay consistent.)

All changes are internal bugfixes with no public-API additions, hence patch bumps.

## After merge

Register **NonlinearSolveBase 2.35.1** and **NonlinearSolveFirstOrder 2.2.2**. Once NonlinearSolveBase 2.35.1 is in the General registry, NonlinearSolve's Core group (and LinearSolve.jl's downstream IntegrationTest job) resolves it automatically (compat `NonlinearSolveBase = "2.35"`) and realigns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
