### PR TITLE
Remove duplicate 'yuan2015recent' BibTeX entry breaking docs build

### DIFF
--- a/docs/src/refs.bib
+++ b/docs/src/refs.bib
@@ -137,16 +137,6 @@
   publisher = {Springer}
 }
 
-@article{yuan2015recent,
-  title     = {Recent advances in trust region algorithms},
-  author    = {Yuan, Ya-xiang},
-  journal   = {Mathematical Programming},
-  volume    = {151},
-  pages     = {249--281},
-  year      = {2015},
-  publisher = {Springer}
-}
-
 @article{ziani2008autoadaptative,
   title     = {An autoadaptative limited memory Broyden’s method to solve systems of nonlinear equations},
   author    = {Ziani, Mohammed and Guyomarc’h, Fr{\'e}d{\'e}ric},


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Problem

The "Documentation / Build and Deploy Documentation" CI job fails on master (and consequently on every PR) with:

```
ERROR: LoadError: Duplicate BibTeX entry key detected: 'yuan2015recent'
```

`docs/src/refs.bib` contained two byte-identical `@article{yuan2015recent, ...}` entries (lines 130-138 and 140-148).

## Bisect

The duplicate was introduced by 2a6f1a98ec8f2b87dd0ebd9de250e93116373d94 ("Update the FAQ and tutorials", 2024-01-11), which re-added the entry that 808512bd ("Clean up and standardize some of the docs") had already added. It only became fatal recently when the docs toolchain started treating duplicate keys as a hard error.

## Fix

Delete one of the two identical entries. The key stays cited from the `TrustRegion` docstrings in `lib/NonlinearSolveFirstOrder/src/trust_region.jl` (`[yuan2015recent](@citet)`), so one entry must remain. Verified there are no other duplicate keys in `refs.bib`.

## Local verification

Ran the full docs build locally (`julia +1.11 --project=docs docs/make.jl`) with this fix applied. Observed: the build no longer errors on the duplicate BibTeX key, loads the bibliography, and progresses through page building and doctests all the way to the linkcheck stage. It then terminated at linkcheck with a transient, environment-dependent failure unrelated to this change:

```
┌ Error: linkcheck 'https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/lmdif.c' status: 429.
ERROR: LoadError: `makedocs` encountered an error [:linkcheck] -- terminating build before rendering.
```

HTTP 429 is GitHub rate-limiting the sandbox's unauthenticated requests, not a broken link. A second confirmation build is currently running locally; I will comment its final outcome here when it completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
