### PR TITLE
Add TaylorHomotopyContinuationJL: Taylor polynomialization + homotopy continuation + Newton polish for non-polynomial systems

### DIFF
--- a/docs/src/api/homotopycontinuation.md
+++ b/docs/src/api/homotopycontinuation.md
@@ -15,5 +15,6 @@ import NonlinearSolve as NLS
 
 ```@docs
 NonlinearSolveHomotopyContinuation.HomotopyContinuationJL
+NonlinearSolveHomotopyContinuation.TaylorHomotopyContinuationJL
 SciMLBase.HomotopyNonlinearFunction
 ```

--- a/lib/NonlinearSolveHomotopyContinuation/Project.toml
+++ b/lib/NonlinearSolveHomotopyContinuation/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveHomotopyContinuation"
 uuid = "2ac3b008-d579-4536-8c91-a1a5998c2f8b"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com> and contributors"]
-version = "0.1.10"
+version = "0.1.11"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -15,6 +15,7 @@ NonlinearSolveBase = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 TaylorDiff = "b36ab563-344f-407b-a36a-4f200bebf99c"
+TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 
 [sources.NonlinearSolveBase]
 path = "../NonlinearSolveBase"
@@ -35,22 +36,23 @@ LinearAlgebra = "1.10"
 NaNMath = "1.1"
 NonlinearSolve = "4.21"
 NonlinearSolveBase = "2.1"
+SafeTestsets = "0.1"
 SciMLBase = "3.34"
+SciMLTesting = "2.1"
 SymbolicIndexingInterface = "0.3.43"
 TaylorDiff = "0.3.1"
+TaylorSeries = "0.22.4"
 Test = "1.10"
 julia = "1.10"
 
-SafeTestsets = "0.1"
-SciMLTesting = "2.1"
 [extras]
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
 [targets]
 test = ["Test", "NonlinearSolve", "Enzyme", "InteractiveUtils", "NaNMath", "SafeTestsets", "SciMLTesting"]

--- a/lib/NonlinearSolveHomotopyContinuation/src/NonlinearSolveHomotopyContinuation.jl
+++ b/lib/NonlinearSolveHomotopyContinuation/src/NonlinearSolveHomotopyContinuation.jl
@@ -7,6 +7,7 @@ using SymbolicIndexingInterface: SymbolicIndexingInterface, parameter_values,
 using LinearAlgebra: LinearAlgebra, norm
 using ADTypes: ADTypes, AutoEnzyme, AutoFiniteDiff, AutoForwardDiff
 using TaylorDiff: TaylorDiff, TaylorScalar
+import TaylorSeries as TS
 using DocStringExtensions: DocStringExtensions, FIELDS, TYPEDEF, TYPEDFIELDS,
     TYPEDSIGNATURES
 import CommonSolve
@@ -15,7 +16,7 @@ import DifferentiationInterface as DI
 
 using ConcreteStructs: @concrete
 
-export HomotopyContinuationJL, HomotopyNonlinearFunction
+export HomotopyContinuationJL, TaylorHomotopyContinuationJL, HomotopyNonlinearFunction
 
 """
     HomotopyContinuationJL{AllRoots}(; autodiff = true, kwargs...)
@@ -68,5 +69,6 @@ end
 include("interface_types.jl")
 include("jacobian_handling.jl")
 include("solve.jl")
+include("taylor_polynomialize.jl")
 
 end

--- a/lib/NonlinearSolveHomotopyContinuation/src/taylor_polynomialize.jl
+++ b/lib/NonlinearSolveHomotopyContinuation/src/taylor_polynomialize.jl
@@ -1,0 +1,394 @@
+"""
+    TaylorHomotopyContinuationJL{AllRoots}(; degree = 3, autodiff = true, kwargs...)
+    TaylorHomotopyContinuationJL(; kwargs...) = TaylorHomotopyContinuationJL{false}(; kwargs...)
+
+A solver for general (non-polynomial) nonlinear systems built on top of
+HomotopyContinuation.jl. The system is approximated by its multivariate Taylor
+polynomial of total degree `degree` around the initial guess, all roots of the
+polynomial surrogate are found via homotopy continuation, and every (near-)real
+root is used as an initial guess for a Newton iteration on the original system.
+Newton iterates that converge are reported as roots.
+
+Unlike [`HomotopyContinuationJL`](@ref) this does not require the system to be
+polynomial. The system function must accept `TaylorSeries.jl` jet types as state
+(the same operator-overloading requirement as ForwardDiff.jl duals). If the system
+*is* polynomial of total degree at most `degree`, the surrogate is exact and all
+roots of the system are found.
+
+The `AllRoots` type parameter can be `true` or `false`. If `true`, an
+`EnsembleSolution` of all distinct roots found is returned and the initial guess
+only serves as the expansion point. If `false`, the single converged root closest
+to the initial guess is returned.
+
+The number of homotopy paths grows like `degree^n` where `n` is the number of
+unknowns, which restricts this method to small-to-medium systems (roughly
+`n ≤ 12` at `degree = 2`, `n ≤ 8` at `degree = 3`).
+
+# Keyword arguments
+
+  - `degree`: the total degree of the Taylor approximation. Higher degrees give more
+    faithful surrogates (and find more roots of transcendental systems) at the cost of
+    `degree^n` path growth.
+  - `autodiff`: the autodiff algorithm used for the Newton polish. `true` maps to
+    `AutoForwardDiff()`, `false` to `AutoFiniteDiff()`; any ADTypes.jl algorithm is
+    accepted. If the `NonlinearFunction` provides a jacobian it is used directly.
+
+All other keyword arguments are forwarded to `HomotopyContinuation.solve`.
+"""
+@concrete struct TaylorHomotopyContinuationJL{AllRoots} <:
+    NonlinearSolveBase.AbstractNonlinearSolveAlgorithm
+    degree::Int
+    autodiff
+    kwargs
+end
+
+function TaylorHomotopyContinuationJL{AllRoots}(;
+        degree = 3, autodiff = true, kwargs...
+    ) where {AllRoots}
+    degree >= 1 || throw(ArgumentError("`degree` must be at least 1"))
+    if autodiff isa Bool
+        autodiff = autodiff ? AutoForwardDiff() : AutoFiniteDiff()
+    end
+    return TaylorHomotopyContinuationJL{AllRoots}(degree, autodiff, kwargs)
+end
+
+TaylorHomotopyContinuationJL(; kwargs...) = TaylorHomotopyContinuationJL{false}(; kwargs...)
+
+function TaylorHomotopyContinuationJL(
+        alg::TaylorHomotopyContinuationJL{R}; kwargs...
+    ) where {R}
+    return TaylorHomotopyContinuationJL{R}(;
+        degree = alg.degree, autodiff = alg.autodiff, alg.kwargs..., kwargs...
+    )
+end
+
+# `TS.variables!` rebuilds the entire jet space, including multiplication
+# tables, on every call. Cache the jet variables per (numvars, order); TaylorN
+# arithmetic uses the space carried by the operands so reuse is safe.
+const TAYLOR_VAR_CACHE = Dict{Tuple{Int, Int}, Vector{TS.TaylorN{Float64}}}()
+const TAYLOR_VAR_LOCK = ReentrantLock()
+
+function taylor_jet_variables(n::Int, degree::Int)
+    return lock(TAYLOR_VAR_LOCK) do
+        get!(TAYLOR_VAR_CACHE, (n, degree)) do
+            TS.variables!("Δ", numvars = n, order = degree, nowarn = true)
+        end
+    end
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Convert a `TaylorSeries.TaylorN` polynomial (in the deviation from the expansion
+point) into a `HomotopyContinuation.ModelKit.Expression` in `vars`. Returns the
+expression and the actual total degree of the polynomial.
+"""
+function taylorn_to_expression(poly::TS.TaylorN, vars)
+    ex = HC.ModelKit.Expression(0)
+    deg = 0
+    for (kp1, homog) in enumerate(poly.coeffs)
+        exponents = poly.space.coeff_table[kp1]
+        for (i, c) in enumerate(homog.coeffs)
+            iszero(c) && continue
+            deg = max(deg, kp1 - 1)
+            mono = HC.ModelKit.Expression(1)
+            for (j, e) in enumerate(exponents[i])
+                e > 0 && (mono *= vars[j]^e)
+            end
+            ex += c * mono
+        end
+    end
+    return ex, deg
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Build the polynomial surrogate system for `f` (of the given
+`HomotopySystemVariant`) around expansion point `u0` by evaluating `f` on
+TaylorSeries.jl jets. Returns `(system, bezout)` where `system` is an
+`HC.ModelKit.System` in the deviation variables and `bezout` is the Bezout
+number of the truncation (product of actual total degrees).
+"""
+function taylor_surrogate_system(f::F, variant, u0, p, degree) where {F}
+    if variant == Scalar
+        t = TS.Taylor1(Float64, degree)
+        fT = f(u0 + t, p)
+        var = HC.ModelKit.Variable(:Δx)
+        coeffs = fT isa TS.Taylor1 ? fT.coeffs : vcat(fT, zeros(degree))
+        ex = sum(coeffs[k + 1] * var^k for k in 0:(length(coeffs) - 1))
+        actual_degree = something(findlast(!iszero, coeffs), 2) - 1
+        sys = HC.ModelKit.System([ex], variables = [var])
+        return sys, max(actual_degree, 1)
+    end
+
+    n = length(u0)
+    d = taylor_jet_variables(n, degree)
+    uT = u0 .+ d
+    fT = if variant == Inplace
+        buffer = [zero(first(d)) for _ in 1:n]
+        f(buffer, uT, p)
+        buffer
+    else
+        f(uT, p)
+    end
+    length(fT) == n || throw(
+        ArgumentError(
+            "`TaylorHomotopyContinuationJL` only supports fully determined systems; " *
+                "got $(length(fT)) equations in $n unknowns."
+        )
+    )
+    vars = HC.variables(:Δx, 1:n)
+    exprs = Vector{HC.ModelKit.Expression}(undef, n)
+    bezout = 1
+    for i in 1:n
+        exprs[i], deg_i = taylorn_to_expression(fT[i], vars)
+        bezout *= max(deg_i, 1)
+    end
+    sys = HC.ModelKit.System(exprs, variables = collect(vars))
+    return sys, bezout
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Solve the polynomial surrogate with HomotopyContinuation.jl and return all finite
+path endpoints as real candidate vectors (in deviation coordinates). Near-real
+endpoints come first; real parts of genuinely complex endpoints are appended as
+lower-quality candidates. Endpoints are deduplicated.
+
+`compile = false` is used because every call builds a system with fresh numeric
+coefficients, so compiled straight-line programs can never be reused; interpreted
+tracking avoids paying seconds of compilation per solve. Threading is only enabled
+when the number of paths is large enough to amortize task-scheduling overhead.
+Dense Taylor truncations gain nothing from polyhedral start systems (the mixed
+volume equals the Bezout number), so the cheaper total-degree start system is used
+unless the path count is large.
+"""
+function solve_taylor_surrogate(sys, bezout; real_tol = 1.0e-6, kwargs...)
+    start_system = bezout <= 200 ? :total_degree : :polyhedral
+    threading = bezout > 4 * Threads.nthreads()
+    result = HC.solve(
+        sys; show_progress = false, compile = false, threading, start_system, kwargs...
+    )
+    endpoints = [HC.solution(pr) for pr in HC.path_results(result)]
+    filter!(endpoints) do s
+        all(z -> isfinite(real(z)) && isfinite(imag(z)), s) && maximum(abs, s) < 1.0e10
+    end
+    isrealsol(s) = maximum(abs ∘ imag, s; init = 0.0) < real_tol * (1 + maximum(abs, s))
+    candidates = [real.(s) for s in endpoints if isrealsol(s)]
+    append!(candidates, [real.(s) for s in endpoints if !isrealsol(s)])
+    deduped = Vector{Vector{Float64}}()
+    for c in candidates
+        if all(d -> maximum(abs, d - c) > 1.0e-8 * (1 + maximum(abs, c)), deduped)
+            push!(deduped, c)
+        end
+    end
+    return deduped, result
+end
+
+# Real-arithmetic residual+jacobian wrappers for the Newton polish, mirroring
+# the complex-valued machinery in jacobian_handling.jl.
+@concrete struct PolishFunction{variant <: HomotopySystemVariant}
+    f
+end
+
+function (pf::PolishFunction{OutOfPlace})(x::AbstractVector, p)
+    return pf.f(x, p)
+end
+function (pf::PolishFunction{Inplace})(u::AbstractVector, x::AbstractVector, p)
+    pf.f(u, x, p)
+    return u
+end
+function (pf::PolishFunction{Scalar})(u::AbstractVector, x::AbstractVector, p)
+    u[1] = pf.f(x[1], p)
+    return u
+end
+
+function construct_polish_jacobian(pf::PolishFunction{OutOfPlace}, autodiff, u0, p)
+    prep = DI.prepare_jacobian(pf, autodiff, u0, DI.Constant(p), strict = Val(false))
+    return (x, p) -> DI.value_and_jacobian(pf, prep, autodiff, x, DI.Constant(p))
+end
+function construct_polish_jacobian(
+        pf::PolishFunction{variant}, autodiff, u0, p
+    ) where {variant}
+    resid = Vector{Float64}(undef, length(u0))
+    prep = DI.prepare_jacobian(
+        pf, resid, autodiff, copy(u0), DI.Constant(p), strict = Val(false)
+    )
+    return function (x, p)
+        fu, J = DI.value_and_jacobian(pf, resid, prep, autodiff, x, DI.Constant(p))
+        return copy(fu), J
+    end
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Newton-polish the candidate `c` (a real vector in the coordinates of the original
+system) using `vjac = (x, p) -> (f(x), J(x))`. Success is judged by the achieved
+residual rather than step-size convergence: at singular roots Newton converges only
+linearly and would report failure despite an excellent iterate. Returns
+`(u, converged)`.
+"""
+function newton_polish(vjac::J, c, p, abstol, maxiters) where {J}
+    u = copy(c)
+    best_u = copy(c)
+    best_resid = Inf
+    for _ in 1:maxiters
+        fu, jac = vjac(u, p)
+        resid = maximum(abs, fu)
+        if resid < best_resid
+            best_resid = resid
+            copyto!(best_u, u)
+        end
+        resid <= abstol && break
+        step = try
+            LinearAlgebra.qr(jac, LinearAlgebra.ColumnNorm()) \ fu
+        catch
+            break
+        end
+        all(isfinite, step) || break
+        u .-= step
+    end
+    return best_u, best_resid <= sqrt(abstol)
+end
+
+function taylor_homotopy_preprocessing(
+        prob::NonlinearProblem, alg::TaylorHomotopyContinuationJL;
+        abstol, maxiters, kwargs...
+    )
+    f = if prob.f isa HomotopyNonlinearFunction
+        prob.f
+    else
+        HomotopyNonlinearFunction(prob.f)
+    end
+
+    u0 = state_values(prob)
+    p = parameter_values(prob)
+    isscalar = u0 isa Number
+    iip = SciMLBase.isinplace(prob)
+    variant = iip ? Inplace : isscalar ? Scalar : OutOfPlace
+
+    u0_p = f.polynomialize(u0, p)
+    expansion_point = isscalar ? u0_p : convert(Vector{Float64}, u0_p)
+
+    sys, bezout = taylor_surrogate_system(f.f.f, variant, u0_p, p, alg.degree)
+    candidates, orig_sol = solve_taylor_surrogate(sys, bezout; alg.kwargs..., kwargs...)
+
+    pf = PolishFunction{variant}(f.f.f)
+    polish_u0 = isscalar ? [expansion_point] : expansion_point
+    vjac = if SciMLBase.has_jac(f.f)
+        ExplicitPolishJacobian{variant}(pf, f.f.jac)
+    else
+        construct_polish_jacobian(pf, alg.autodiff, polish_u0, p)
+    end
+
+    roots = Vector{Vector{Float64}}()
+    for c in candidates
+        guess = polish_u0 .+ c
+        u, converged = newton_polish(vjac, guess, p, abstol, maxiters)
+        converged || continue
+        if all(r -> maximum(abs, r - u) > 1.0e-6 * (1 + maximum(abs, u)), roots)
+            push!(roots, u)
+        end
+    end
+
+    return f, roots, expansion_point, orig_sol
+end
+
+@concrete struct ExplicitPolishJacobian{variant}
+    pf
+    jac
+end
+
+function (f::ExplicitPolishJacobian{OutOfPlace})(x, p)
+    return f.pf(x, p), f.jac(x, p)
+end
+function (f::ExplicitPolishJacobian{Inplace})(x, p)
+    u = Vector{Float64}(undef, length(x))
+    J = Matrix{Float64}(undef, length(x), length(x))
+    f.pf(u, x, p)
+    f.jac(J, x, p)
+    return u, J
+end
+function (f::ExplicitPolishJacobian{Scalar})(x, p)
+    u = Vector{Float64}(undef, 1)
+    f.pf(u, x, p)
+    return u, fill(f.jac(x[1], p), 1, 1)
+end
+
+function unpolynomialize_roots(f, roots, p, denominator_abstol, isscalar)
+    validsols = isscalar ? Float64[] : Vector{Float64}[]
+    for u in roots
+        u_p = isscalar ? u[1] : u
+        if any(<=(denominator_abstol) ∘ abs, f.denominator(u_p, p))
+            continue
+        end
+        for sol in f.unpolynomialize(u_p, p)
+            any(isnan, sol) && continue
+            push!(validsols, sol)
+        end
+    end
+    return validsols
+end
+
+function CommonSolve.solve(
+        prob::NonlinearProblem, alg::TaylorHomotopyContinuationJL{true};
+        abstol = 1.0e-10, maxiters = 200, denominator_abstol = 1.0e-7, kwargs...
+    )
+    u0 = state_values(prob)
+    isscalar = u0 isa Number
+    f, roots, _, orig_sol = taylor_homotopy_preprocessing(
+        prob, alg; abstol, maxiters, kwargs...
+    )
+
+    validsols = unpolynomialize_roots(
+        f, roots, parameter_values(prob),
+        denominator_abstol, isscalar
+    )
+
+    if isempty(validsols)
+        retcode = SciMLBase.ReturnCode.ConvergenceFailure
+        resid = NonlinearSolveBase.Utils.evaluate_f(prob, u0)
+        nlsol = SciMLBase.build_solution(prob, alg, u0, resid; retcode, original = orig_sol)
+        return SciMLBase.EnsembleSolution([nlsol], 0.0, false, nothing)
+    end
+
+    retcode = SciMLBase.ReturnCode.Success
+    nlsols = map(validsols) do u
+        resid = NonlinearSolveBase.Utils.evaluate_f(prob, u)
+        return SciMLBase.build_solution(prob, alg, u, resid; retcode, original = orig_sol)
+    end
+    return SciMLBase.EnsembleSolution(nlsols, 0.0, true, nothing)
+end
+
+function CommonSolve.solve(
+        prob::NonlinearProblem, alg::TaylorHomotopyContinuationJL{false};
+        abstol = 1.0e-10, maxiters = 200, denominator_abstol = 1.0e-7, kwargs...
+    )
+    u0 = state_values(prob)
+    isscalar = u0 isa Number
+    f, roots, expansion_point, orig_sol = taylor_homotopy_preprocessing(
+        prob, alg; abstol, maxiters, kwargs...
+    )
+
+    validsols = unpolynomialize_roots(
+        f, roots, parameter_values(prob),
+        denominator_abstol, isscalar
+    )
+
+    if isempty(validsols)
+        retcode = SciMLBase.ReturnCode.ConvergenceFailure
+        resid = NonlinearSolveBase.Utils.evaluate_f(prob, u0)
+        return SciMLBase.build_solution(prob, alg, u0, resid; retcode, original = orig_sol)
+    end
+
+    _, idx = findmin(validsols) do sol
+        norm(sol .- u0)
+    end
+    u = validsols[idx]
+    resid = NonlinearSolveBase.Utils.evaluate_f(prob, u)
+    retcode = SciMLBase.ReturnCode.Success
+    return SciMLBase.build_solution(prob, alg, u, resid; retcode, original = orig_sol)
+end

--- a/lib/NonlinearSolveHomotopyContinuation/test/runtests.jl
+++ b/lib/NonlinearSolveHomotopyContinuation/test/runtests.jl
@@ -12,7 +12,8 @@ run_tests(;
     env = "NONLINEARSOLVE_TEST_GROUP",
     core = function ()
         @safetestset "AllRoots" include("allroots.jl")
-        return @safetestset "Single Root" include("single_root.jl")
+        @safetestset "Single Root" include("single_root.jl")
+        return @safetestset "Taylor Polynomialize" include("taylor_polynomialize.jl")
     end,
     # QA (Aqua/ExplicitImports via SciMLTesting.run_qa) is a dep-adding group: it runs
     # in its own isolated sub-env under test/qa (excluded from the base/Core/All run).

--- a/lib/NonlinearSolveHomotopyContinuation/test/taylor_polynomialize.jl
+++ b/lib/NonlinearSolveHomotopyContinuation/test/taylor_polynomialize.jl
@@ -1,0 +1,160 @@
+using NonlinearSolve
+using NonlinearSolveHomotopyContinuation
+using SciMLBase: NonlinearSolution
+using ADTypes
+using LinearAlgebra: norm
+
+allroots = TaylorHomotopyContinuationJL{true}(; threading = false)
+
+function sorted_roots(sol)
+    us = [s.u for s in sol.u]
+    return sort(us; by = u -> u isa Number ? u : u[1])
+end
+
+@testset "scalar transcendental" begin
+    # u = 2 sin(u): roots 0 and ±1.8954942670339809. The expansion point must
+    # be central enough for the truncation to cover all roots.
+    rhs = (u, p) -> u - p * sin(u)
+    prob = NonlinearProblem(rhs, 0.5, 2.0)
+
+    sol = solve(prob, TaylorHomotopyContinuationJL{true}(; degree = 9, threading = false))
+    @test sol isa EnsembleSolution
+    @test sol.converged
+    us = sorted_roots(sol)
+    @test length(us) == 3
+    if length(us) == 3
+        @test us[1] ≈ -1.8954942670339809 atol = 1.0e-8
+        @test us[2] ≈ 0.0 atol = 1.0e-8
+        @test us[3] ≈ 1.8954942670339809 atol = 1.0e-8
+    end
+    @test all(s -> abs(s.resid) < 1.0e-8, sol.u)
+
+    # single-root variant returns the root closest to the initial guess
+    prob = NonlinearProblem(rhs, 1.7, 2.0)
+    sol1 = solve(prob, TaylorHomotopyContinuationJL(; degree = 9, threading = false))
+    @test sol1 isa NonlinearSolution
+    @test SciMLBase.successful_retcode(sol1)
+    @test sol1.u ≈ 1.8954942670339809 atol = 1.0e-8
+end
+
+@testset "polynomial system is solved exactly" begin
+    # Himmelblau critical points: gradient system, degree 3, 9 real roots
+    rhs = function (u, p)
+        x, y = u
+        return [
+            4x * (x^2 + y - p[1]) + 2 * (x + y^2 - p[2]),
+            2 * (x^2 + y - p[1]) + 4y * (x + y^2 - p[2]),
+        ]
+    end
+    prob = NonlinearProblem(rhs, zeros(2), [11.0, 7.0])
+    sol = solve(prob, allroots)
+    @test sol.converged
+    @test length(sol.u) == 9
+    @test all(s -> norm(s.resid) < 1.0e-8, sol.u)
+    # the four Himmelblau minima are among the roots
+    for minimum_u in (
+            [3.0, 2.0], [-2.805118, 3.131313], [-3.77931, -3.283186],
+            [3.584428, -1.848127],
+        )
+        @test any(s -> isapprox(s.u, minimum_u; atol = 1.0e-5), sol.u)
+    end
+end
+
+@testset "transcendental system, out of place" begin
+    # from the HomotopyContinuation.jl docs; roots on the circle
+    # x^2 + y^2 = log(3) with x + y = sin(3(x+y))
+    rhs = function (u, p)
+        x, y = u
+        return [exp(x^2 + y^2) - p, x + y - sin(3 * (x + y))]
+    end
+    prob = NonlinearProblem(rhs, [0.5, -0.5], 3.0)
+    sol = solve(prob, TaylorHomotopyContinuationJL{true}(; degree = 6, threading = false))
+    @test sol.converged
+    @test length(sol.u) >= 2
+    @test all(s -> norm(s.resid) < 1.0e-8, sol.u)
+end
+
+@testset "transcendental system, in place" begin
+    # 1D Bratu with two solution branches
+    lam = 3.0
+    n = 4
+    rhs = function (du, u, p)
+        h = 1 / (length(u) + 1)
+        for i in eachindex(u)
+            um = i == 1 ? zero(eltype(u)) : u[i - 1]
+            up = i == length(u) ? zero(eltype(u)) : u[i + 1]
+            du[i] = (um - 2u[i] + up) / h^2 + p * exp(u[i])
+        end
+        return nothing
+    end
+    prob = NonlinearProblem(rhs, fill(0.5, n), lam)
+    sol = solve(prob, TaylorHomotopyContinuationJL{true}(; degree = 4, threading = false))
+    @test sol.converged
+    @test length(sol.u) == 2
+    @test all(s -> norm(s.resid) < 1.0e-8, sol.u)
+
+    # single root: returns one converged branch
+    sol1 = solve(prob, TaylorHomotopyContinuationJL(; degree = 4, threading = false))
+    @test sol1 isa NonlinearSolution
+    @test SciMLBase.successful_retcode(sol1)
+    @test norm(sol1.resid) < 1.0e-8
+end
+
+@testset "explicit jacobian is used" begin
+    rhs = (u, p) -> [u[1]^2 - p, u[1] + u[2]]
+    jac = (u, p) -> [2u[1] 0.0; 1.0 1.0]
+    fn = NonlinearFunction(rhs; jac)
+    prob = NonlinearProblem(fn, [1.0, -1.0], 4.0)
+    sol = solve(prob, TaylorHomotopyContinuationJL{true}(; degree = 2, threading = false))
+    @test sol.converged
+    us = sorted_roots(sol)
+    @test length(us) == 2
+    @test us[1] ≈ [-2.0, 2.0] atol = 1.0e-8
+    @test us[2] ≈ [2.0, -2.0] atol = 1.0e-8
+end
+
+@testset "no real roots" begin
+    rhs = (u, p) -> u^2 + p
+    prob = NonlinearProblem(rhs, 1.0, 4.0)
+    sol = solve(prob, TaylorHomotopyContinuationJL{true}(; degree = 2, threading = false))
+    @test sol isa EnsembleSolution
+    @test !sol.converged
+    @test sol.u[1].retcode == SciMLBase.ReturnCode.ConvergenceFailure
+
+    sol1 = solve(prob, TaylorHomotopyContinuationJL(; degree = 2, threading = false))
+    @test sol1.retcode == SciMLBase.ReturnCode.ConvergenceFailure
+end
+
+@testset "singular root" begin
+    # Powell singular: multiplicity-4 root at the origin; HC classifies the
+    # surrogate root as "excess" and Newton only converges linearly
+    rhs = function (u, p)
+        return [
+            u[1] + 10u[2],
+            sqrt(5) * (u[3] - u[4]),
+            (u[2] - 2u[3])^2,
+            sqrt(10) * (u[1] - u[4])^2,
+        ]
+    end
+    prob = NonlinearProblem(rhs, [3.0, -1.0, 0.0, 1.0], nothing)
+    sol = solve(prob, TaylorHomotopyContinuationJL{true}(; degree = 2, threading = false))
+    @test sol.converged
+    @test any(s -> norm(s.u) < 1.0e-4, sol.u)
+end
+
+@testset "unpolynomialize" begin
+    # roots of x^2 - 5x + 6 in transformed coordinates y = exp(x)
+    rhs = (u, p) -> u^2 - p[1] * u + p[2]
+    f = HomotopyNonlinearFunction(
+        NonlinearFunction(rhs);
+        polynomialize = (u, p) -> log(u),
+        unpolynomialize = (u, p) -> [exp(u)]
+    )
+    prob = NonlinearProblem(f, exp(1.9), [5.0, 6.0])
+    sol = solve(prob, TaylorHomotopyContinuationJL{true}(; degree = 2, threading = false))
+    @test sol.converged
+    us = sorted_roots(sol)
+    @test length(us) == 2
+    @test us[1] ≈ exp(2.0) atol = 1.0e-6
+    @test us[2] ≈ exp(3.0) atol = 1.0e-6
+end


### PR DESCRIPTION
> [!NOTE]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

Adds `TaylorHomotopyContinuationJL{AllRoots}` to NonlinearSolveHomotopyContinuation: a solver for **general (non-polynomial) nonlinear systems** that

1. Taylor-expands the system around the initial guess into a polynomial surrogate of total degree `degree` (default 3), via TaylorSeries.jl jet transport — works on any generic Julia function, same operator-overloading requirement as ForwardDiff duals;
2. finds **all** roots of the surrogate with HomotopyContinuation.jl (no initial-guess dependence);
3. polishes every (near-)real path endpoint with a Newton iteration on the **original** system, reporting the distinct converged roots.

If the system is polynomial of total degree ≤ `degree`, the surrogate is exact and all roots are found. `AllRoots = true` returns an `EnsembleSolution` of every root (mirroring `HomotopyContinuationJL{true}`); the default single-root form returns the converged root closest to the initial guess. Supports oop/iip/scalar problems, explicit jacobians, and `HomotopyNonlinearFunction` transformations.

This complements the existing algorithm: `HomotopyContinuationJL{true}` requires a genuinely polynomial (HC-traceable) system; this works on transcendental ones at the cost of approximation, with the Newton polish recovering exactness of the reported roots.

## Motivation / prototype results

Prototyped and benchmarked before this PR (details: https://github.com/ChrisRackauckas/InternalJunk/pull/69). On an 8-problem hard suite × 20 random starts (success = ‖f‖∞ < 1e-8): **100% success on every problem**, including Freudenstein–Roth where TrustRegion stalls at the classic local-min of ‖f‖ (8/20), exp–sin where plain Newton scores 11/20, Bratu n=6 (returns both solution branches; Newton 17/20), Powell singular (multiplicity-4 root), and Kearfott's badly-scaled problem. Median solve times after tuning: 3–50 ms for n ≤ 5, ~0.4 s for n = 6 with 729 paths. The `degree^n` path count limits the method to roughly n ≤ 12 at degree 2, n ≤ 8 at degree 3 (documented in the docstring).

## Implementation notes (perf/correctness findings baked in)

- **`compile = false` for the HC solve** — every call builds a `System` with fresh numeric coefficients, so HC's compiled straight-line programs never get cache hits; without this each solve costs ~3.5 s of codegen (700× slowdown at these sizes).
- **All finite path endpoints are harvested**, not just `HC.solutions()` — multiplicity-k roots (e.g. Powell singular) are classified as "excess" endpoints and dropped by the default accessors under every flag combination. As Newton guesses every finite endpoint is fair game; the polish filters junk.
- **Polish success is judged by achieved residual, not step convergence** — at singular roots Newton converges only linearly and would report MaxIters despite an excellent iterate.
- **Total-degree start system for small path counts** — dense Taylor truncations have mixed volume = Bézout number, so polyhedral mixed-cell computation is pure overhead (measured 47× on a trigexp system); polyhedral is used automatically above 200 paths.
- TaylorSeries jet spaces are cached per `(numvars, order)` behind a lock (`variables!` rebuilds multiplication tables on every call).

## Tests

New `test/taylor_polynomialize.jl` wired into the Core group: scalar transcendental (all 3 roots of u = 2sin(u) + closest-root variant), exact recovery of all 9 Himmelblau critical points, transcendental oop (exp–sin) and iip (Bratu, both branches), explicit-jacobian path, no-real-roots retcodes, multiplicity-4 singular root, and `HomotopyNonlinearFunction` polynomialize/unpolynomialize round-trip.

Ran locally with `Pkg.test()` on Julia 1.11:

```
Test Summary: | Pass  Total     Time
AllRoots      |  169    169  3m52.6s
Test Summary: | Pass  Total     Time
Single Root   |   50     50  1m47.4s
Test Summary:        | Pass  Total     Time
Taylor Polynomialize |   40     40  8m50.0s
     Testing NonlinearSolveHomotopyContinuation tests passed
```

Runic has been run on all changed files. Version bumped 0.1.10 → 0.1.11; TaylorSeries (0.22.4+) added as a dependency; docstring added to the docs API page in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYuTWSRDz6kE8Bn8vAKh57