### PR TITLE
Add reusable homotopy solver caches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.23.2"
+version = "4.24.0"
 authors = ["SciML"]
 
 [deps]
@@ -98,7 +98,7 @@ NLSolvers = "0.5"
 NLsolve = "4.5"
 NaNMath = "1"
 NonlinearProblemLibrary = "0.1.2"
-NonlinearSolveBase = "2.37"
+NonlinearSolveBase = "2.40"
 NonlinearSolveFirstOrder = "2"
 NonlinearSolveQuasiNewton = "1.12"
 NonlinearSolveSpectralMethods = "1.6"

--- a/docs/src/devdocs/algorithm_helpers.md
+++ b/docs/src/devdocs/algorithm_helpers.md
@@ -62,6 +62,7 @@ NonlinearSolveFirstOrder.GenericTrustRegionScheme
 ```@docs
 NonlinearSolveBase.callback_into_cache!
 NonlinearSolveBase.concrete_jac
+NonlinearSolveBase.solve_cache!
 NonlinearSolveBase.assert_extension_supported_termination_condition
 NonlinearSolveBase.construct_extension_function_wrapper
 NonlinearSolveBase.construct_extension_jac

--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.39.1"
+version = "2.40.0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.39.0"
+version = "2.39.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
+++ b/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
@@ -106,7 +106,10 @@ include("solve.jl")
 include("forward_diff.jl")
 
 # Unexported Public API
-@compat(public, (L2_NORM, Linf_NORM, NAN_CHECK, UNITLESS_ABS2, get_tolerance))
+@compat(
+    public,
+    (L2_NORM, Linf_NORM, NAN_CHECK, UNITLESS_ABS2, get_tolerance, solve_cache!)
+)
 
 @compat(public, (get_abstol, get_reltol))
 @compat(public, (AbstractNonlinearTerminationMode, AbstractSafeNonlinearTerminationMode))

--- a/lib/NonlinearSolveBase/src/arclength.jl
+++ b/lib/NonlinearSolveBase/src/arclength.jl
@@ -829,10 +829,10 @@ function CommonSolve.solve(
         # and discovers the winner) instead of re-failing the cheaper ladder members
         # on every warm-started step.
         reinit_retaining!(corr_cache, xpred)
-        last_sol = CommonSolve.solve!(corr_cache)
+        last_sol = _solve_without_solution!(corr_cache)
 
-        if SciMLBase.successful_retcode(last_sol)
-            xnew = last_sol.u
+        if _solve_result_successful(last_sol)
+            xnew = _solve_result_u(last_sol)
             # realized chord, built in the (currently free) secant scratch
             @. tscratch = xnew - xcur
             nchord = _theta_norm(tscratch, wu, wλ, n)
@@ -892,7 +892,8 @@ function CommonSolve.solve(
             # sweep — see `_effort_growth_factor`), giving the arclength driver an effort
             # signal alongside the purely geometric bend-angle test.
             if alg.adaptive
-                nit = last_sol.stats === nothing ? -1 : Int(last_sol.stats.nsteps)
+                result_stats = _solve_result_stats(last_sol)
+                nit = result_stats === nothing ? -1 : Int(result_stats.nsteps)
                 if _effort_wants_shrink(nit, budget)
                     ds / 2 >= min_ds && (ds = ds / 2)
                     streak = 0
@@ -913,7 +914,8 @@ function CommonSolve.solve(
         else
             return build_solution_less_specialize(
                 prob, alg, u, nothing;
-                retcode = last_sol.retcode, original = last_sol,
+                retcode = _solve_result_retcode(last_sol),
+                original = _solve_result_original(last_sol),
                 store_original = alg.store_original
             )
         end

--- a/lib/NonlinearSolveBase/src/forward_diff.jl
+++ b/lib/NonlinearSolveBase/src/forward_diff.jl
@@ -11,6 +11,9 @@ get_u(cache::NonlinearSolveForwardDiffCache) = get_u(cache.cache)
 get_fu(cache::NonlinearSolveForwardDiffCache) = get_fu(cache.cache)
 set_fu!(cache::NonlinearSolveForwardDiffCache, fu) = set_fu!(cache.cache, fu)
 SciMLBase.set_u!(cache::NonlinearSolveForwardDiffCache, u) = SciMLBase.set_u!(cache.cache, u)
+function _solve_without_solution!(cache::NonlinearSolveForwardDiffCache)
+    return CommonSolve.solve!(cache)
+end
 function NonlinearSolveBase.get_abstol(cache::NonlinearSolveForwardDiffCache)
     return NonlinearSolveBase.get_abstol(cache.cache)
 end

--- a/lib/NonlinearSolveBase/src/homotopy_sweep.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_sweep.jl
@@ -17,7 +17,14 @@ The inner solver is initialized once and re-driven each step through the
 `init`/`reinit!`/`solve!` cache interface, so the continuation loop reuses the inner
 solver's workspace (Jacobian buffers, linear-solver storage) instead of reconstructing
 the solver every step; the sweep's own per-step state lives in a fixed set of
-preallocated buffers. When the inner solver is a polyalgorithm (as the default is),
+preallocated buffers. The complete sweep also supports the standard
+`init`/`reinit!`/`solve!` interface: initialize once, optionally update `u0` and `p`
+with `reinit!`, and call `solve!` repeatedly to reuse both the continuation buffers
+and the inner nonlinear-solver cache across homotopy problems of the same type. Solver
+options such as `abstol` can also be updated when the option was supplied to `init`
+and its type is unchanged.
+
+When the inner solver is a polyalgorithm (as the default is),
 the warm-started tracking steps additionally arm best-subalgorithm retention on that
 cache (see [`NonlinearSolvePolyAlgorithm`](@ref)): each step resumes from the
 subalgorithm that produced the previous step's success instead of re-running the
@@ -134,8 +141,8 @@ Keyword arguments:
 When the sweep cannot reach the end of `λspan`, the returned solution carries a failure
 retcode: its `u` is the last converged iterate (at some ``λ`` short of `λspan[2]`, or
 `u0` itself if the initial `λspan[1]` anchor solve failed), while `resid` comes from the
-failed step (`nothing` on the `ReturnCode.Stalled` and `ReturnCode.MaxIters` paths,
-where no failed step is available).
+most recent inner solve. On the `ReturnCode.Stalled` and `ReturnCode.MaxIters` paths no
+new failed corrector is available, so the residual is from the last accepted point.
 
 This is the embedding-homotopy / continuation analogue used to robustly initialize
 systems whose target form is hard to solve cold; it is unrelated to the polynomial
@@ -259,6 +266,22 @@ mutable struct FixLambda{F, T}
     λ::T
 end
 (fl::FixLambda)(args...) = fl.f(args..., fl.λ)
+
+@concrete mutable struct HomotopySweepCache
+    prob <: SciMLBase.HomotopyProblem
+    alg
+    args <: Tuple
+    kwargs <: NamedTuple
+    fixλ <: FixLambda
+    inner_cache
+    u
+    u_prev
+    guess
+    virtual
+    budget::Int
+    cap_active::Bool
+    tol_active::Bool
+end
 
 # λ-fixing wrapper for the user's analytic Jacobian `jac(u, p, λ)` / `jac(J, u, p, λ)`,
 # exposing the standard 2/3-argument form to the inner solver. It reads λ from the
@@ -530,9 +553,100 @@ function CommonSolve.solve(
         prob::SciMLBase.HomotopyProblem,
         alg::Union{HomotopySweep, KantorovichHomotopy}, args...; kwargs...
     )
-    sol, _ = _homotopy_sweep_solve(prob, alg, args...; kwargs...)
-    return sol
+    return CommonSolve.solve!(SciMLBase.init(prob, alg, args...; kwargs...))
 end
+
+function _homotopy_sweep_init(
+        prob::SciMLBase.HomotopyProblem{uType, iip},
+        alg::Union{HomotopySweep, KantorovichHomotopy}, args...; kwargs...
+    ) where {uType, iip}
+    λ = float(first(prob.λspan))
+    budget, cap_active = _tracking_budget(alg.tracking_maxiters, prob.kwargs, kwargs)
+    track_abstol, tol_active = _tracking_tolerance(
+        alg.tracking_abstol, prob.kwargs, kwargs
+    )
+
+    u = copy(prob.u0)
+    u_prev = copy(u)
+    guess = copy(u)
+    virtual = Utils.safe_similar(u)
+    fixλ = FixLambda(prob.f, λ)
+    fλ = _sweep_nonlinear_function(Val(iip), prob.f, fixλ)
+    inner_prob = NonlinearProblem{iip}(fλ, guess, prob.p)
+    inner_cache = if cap_active && tol_active
+        init(
+            inner_prob, alg.inner, args...;
+            prob.kwargs..., kwargs..., maxiters = budget, abstol = track_abstol
+        )
+    elseif cap_active
+        init(
+            inner_prob, alg.inner, args...;
+            prob.kwargs..., kwargs..., maxiters = budget
+        )
+    elseif tol_active
+        init(
+            inner_prob, alg.inner, args...;
+            prob.kwargs..., kwargs..., abstol = track_abstol
+        )
+    else
+        init(inner_prob, alg.inner, args...; prob.kwargs..., kwargs...)
+    end
+
+    return HomotopySweepCache(
+        prob, alg, args, (; kwargs...), fixλ, inner_cache,
+        u, u_prev, guess, virtual, budget, cap_active, tol_active
+    )
+end
+
+function SciMLBase.init(
+        prob::SciMLBase.HomotopyProblem,
+        alg::Union{HomotopySweep, KantorovichHomotopy}, args...;
+        sensealg = nothing, u0 = nothing, p = nothing, kwargs...
+    )
+    _u0 = u0 === nothing ? prob.u0 : u0
+    _p = p === nothing ? prob.p : p
+    _prob = _u0 === prob.u0 && _p === prob.p ? prob : SciMLBase.remake(prob; u0 = _u0, p = _p)
+    return _homotopy_sweep_init(_prob, alg, args...; kwargs...)
+end
+
+function SciMLBase.reinit!(
+        cache::HomotopySweepCache, u0 = cache.prob.u0; p = cache.prob.p, kwargs...
+    )
+    if !isempty(kwargs)
+        merged_kwargs = merge(cache.kwargs, (; kwargs...))
+        typeof(merged_kwargs) === typeof(cache.kwargs) || throw(
+            ArgumentError(
+                "`reinit!` can update existing homotopy solver options without " *
+                    "changing their types; pass every option that will be updated to `init`."
+            )
+        )
+        cache.kwargs = merged_kwargs
+        cache.budget = first(
+            _tracking_budget(cache.alg.tracking_maxiters, cache.prob.kwargs, merged_kwargs)
+        )
+        guess = _sweep_warmstart!(cache.guess, u0)
+        SciMLBase.reinit!(cache.inner_cache, guess; p, kwargs...)
+    end
+    cache.prob = SciMLBase.remake(cache.prob; u0, p)
+    return cache
+end
+
+function CommonSolve.solve!(cache::HomotopySweepCache)
+    return _homotopy_sweep_solve!(cache, Val(false))
+end
+
+function _store_sweep_state!(cache::HomotopySweepCache, u, u_prev, guess, virtual)
+    cache.u = u
+    cache.u_prev = u_prev
+    cache.guess = guess
+    cache.virtual = virtual
+    return nothing
+end
+
+_sweep_original(result, ::Val{false}) = nothing
+_sweep_original(result, ::Val{true}) = _solve_result_original(result)
+_sweep_return(sol, λ, ::Val{false}) = sol
+_sweep_return(sol, λ, ::Val{true}) = (sol, λ)
 
 # Internal driver returning `(sol, λ_last)`. `λ_last` is the λ of the sweep's last
 # ACCEPTED point when the sweep fails past the anchor (so `sol.u` is a converged
@@ -544,6 +658,12 @@ function _homotopy_sweep_solve(
         prob::SciMLBase.HomotopyProblem{uType, iip},
         alg::Union{HomotopySweep, KantorovichHomotopy}, args...; kwargs...
     ) where {uType, iip}
+    return _homotopy_sweep_solve!(SciMLBase.init(prob, alg, args...; kwargs...), Val(true))
+end
+
+function _homotopy_sweep_solve!(sweep_cache::HomotopySweepCache, return_λ::Val)
+    (; prob, alg, args, kwargs, fixλ, inner_cache, budget, cap_active, tol_active) =
+        sweep_cache
     λ0, λ1 = prob.λspan
     λ = float(λ0)
     λT = typeof(λ)
@@ -554,49 +674,12 @@ function _homotopy_sweep_solve(
     max_dλ = λT(alg.max_step_factor) * span     # carries span's sign, like dλ
     expand_factor = alg isa HomotopySweep ? λT(alg.expand_factor) : one(λT)
     abs(dλ) > abs(max_dλ) && (dλ = max_dλ)
-    u = copy(prob.u0)
-    budget, cap_active = _tracking_budget(alg.tracking_maxiters, prob.kwargs, kwargs)
-    track_abstol, tol_active = _tracking_tolerance(
-        alg.tracking_abstol, prob.kwargs, kwargs
-    )
-
-    # One inner-solver cache, built once around the mutable `FixLambda` and reused for
-    # every solve of the sweep (the anchor below and each continuation step): advancing
-    # λ is a field write plus a `reinit!` with the new warm start, so the inner solver's
-    # workspace is reused instead of reconstructed. `guess` is handed to the cache and
-    # may be iterated in place when aliasing is forwarded; `u` is a separately-owned
-    # buffer the inner solver never writes, so a FAILED attempt leaves the last
-    # converged iterate intact for retries and the failure returns below. When the
-    # tracking cap / loose tracking tolerance are active they are baked into this
-    # cache (the many interior steps all run capped/loose; `abstol` cannot reliably be
-    # changed through `reinit!` — e.g. the default polyalgorithm's cache `reinit!`
-    # accepts no tolerance kwargs); the anchor and the final landing are exempted
-    # through the `_sweep_exempt_solve` calls below rather than a second full-fidelity
-    # cache, so the happy path keeps a single inner workspace.
-    fixλ = FixLambda(prob.f, λ)
-    fλ = _sweep_nonlinear_function(Val(iip), prob.f, fixλ)
-    guess = copy(u)
-    cache = if cap_active && tol_active
-        init(
-            NonlinearProblem{iip}(fλ, guess, prob.p), alg.inner, args...;
-            prob.kwargs..., kwargs..., maxiters = budget, abstol = track_abstol
-        )
-    elseif cap_active
-        init(
-            NonlinearProblem{iip}(fλ, guess, prob.p), alg.inner, args...;
-            prob.kwargs..., kwargs..., maxiters = budget
-        )
-    elseif tol_active
-        init(
-            NonlinearProblem{iip}(fλ, guess, prob.p), alg.inner, args...;
-            prob.kwargs..., kwargs..., abstol = track_abstol
-        )
-    else
-        init(
-            NonlinearProblem{iip}(fλ, guess, prob.p), alg.inner, args...;
-            prob.kwargs..., kwargs...
-        )
-    end
+    u = _sweep_warmstart!(sweep_cache.u, prob.u0)
+    u_prev = _sweep_warmstart!(sweep_cache.u_prev, prob.u0)
+    guess = _sweep_warmstart!(sweep_cache.guess, prob.u0)
+    virtual = sweep_cache.virtual
+    fixλ.λ = λ
+    SciMLBase.reinit!(inner_cache, guess; p = prob.p)
 
     # Anchor: solve the system at λ = λspan[1] from u0 BEFORE stepping. For the
     # canonical (0, 1) span this is the pure `simplified` system — the one the
@@ -612,37 +695,43 @@ function _homotopy_sweep_solve(
         # also covers the tracking-cap exemption). A one-time cost when opting in.
         _sweep_exempt_solve(prob, alg.inner, u, λ, args...; kwargs...)
     else
-        CommonSolve.solve!(cache)
+        _solve_without_solution!(inner_cache)
     end
-    if cap_active && !tol_active && !SciMLBase.successful_retcode(last_sol)
+    if cap_active && !tol_active && !_solve_result_successful(last_sol)
         # The anchor is exempt from the tracking cap — it is the one cold-start solve
         # the homotopy contract is designed around, so it may legitimately need many
         # more iterations than a warm-started tracking step. Rerun it with the full
         # user budget before declaring the homotopy premise broken.
         last_sol = _sweep_exempt_solve(prob, alg.inner, u, λ, args...; kwargs...)
     end
-    if !SciMLBase.successful_retcode(last_sol)
+    if !_solve_result_successful(last_sol)
         # the λ = λspan[1] system itself failed from u0: the homotopy premise is
         # broken, so no continuation is possible. `u` stays u0. No accepted point
         # exists, so there is nothing to hand off.
-        return build_solution_less_specialize(
-                prob, alg, u, last_sol.resid;
-                retcode = last_sol.retcode, original = last_sol,
-                store_original = alg.store_original
-            ), nothing
+        _store_sweep_state!(sweep_cache, u, u_prev, guess, virtual)
+        sol = build_solution_less_specialize(
+            prob, alg, u, _solve_result_resid(last_sol);
+            retcode = _solve_result_retcode(last_sol),
+            original = _sweep_original(last_sol, alg.store_original),
+            store_original = alg.store_original
+        )
+        return _sweep_return(sol, nothing, return_λ)
     end
-    u = copy(last_sol.u)
+    u = _sweep_warmstart!(u, _solve_result_u(last_sol))
     # Zero-width λspan (λ0 == λend): the anchor IS the single target solve.
-    λ == λend && return SciMLBase.build_solution(
-            prob, alg, u, last_sol.resid; retcode = ReturnCode.Success
-        ), nothing
+    if λ == λend
+        _store_sweep_state!(sweep_cache, u, u_prev, guess, virtual)
+        sol = SciMLBase.build_solution(
+            prob, alg, u, _solve_result_resid(last_sol); retcode = ReturnCode.Success
+        )
+        return _sweep_return(sol, nothing, return_λ)
+    end
 
     # Reused across every step: `u`/`u_prev` are the last two accepted iterates (their
     # buffers are swapped, never reallocated); `virtual` is scratch for the secant
     # quality gate. λ_prev == λ means there is no history yet and the predictor falls
     # back to a constant warm start.
-    u_prev = copy(u)
-    virtual = Utils.safe_similar(u)
+    u_prev = _sweep_warmstart!(u_prev, u)
     λ_prev = λ
     streak = 0
     # Consecutive accepted steps whose measured secant quality was good. The secant is
@@ -659,17 +748,23 @@ function _homotopy_sweep_solve(
             # Cap on total attempts (accepted steps plus bisection retries), mirroring
             # ArcLengthContinuation's guard: without it the loop is bounded only by
             # span/min_dλ ≈ 7×10⁷ accepted steps.
-            return SciMLBase.build_solution(
-                    prob, alg, u, nothing; retcode = ReturnCode.MaxIters
-                ), λ
+            _store_sweep_state!(sweep_cache, u, u_prev, guess, virtual)
+            sol = SciMLBase.build_solution(
+                prob, alg, u, _solve_result_resid(last_sol);
+                retcode = ReturnCode.MaxIters
+            )
+            return _sweep_return(sol, λ, return_λ)
         end
         next_λ = abs(λend - λ) <= abs(dλ) ? λend : λ + dλ
         if next_λ == λ && next_λ != λend
             # dλ underflowed below eps(λ) mid-continuation: no further progress is
             # possible (the zero-width span is already handled by the anchor above).
-            return SciMLBase.build_solution(
-                    prob, alg, u, nothing; retcode = ReturnCode.Stalled
-                ), λ
+            _store_sweep_state!(sweep_cache, u, u_prev, guess, virtual)
+            sol = SciMLBase.build_solution(
+                prob, alg, u, _solve_result_resid(last_sol);
+                retcode = ReturnCode.Stalled
+            )
+            return _sweep_return(sol, λ, return_λ)
         end
         used_secant = alg.predictor === :secant && trust >= 2 && λ_prev != λ
         guess = if used_secant
@@ -684,9 +779,9 @@ function _homotopy_sweep_solve(
         # Retaining reinit!: a polyalgorithm inner resumes from the subalgorithm that
         # won the previous solve (the anchor's full-ladder run discovers the winner)
         # instead of re-failing the cheaper ladder members on every warm-started step.
-        reinit_retaining!(cache, guess)
+        reinit_retaining!(inner_cache, guess, prob.p)
         last_sol, first_Θ, rejected_Θ, has_Θ, contraction_rejected =
-            _homotopy_corrector!(cache, alg, λT)
+            _homotopy_corrector!(inner_cache, alg, λT)
 
         if next_λ == λend
             if cap_active && !_solve_result_successful(last_sol)
@@ -777,18 +872,22 @@ function _homotopy_sweep_solve(
                 # on failure: u is the last converged iterate (λ<λ1); resid is from the failed step (advisory)
                 retcode = strict_rejection ? ReturnCode.ConvergenceFailure :
                     _solve_result_retcode(last_sol)
-                return build_solution_less_specialize(
-                        prob, alg, u, _solve_result_resid(last_sol);
-                        retcode, original = _solve_result_original(last_sol),
-                        store_original = alg.store_original
-                    ), λ
+                _store_sweep_state!(sweep_cache, u, u_prev, guess, virtual)
+                sol = build_solution_less_specialize(
+                    prob, alg, u, _solve_result_resid(last_sol);
+                    retcode, original = _sweep_original(last_sol, alg.store_original),
+                    store_original = alg.store_original
+                )
+                return _sweep_return(sol, λ, return_λ)
             end
         end
     end
 
-    return SciMLBase.build_solution(
-            prob, alg, u, _solve_result_resid(last_sol); retcode = ReturnCode.Success
-        ), nothing
+    _store_sweep_state!(sweep_cache, u, u_prev, guess, virtual)
+    sol = SciMLBase.build_solution(
+        prob, alg, u, _solve_result_resid(last_sol); retcode = ReturnCode.Success
+    )
+    return _sweep_return(sol, nothing, return_λ)
 end
 
 # A HomotopyProblem with no algorithm defaults to the staged polyalgorithm (sweep first,

--- a/lib/NonlinearSolveBase/src/homotopy_sweep.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_sweep.jl
@@ -381,14 +381,14 @@ function _effort_wants_shrink(nit::Int, budget::Int)
 end
 
 function _homotopy_corrector!(cache, ::HomotopySweep, ::Type{T}) where {T}
-    sol = CommonSolve.solve!(cache)
+    sol = _solve_without_solution!(cache)
     return sol, zero(T), zero(T), false, false
 end
 
 function _homotopy_corrector!(
         cache::NonlinearSolvePolyAlgorithmCache, ::KantorovichHomotopy, ::Type{T}
     ) where {T}
-    sol = CommonSolve.solve!(cache)
+    sol = _solve_without_solution!(cache)
     return sol, zero(T), zero(T), false, false
 end
 
@@ -423,7 +423,7 @@ function _homotopy_corrector!(
         residualnormprev = residualnorm
     end
 
-    sol = CommonSolve.solve!(cache)
+    sol = _solve_without_solution!(cache)
     return sol, first_Θ, rejected_Θ, has_Θ, contraction_rejected
 end
 
@@ -689,7 +689,7 @@ function _homotopy_sweep_solve(
             _homotopy_corrector!(cache, alg, λT)
 
         if next_λ == λend
-            if cap_active && !SciMLBase.successful_retcode(last_sol)
+            if cap_active && !_solve_result_successful(last_sol)
                 # The final landing on λspan[2] is exempt from the tracking cap: give
                 # it the full user budget before letting the failure feed the
                 # bisection logic. The prediction is recomputed (never reuse `guess`:
@@ -708,19 +708,19 @@ function _homotopy_sweep_solve(
                 rejected_Θ = zero(λT)
                 has_Θ = false
                 contraction_rejected = false
-            elseif tol_active && SciMLBase.successful_retcode(last_sol)
+            elseif tol_active && _solve_result_successful(last_sol)
                 # The landing is exempt from the loose tracking tolerance: the loose
                 # cache solve above did the bulk of the convergence, now re-polish at
                 # the user's full tolerances warm-started from it (~1–2 corrector
                 # iterations), so the returned solution's accuracy semantics are
                 # unchanged. A failed polish feeds the ordinary bisection logic.
                 last_sol = _sweep_exempt_solve(
-                    prob, alg.inner, last_sol.u, next_λ, args...; kwargs...
+                    prob, alg.inner, _solve_result_u(last_sol), next_λ, args...; kwargs...
                 )
             end
         end
 
-        inner_success = SciMLBase.successful_retcode(last_sol)
+        inner_success = _solve_result_successful(last_sol)
         strict_rejection = _strict_contraction_rejection(alg, contraction_rejected)
         if inner_success && !strict_rejection
             # The secant prediction error θ (relative to the recent solution movement)
@@ -738,23 +738,25 @@ function _homotopy_sweep_solve(
                 # have iterated in place in the guess buffer when aliasing is forwarded
                 sv = (next_λ - λ) / (λ - λ_prev)
                 virtual = _sweep_extrapolate!(virtual, u, u_prev, sv)
-                correction = Utils.norm_op(L2_NORM, -, last_sol.u, virtual)
-                disp = Utils.norm_op(L2_NORM, -, last_sol.u, u)
-                scale = max(disp, disp_prev, sqrt(eps(λT)) * (1 + L2_NORM(last_sol.u)))
+                result_u = _solve_result_u(last_sol)
+                correction = Utils.norm_op(L2_NORM, -, result_u, virtual)
+                disp = Utils.norm_op(L2_NORM, -, result_u, u)
+                scale = max(disp, disp_prev, sqrt(eps(λT)) * (1 + L2_NORM(result_u)))
                 θ = correction / scale
                 # the secant only earns its keep when it predicts at least twice as
                 # well as the trivial constant prediction (whose θ is exactly 1)
                 trust = θ < 1 / 2 ? trust + 1 : 0
                 disp_prev = disp
             else
-                disp_prev = Utils.norm_op(L2_NORM, -, last_sol.u, u)
+                disp_prev = Utils.norm_op(L2_NORM, -, _solve_result_u(last_sol), u)
             end
             # accept: swap `u`↔`u_prev` and copy the solution into `u` (no allocation).
-            u, u_prev = _sweep_accept!(u, u_prev, last_sol.u)
+            u, u_prev = _sweep_accept!(u, u_prev, _solve_result_u(last_sol))
             λ_prev = λ
             λ = next_λ
             λ == λend && break
-            nit = last_sol.stats === nothing ? -1 : Int(last_sol.stats.nsteps)
+            result_stats = _solve_result_stats(last_sol)
+            nit = result_stats === nothing ? -1 : Int(result_stats.nsteps)
             dλ, streak = _accepted_step_size(
                 alg, dλ, streak, θ, nit, budget, min_dλ, max_dλ,
                 expand_factor, λT, first_Θ, has_Θ
@@ -773,10 +775,11 @@ function _homotopy_sweep_solve(
                 trust = 0
             else
                 # on failure: u is the last converged iterate (λ<λ1); resid is from the failed step (advisory)
-                retcode = strict_rejection ? ReturnCode.ConvergenceFailure : last_sol.retcode
+                retcode = strict_rejection ? ReturnCode.ConvergenceFailure :
+                    _solve_result_retcode(last_sol)
                 return build_solution_less_specialize(
-                        prob, alg, u, last_sol.resid;
-                        retcode, original = last_sol,
+                        prob, alg, u, _solve_result_resid(last_sol);
+                        retcode, original = _solve_result_original(last_sol),
                         store_original = alg.store_original
                     ), λ
             end
@@ -784,7 +787,7 @@ function _homotopy_sweep_solve(
     end
 
     return SciMLBase.build_solution(
-            prob, alg, u, last_sol.resid; retcode = ReturnCode.Success
+            prob, alg, u, _solve_result_resid(last_sol); retcode = ReturnCode.Success
         ), nothing
 end
 

--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -125,7 +125,8 @@ function construct_jacobian_cache(
         end
     end
 
-    return JacobianCache(J, f, fu, p, stats, autodiff, di_extras)
+    J_destination = jacobian_destination(J, autodiff)
+    return JacobianCache(J, J_destination, f, fu, p, stats, autodiff, di_extras)
 end
 
 function construct_jacobian_cache(
@@ -134,7 +135,7 @@ function construct_jacobian_cache(
         linsolve = missing
     )
     if SciMLBase.has_jac(f) || SciMLBase.has_vjp(f) || SciMLBase.has_jvp(f)
-        return JacobianCache(fu, f, fu, p, stats, autodiff, nothing)
+        return JacobianCache(fu, fu, f, fu, p, stats, autodiff, nothing)
     end
     if autodiff === nothing
         throw(ArgumentError("`autodiff` argument to `construct_jacobian_cache` must be \
@@ -145,11 +146,33 @@ function construct_jacobian_cache(
     @assert !(autodiff isa AutoSparse) "`autodiff` cannot be `AutoSparse` for scalar \
                                         nonlinear problems."
     di_extras = DI.prepare_derivative(f, autodiff, u, Constant(prob.p))
-    return JacobianCache(u, f, fu, p, stats, autodiff, di_extras)
+    return JacobianCache(u, u, f, fu, p, stats, autodiff, di_extras)
 end
+
+struct FixedShapeJacobianDestination{T, A <: Matrix{T}} <: AbstractMatrix{T}
+    parent::A
+end
+
+Base.size(destination::FixedShapeJacobianDestination) = size(destination.parent)
+Base.axes(destination::FixedShapeJacobianDestination) = axes(destination.parent)
+Base.IndexStyle(::Type{<:FixedShapeJacobianDestination}) = IndexLinear()
+@inline Base.getindex(destination::FixedShapeJacobianDestination, indices...) =
+    getindex(destination.parent, indices...)
+@inline Base.setindex!(destination::FixedShapeJacobianDestination, value, indices...) =
+    setindex!(destination.parent, value, indices...)
+function Base.reshape(destination::FixedShapeJacobianDestination, dims::Dims)
+    size(destination) == dims || throw(DimensionMismatch("cannot reshape Jacobian destination"))
+    return destination
+end
+Base.reshape(destination::FixedShapeJacobianDestination, dims::Int...) =
+    reshape(destination, dims)
+
+jacobian_destination(J::Matrix, ::AutoForwardDiff) = FixedShapeJacobianDestination(J)
+jacobian_destination(J, autodiff) = J
 
 @concrete mutable struct JacobianCache <: AbstractJacobianCache
     J
+    J_destination
     f <: NonlinearFunction
     fu
     p
@@ -218,12 +241,9 @@ function (cache::JacobianCache)(u)
         if SciMLBase.has_jac(f)
             f.jac(J, u, p)
         else
-            # ForwardDiff reshapes its destination internally. A full view preserves the
-            # matrix storage while letting Julia eliminate the temporary reshape wrapper.
-            J_dest = J isa Matrix && cache.autodiff isa AutoForwardDiff ?
-                view(J, axes(J)...) : J
             DI.jacobian!(
-                f, cache.fu, J_dest, cache.di_extras, cache.autodiff, u, Constant(p)
+                f, cache.fu, cache.J_destination, cache.di_extras, cache.autodiff, u,
+                Constant(p)
             )
         end
         return J

--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -218,8 +218,12 @@ function (cache::JacobianCache)(u)
         if SciMLBase.has_jac(f)
             f.jac(J, u, p)
         else
+            # ForwardDiff reshapes its destination internally. A full view preserves the
+            # matrix storage while letting Julia eliminate the temporary reshape wrapper.
+            J_dest = J isa Matrix && cache.autodiff isa AutoForwardDiff ?
+                view(J, axes(J)...) : J
             DI.jacobian!(
-                f, cache.fu, J, cache.di_extras, cache.autodiff, u, Constant(p)
+                f, cache.fu, J_dest, cache.di_extras, cache.autodiff, u, Constant(p)
             )
         end
         return J

--- a/lib/NonlinearSolveBase/src/polyalg.jl
+++ b/lib/NonlinearSolveBase/src/polyalg.jl
@@ -60,7 +60,8 @@ residual cost from one evaluation per subalgorithm to one per subalgorithm actua
 attempted (usually just the retained one). A consequence is that the shared `stats`
 of a solution produced after mid-solve escalation only reflect the subalgorithms run
 since the last deferred reinitialization, i.e. effectively the winning subalgorithm's
-own effort.
+own effort. Updating solver options in the same `reinit!` eagerly updates every
+subcache so that later escalation observes the new values.
 """
 @concrete struct NonlinearSolvePolyAlgorithm <: AbstractNonlinearSolveAlgorithm
     static_length <: Val
@@ -175,7 +176,7 @@ const RETAIN_REPROBE_INTERVAL = 8
 
 function InternalAPI.reinit!(
         cache::NonlinearSolvePolyAlgorithmCache, args...; p = cache.prob.p, u0 = cache.u0,
-        retain_best::Bool = false
+        retain_best::Bool = false, kwargs...
     )
     cache.retain_best = retain_best
     cache.retain_count = retain_best ? cache.retain_count + 1 : 0
@@ -186,19 +187,21 @@ function InternalAPI.reinit!(
     cache.start_current = cache.current
     cache.wrapped = false
     if retain_best
+        cache.deferred_u0 = u0
+        cache.deferred_p = p
+    end
+    if retain_best && isempty(kwargs)
         # Lazy subcache reinitialization: every subcache `reinit!` evaluates the
         # residual at the new `u0` (`Utils.reinit_common!`), so eagerly
         # reinitializing all N subcaches costs N residual calls per warm-started
         # solve even though a retained solve usually runs only the starting
         # subalgorithm. Reinitialize just that one here and defer the rest to the
         # moment escalation actually reaches them (`deferred_subcache_reinit!`).
-        cache.deferred_u0 = u0
-        cache.deferred_p = p
         subcache = cache.caches[cache.current]
-        InternalAPI.reinit!(subcache, args...; u = get_u(subcache), p, u0)
+        InternalAPI.reinit!(subcache, args...; u = get_u(subcache), p, u0, kwargs...)
     else
         foreach(cache.caches) do cache
-            InternalAPI.reinit!(cache, args...; u = get_u(cache), p, u0)
+            InternalAPI.reinit!(cache, args...; u = get_u(cache), p, u0, kwargs...)
         end
     end
     InternalAPI.reinit!(cache.stats)
@@ -224,6 +227,10 @@ end
 reinit_retaining!(cache, u0) = SciMLBase.reinit!(cache, u0)
 function reinit_retaining!(cache::NonlinearSolvePolyAlgorithmCache, u0)
     return SciMLBase.reinit!(cache, u0; retain_best = true)
+end
+reinit_retaining!(cache, u0, p) = SciMLBase.reinit!(cache, u0; p)
+function reinit_retaining!(cache::NonlinearSolvePolyAlgorithmCache, u0, p)
+    return SciMLBase.reinit!(cache, u0; p, retain_best = true)
 end
 
 function SciMLBase.__init(

--- a/lib/NonlinearSolveBase/src/public.jl
+++ b/lib/NonlinearSolveBase/src/public.jl
@@ -66,6 +66,24 @@ NonlinearSolveBase.L2_NORM([3.0, 4.0])
 function L2_NORM end
 
 """
+    solve_cache!(cache; step_observer = nothing) -> ReturnCode
+
+Drive an initialized nonlinear solver cache to termination without constructing a
+`NonlinearSolution`.
+
+This allocation-sensitive interface is intended for nested solvers that already own a
+cache from `init`. `step_observer`, when provided, is called after every nonlinear
+iteration as `step_observer(u, fu, iteration)`. The state and residual arguments alias
+the solver cache and must not be mutated. The returned `SciMLBase.ReturnCode` reports
+the final solver status; the final state remains available through
+`SymbolicIndexingInterface.state_values(cache)`.
+
+Unlike `solve!(cache)`, this function does not transform a bounded problem's internal
+unconstrained state back to the bounded coordinates.
+"""
+function solve_cache! end
+
+"""
     Linf_NORM(u)
 
 Compute the infinity norm used by NonlinearSolve internals.

--- a/lib/NonlinearSolveBase/src/public.jl
+++ b/lib/NonlinearSolveBase/src/public.jl
@@ -72,10 +72,11 @@ Drive an initialized nonlinear solver cache to termination without constructing 
 `NonlinearSolution`.
 
 This allocation-sensitive interface is intended for nested solvers that already own a
-cache from `init`. `step_observer`, when provided, is called after every nonlinear
-iteration as `step_observer(u, fu, iteration)`. The state and residual arguments alias
-the solver cache and must not be mutated. The returned `SciMLBase.ReturnCode` reports
-the final solver status; the final state remains available through
+cache from `init` and whose algorithm supports the nonlinear solver iterator interface.
+`step_observer`, when provided, is called after every nonlinear iteration as
+`step_observer(u, fu, iteration)`. The state and residual arguments alias the solver
+cache and must not be mutated. The returned `SciMLBase.ReturnCode` reports the final
+solver status; the final state remains available through
 `SymbolicIndexingInterface.state_values(cache)`.
 
 Unlike `solve!(cache)`, this function does not transform a bounded problem's internal

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -304,14 +304,8 @@ function SciMLBase.__solve(
     return sol
 end
 
-function CommonSolve.solve!(cache::AbstractNonlinearSolveCache)
-    if cache.retcode == ReturnCode.InitialFailure
-        return SciMLBase.build_solution(
-            cache.prob, cache.alg, get_u(cache), get_fu(cache);
-            cache.retcode, cache.stats, cache.trace
-        )
-    end
-
+function _run_cache_to_completion!(cache::AbstractNonlinearSolveCache)
+    cache.retcode == ReturnCode.InitialFailure && return cache
     while not_terminated(cache)
         CommonSolve.step!(cache)
     end
@@ -330,6 +324,15 @@ function CommonSolve.solve!(cache::AbstractNonlinearSolveCache)
         last = Val(true)
     )
 
+    return cache
+end
+
+@inline function _has_bounded_wrapper(cache::AbstractNonlinearSolveCache)
+    return hasfield(typeof(cache.prob), :f) &&
+        hasfield(typeof(cache.prob.f), :f) && cache.prob.f.f isa BoundedWrapper
+end
+
+function _solution_from_cache(cache::AbstractNonlinearSolveCache; transform_bounds::Bool)
     sol = SciMLBase.build_solution(
         cache.prob, cache.alg, get_u(cache), get_fu(cache);
         cache.retcode, cache.stats, cache.trace
@@ -337,9 +340,7 @@ function CommonSolve.solve!(cache::AbstractNonlinearSolveCache)
 
     # Inverse bounds transform: if the problem function was wrapped with a
     # BoundedWrapper, map the solution back from unbounded to bounded space.
-    if hasfield(typeof(cache.prob), :f) &&
-            hasfield(typeof(cache.prob.f), :f) &&
-            cache.prob.f.f isa BoundedWrapper
+    if transform_bounds && _has_bounded_wrapper(cache)
         bw = cache.prob.f.f
         sol.u .= _from_unbounded.(sol.u, bw.lb, bw.ub)
 
@@ -349,6 +350,47 @@ function CommonSolve.solve!(cache::AbstractNonlinearSolveCache)
     end
 
     return sol
+end
+
+function _solve_without_solution!(cache::AbstractNonlinearSolveCache)
+    if applicable(InternalAPI.step!, cache) && hasfield(typeof(cache), :termination_cache) &&
+            hasfield(typeof(cache), :trace)
+        cache.retcode == ReturnCode.InitialFailure && return cache
+        _run_cache_to_completion!(cache)
+        return _has_bounded_wrapper(cache) ?
+            _solution_from_cache(cache; transform_bounds = true) : cache
+    end
+    return CommonSolve.solve!(cache)
+end
+
+function CommonSolve.solve!(cache::AbstractNonlinearSolveCache)
+    if cache.retcode == ReturnCode.InitialFailure
+        return _solution_from_cache(cache; transform_bounds = false)
+    end
+
+    _run_cache_to_completion!(cache)
+    return _solution_from_cache(cache; transform_bounds = true)
+end
+
+
+@inline _solve_result_u(result) = result.u
+@inline _solve_result_resid(result) = result.resid
+@inline _solve_result_retcode(result) = result.retcode
+@inline _solve_result_stats(result) = result.stats
+@inline _solve_result_original(result) = result
+
+@inline _solve_result_u(cache::AbstractNonlinearSolveCache) = get_u(cache)
+@inline _solve_result_resid(cache::AbstractNonlinearSolveCache) = get_fu(cache)
+@inline _solve_result_retcode(cache::AbstractNonlinearSolveCache) = cache.retcode
+@inline _solve_result_stats(cache::AbstractNonlinearSolveCache) = cache.stats
+@inline function _solve_result_original(cache::AbstractNonlinearSolveCache)
+    return _solution_from_cache(
+        cache; transform_bounds = cache.retcode != ReturnCode.InitialFailure
+    )
+end
+
+@inline function _solve_result_successful(result)
+    return SciMLBase.successful_retcode(_solve_result_retcode(result))
 end
 
 @generated function CommonSolve.solve!(cache::NonlinearSolvePolyAlgorithmCache{Val{N}}) where {N}
@@ -500,6 +542,10 @@ end
     )
 
     return Expr(:block, calls...)
+end
+
+function _solve_without_solution!(cache::NonlinearSolvePolyAlgorithmCache)
+    return CommonSolve.solve!(cache)
 end
 
 function SciMLBase.__solve(
@@ -774,6 +820,11 @@ function CommonSolve.solve!(cache::NonlinearSolveNoInitCache)
         )
     end
     return CommonSolve.solve(cache.prob, cache.alg, cache.args...; cache.kwargs...)
+end
+
+
+function _solve_without_solution!(cache::NonlinearSolveNoInitCache)
+    return CommonSolve.solve!(cache)
 end
 
 function _solve_adjoint(

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -304,10 +304,18 @@ function SciMLBase.__solve(
     return sol
 end
 
-function _run_cache_to_completion!(cache::AbstractNonlinearSolveCache)
+@inline _observe_nonlinear_step!(::Nothing, cache) = nothing
+@inline function _observe_nonlinear_step!(step_observer, cache)
+    return step_observer(get_u(cache), get_fu(cache), cache.nsteps)
+end
+
+function _run_cache_to_completion!(
+        cache::AbstractNonlinearSolveCache, step_observer = nothing
+    )
     cache.retcode == ReturnCode.InitialFailure && return cache
     while not_terminated(cache)
         CommonSolve.step!(cache)
+        _observe_nonlinear_step!(step_observer, cache)
     end
 
     # The solver might have set a different `retcode`
@@ -325,6 +333,11 @@ function _run_cache_to_completion!(cache::AbstractNonlinearSolveCache)
     )
 
     return cache
+end
+
+function solve_cache!(cache::AbstractNonlinearSolveCache; step_observer = nothing)
+    _run_cache_to_completion!(cache, step_observer)
+    return cache.retcode
 end
 
 @inline function _has_bounded_wrapper(cache::AbstractNonlinearSolveCache)

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -336,6 +336,12 @@ function _run_cache_to_completion!(
 end
 
 function solve_cache!(cache::AbstractNonlinearSolveCache; step_observer = nothing)
+    applicable(InternalAPI.step!, cache) || throw(
+        ArgumentError(
+            "`solve_cache!` requires an algorithm that supports the nonlinear " *
+                "solver iterator interface."
+        )
+    )
     _run_cache_to_completion!(cache, step_observer)
     return cache.retcode
 end

--- a/lib/NonlinearSolveBase/src/utils.jl
+++ b/lib/NonlinearSolveBase/src/utils.jl
@@ -111,7 +111,7 @@ function restructure(
     @assert size(y) == size(x) "cannot restructure operators. ensure their sizes match."
     return x
 end
-restructure(y, x) = ArrayInterface.restructure(y, x)
+restructure(y, x) = y === x ? x : ArrayInterface.restructure(y, x)
 
 function safe_similar(x, args...; kwargs...)
     y = similar(x, args...; kwargs...)

--- a/lib/NonlinearSolveBase/test/allocation_fastpaths.jl
+++ b/lib/NonlinearSolveBase/test/allocation_fastpaths.jl
@@ -1,0 +1,47 @@
+using ADTypes: AutoForwardDiff
+using ForwardDiff
+using NonlinearSolveBase
+using SciMLBase
+using Test
+
+function dense_jacobian_cache_allocations()
+    function f!(du, u, p)
+        du[1] = u[1]^2 + u[2] + p
+        du[2] = u[1] + 3 * u[2] - p
+        return nothing
+    end
+
+    u = [2.0, 3.0]
+    p = 0.5
+    f = NonlinearFunction{true, SciMLBase.FullSpecialize}(f!)
+    prob = NonlinearProblem(f, u, p)
+    fu = similar(u)
+    f(fu, u, p)
+    cache = NonlinearSolveBase.construct_jacobian_cache(
+        prob, nothing, f, fu;
+        stats = SciMLBase.NLStats(0, 0, 0, 0, 0),
+        autodiff = AutoForwardDiff(; chunksize = 1),
+    )
+
+    cache(u)
+    cache(u)
+    J = copy(cache(u))
+    allocs = @allocated cache(u)
+    return J, allocs
+end
+
+J, jacobian_allocs = dense_jacobian_cache_allocations()
+@test J == [4.0 1.0; 1.0 3.0]
+@test jacobian_allocs == 0
+
+function same_buffer_restructure_allocations()
+    x = ones(4)
+    NonlinearSolveBase.Utils.restructure(x, x)
+    y = NonlinearSolveBase.Utils.restructure(x, x)
+    allocs = @allocated NonlinearSolveBase.Utils.restructure(x, x)
+    return x, y, allocs
+end
+
+x, y, restructure_allocs = same_buffer_restructure_allocations()
+@test y === x
+@test restructure_allocs == 0

--- a/lib/NonlinearSolveBase/test/allocation_fastpaths.jl
+++ b/lib/NonlinearSolveBase/test/allocation_fastpaths.jl
@@ -26,12 +26,16 @@ function dense_jacobian_cache_allocations()
     cache(u)
     cache(u)
     J = copy(cache(u))
-    allocs = @allocated cache(u)
-    return J, allocs
+    destination = cache.J_destination
+    reshape_allocs = @allocated reshape(destination, size(destination))
+    jacobian_allocs = @allocated cache(u)
+    return J, destination, reshape_allocs, jacobian_allocs
 end
 
-J, jacobian_allocs = dense_jacobian_cache_allocations()
+J, destination, reshape_allocs, jacobian_allocs = dense_jacobian_cache_allocations()
 @test J == [4.0 1.0; 1.0 3.0]
+@test reshape(destination, size(destination)) === destination
+@test reshape_allocs == 0
 @test jacobian_allocs == 0
 
 function same_buffer_restructure_allocations()

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -128,6 +128,10 @@ run_tests(;
 
         @safetestset "Linear solver routing" include("linear_solver_routing.jl")
 
+        @safetestset "Jacobian and restructure allocation fast paths" include(
+            "allocation_fastpaths.jl"
+        )
+
         @safetestset "Operator Jacobian cache dispatch" begin
             using NonlinearSolveBase, SciMLBase, SciMLOperators
 

--- a/test/Core/bounds_tests__item1.jl
+++ b/test/Core/bounds_tests__item1.jl
@@ -32,6 +32,12 @@ end
     sol = solve!(cache)
     @test all(sol.u .>= 3.0)
     @test all(sol.u .<= 10.0)
+
+    cache = init(prob, alg)
+    sol = NonlinearSolveBase._solve_without_solution!(cache)
+    @test !(sol isa NonlinearSolveBase.AbstractNonlinearSolveCache)
+    @test all(sol.u .>= 3.0)
+    @test all(sol.u .<= 10.0)
 end
 
 # Test in-place version — use FullSpecialize for bounds compatibility

--- a/test/Core/cache_solve_tests__item1.jl
+++ b/test/Core/cache_solve_tests__item1.jl
@@ -1,0 +1,47 @@
+using NonlinearSolve, SciMLBase, SymbolicIndexingInterface, Test
+using ADTypes: AutoFiniteDiff
+using NonlinearSolveBase: solve_cache!
+
+mutable struct StepObserver
+    iterations::Int
+    residual_norm::Float64
+end
+
+function (observer::StepObserver)(u, fu, iteration)
+    observer.iterations = iteration
+    observer.residual_norm = sum(abs2, fu)
+    return nothing
+end
+
+function cache_solve!(cache, observer)
+    observer.iterations = 0
+    observer.residual_norm = Inf
+    return solve_cache!(cache; step_observer = observer)
+end
+
+function cache_solve_allocations(cache, observer)
+    reinit!(cache, [1.0])
+    GC.gc()
+    return @allocated cache_solve!(cache, observer)
+end
+
+function cache_problem!(resid, u, p)
+    resid[1] = u[1]^2 - p
+    return nothing
+end
+
+prob = NonlinearProblem(cache_problem!, [1.0], 2.0)
+cache = init(prob, NewtonRaphson(; autodiff = AutoFiniteDiff()))
+observer = StepObserver(0, Inf)
+
+retcode = cache_solve!(cache, observer)
+@test SciMLBase.successful_retcode(retcode)
+@test only(state_values(cache)) ≈ √2
+@test observer.iterations > 0
+@test observer.residual_norm ≤ 1.0e-12
+
+reinit!(cache, [1.0])
+@test SciMLBase.successful_retcode(cache_solve!(cache, observer))
+allocations = cache_solve_allocations(cache, observer)
+@test SciMLBase.successful_retcode(cache.retcode)
+VERSION ≥ v"1.11" && @test allocations == 0

--- a/test/Core/cache_solve_tests__item1.jl
+++ b/test/Core/cache_solve_tests__item1.jl
@@ -2,6 +2,8 @@ using NonlinearSolve, SciMLBase, SymbolicIndexingInterface, Test
 using ADTypes: AutoFiniteDiff
 using NonlinearSolveBase: solve_cache!
 
+struct UnsupportedCache <: NonlinearSolveBase.AbstractNonlinearSolveCache end
+
 mutable struct StepObserver
     iterations::Int
     residual_norm::Float64
@@ -45,3 +47,5 @@ reinit!(cache, [1.0])
 allocations = cache_solve_allocations(cache, observer)
 @test SciMLBase.successful_retcode(cache.retcode)
 VERSION ≥ v"1.11" && @test allocations == 0
+
+@test_throws ArgumentError solve_cache!(UnsupportedCache())

--- a/test/Core/homotopy_alloc_tests__item1.jl
+++ b/test/Core/homotopy_alloc_tests__item1.jl
@@ -34,6 +34,25 @@ wrapped = NLB.maybe_wrap_nonlinear_f(inner_prob)
 @test NLB.is_fw_wrapped(wrapped)
 @test isconcretetype(only(Base.return_types(NLB.maybe_wrap_nonlinear_f, (typeof(inner_prob),))))
 
+# Measure the cache-only solve independently of the end-to-end continuation slopes below.
+function cache_only_solve_allocations(prob)
+    u0 = copy(prob.u0)
+    cache = SciMLBase.init(prob, NewtonRaphson())
+    result = NLB._solve_without_solution!(cache)
+    SciMLBase.reinit!(cache, u0)
+    NLB._solve_without_solution!(cache)
+    SciMLBase.reinit!(cache, u0)
+    GC.gc()
+    allocs = @allocated NLB._solve_without_solution!(cache)
+    return result, result === cache, allocs
+end
+
+cache_result, same_cache, cache_solve_allocs = cache_only_solve_allocations(inner_prob)
+@test cache_result isa NLB.AbstractNonlinearSolveCache
+@test same_cache
+@test SciMLBase.successful_retcode(cache_result.retcode)
+VERSION >= v"1.11" && @test cache_solve_allocs == 0
+
 # --- end-to-end per-step allocation with a clean `NewtonRaphson` inner. The slope between two
 # fixed-step runs cancels compile/one-time-init cost, leaving pure per-step allocation. Gated
 # on Julia 1.11+: the LinearSolve factorization-workspace reuse that removes the last

--- a/test/Core/homotopy_alloc_tests__item1.jl
+++ b/test/Core/homotopy_alloc_tests__item1.jl
@@ -1,5 +1,6 @@
 using NonlinearSolve
 
+using CommonSolve
 using SciMLBase
 
 import NonlinearSolveBase as NLB
@@ -52,6 +53,26 @@ cache_result, same_cache, cache_solve_allocs = cache_only_solve_allocations(inne
 @test same_cache
 @test SciMLBase.successful_retcode(cache_result.retcode)
 VERSION >= v"1.11" && @test cache_solve_allocs == 0
+
+function cached_sweep_retcode!(cache, u0, p, abstol)
+    SciMLBase.reinit!(cache, u0; p, abstol)
+    return CommonSolve.solve!(cache).retcode
+end
+
+function cached_sweep_allocations(prob)
+    alg = HomotopySweep(; inner = NewtonRaphson(), adaptive = false, nsteps = 10)
+    cache = SciMLBase.init(prob, alg; abstol = 0.0)
+    abstol = 1.0e-10
+    cached_sweep_retcode!(cache, prob.u0, prob.p, abstol)
+    cached_sweep_retcode!(cache, prob.u0, prob.p, abstol)
+    GC.gc()
+    allocs = @allocated cached_sweep_retcode!(cache, prob.u0, prob.p, abstol)
+    return cache, allocs
+end
+
+sweep_cache, sweep_cache_allocs = cached_sweep_allocations(prob)
+@test SciMLBase.successful_retcode(CommonSolve.solve!(sweep_cache))
+VERSION >= v"1.11" && @test sweep_cache_allocs == 0
 
 # --- end-to-end per-step allocation with a clean `NewtonRaphson` inner. The slope between two
 # fixed-step runs cancels compile/one-time-init cost, leaving pure per-step allocation. Gated

--- a/test/Core/homotopy_effort_tests__item2.jl
+++ b/test/Core/homotopy_effort_tests__item2.jl
@@ -14,6 +14,7 @@ sol = solve(prob, HomotopySweep(; initial_step_factor = 1.0e-4, expand_factor = 
 @test !SciMLBase.successful_retcode(sol)
 @test isfinite(sol.u[1])
 @test 0 < sol.u[1] < 1
+@test sol.resid !== nothing
 
 Hs(u, p, λ) = SA[u[1] - λ]
 probs = HomotopyProblem(Hs, SA[0.0]; λspan = (0.0, 1.0))

--- a/test/Core/homotopy_sweep_tests__item10.jl
+++ b/test/Core/homotopy_sweep_tests__item10.jl
@@ -12,4 +12,5 @@ prob = HomotopyProblem(H, [0.0]; λspan = (1.0e9, 2.0e9))
 sol = solve(prob, HomotopySweep(; inner = NewtonRaphson()); maxiters = 5)
 @test sol.retcode == SciMLBase.ReturnCode.Stalled
 @test !SciMLBase.successful_retcode(sol)
-@test sol.resid === nothing
+@test sol.resid !== nothing
+@test all(isfinite, sol.resid)

--- a/test/Core/homotopy_sweep_tests__item23.jl
+++ b/test/Core/homotopy_sweep_tests__item23.jl
@@ -1,0 +1,33 @@
+using NonlinearSolve
+using CommonSolve
+using SciMLBase
+using Test
+
+function Hcache!(du, u, p, λ)
+    du[1] = (1 - λ) * (u[1] - p[1]) + λ * (u[1]^2 - p[1])
+    return nothing
+end
+
+prob = HomotopyProblem(Hcache!, [4.0], [4.0])
+algs = (
+    HomotopySweep(; inner = NewtonRaphson(), adaptive = false, nsteps = 10),
+    KantorovichHomotopy(; inner = NewtonRaphson(), nsteps = 10, strict = false),
+    HomotopySweep(; adaptive = false, nsteps = 10),
+)
+
+for alg in algs
+    cache = init(prob, alg; abstol = 0.0)
+    @test reinit!(cache, prob.u0; p = prob.p, abstol = 1.0e-10) === cache
+    sol = solve!(cache)
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[1] ≈ 2.0 atol = 1.0e-10
+
+    u0 = [9.0]
+    p = [9.0]
+    @test reinit!(cache, u0; p, abstol = 1.0e-10) === cache
+    sol = solve!(cache)
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[1] ≈ 3.0 atol = 1.0e-10
+    @test sol.prob.u0 === u0
+    @test sol.prob.p === p
+end

--- a/test/Core/kantorovich_homotopy_tests__item1.jl
+++ b/test/Core/kantorovich_homotopy_tests__item1.jl
@@ -143,6 +143,7 @@ corrector_prob = NonlinearProblem((u, p) -> [u[1] - 1], [0.0])
 corrector_cache = init(corrector_prob, SlowContractionAlgorithm(); maxiters = 2)
 corrector_sol, first_Θ, rejected_Θ, has_Θ, contraction_rejected =
     NonlinearSolveBase._homotopy_corrector!(corrector_cache, alg, Float64)
+@test corrector_sol isa SciMLBase.NonlinearSolution
 @test SciMLBase.successful_retcode(corrector_sol)
 @test has_Θ
 @test first_Θ ≈ 0.99

--- a/test/Core/polyalg_retention_tests__item1.jl
+++ b/test/Core/polyalg_retention_tests__item1.jl
@@ -3,6 +3,7 @@
 # subcache reinitialization, upward escalation, wrap-around floored at the
 # algorithm's `start_index`, and exact status-quo behavior when retention is off.
 using NonlinearSolve, SciMLBase
+using NonlinearSolveBase: get_abstol
 
 using Test
 
@@ -122,4 +123,17 @@ end
     sol2 = solve!(cache)
     @test SciMLBase.successful_retcode(sol2)
     @test sol2.u[1] ≈ ROOT atol = 1.0e-6
+end
+
+@testset "solver option updates reach every retained subcache" begin
+    alg = NonlinearSolvePolyAlgorithm((NewtonRaphson(), Broyden()))
+    prob = NonlinearProblem(fcubic, [0.0])
+    cache = init(prob, alg; abstol = 0.0)
+    cache.best = 2
+
+    NF[] = 0
+    reinit!(cache, [1.2]; retain_best = true, abstol = 1.0e-8)
+    @test cache.current == 2
+    @test NF[] == 2
+    @test all(subcache -> get_abstol(subcache) == 1.0e-8, cache.caches)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,6 +87,7 @@ else
             @time @safetestset "HomotopySweep secant predictor reduces corrector work" include("Core/homotopy_sweep_tests__item20.jl")
             @time @safetestset "HomotopySweep regrows the step after bisecting a hard region" include("Core/homotopy_sweep_tests__item21.jl")
             @time @safetestset "Continuation drivers return concretely-typed solutions (no Any-typed original)" include("Core/homotopy_sweep_tests__item22.jl")
+            @time @safetestset "HomotopySweep init/reinit!/solve! cache reuse" include("Core/homotopy_sweep_tests__item23.jl")
             @time @safetestset "Kantorovich homotopy controller" include("Core/kantorovich_homotopy_tests__item1.jl")
             @time @safetestset "ArcLengthContinuation construction + defaults" include("Core/arclength_tests__item1.jl")
             @time @safetestset "ArcLengthContinuation happy path (fold-free, matches sweep)" include("Core/arclength_tests__item2.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,7 @@ else
             @time @safetestset "No AD" include("Core/core_tests__item11.jl")
             @time @safetestset "Infeasible" include("Core/core_tests__item12.jl")
             @time @safetestset "NoInit Caching" include("Core/core_tests__item13.jl")
+            @time @safetestset "Allocation-free cache solve" include("Core/cache_solve_tests__item1.jl")
             @time @safetestset "Singular Systems -- Auto Linear Solve Switching" include("Core/core_tests__item16.jl")
             @time @safetestset "No PolyesterForwardDiff for SArray" include("Core/core_tests__item17.jl")
             @time @safetestset "NonlinearLeastSquares ReturnCode" include("Core/core_tests__item18.jl")


### PR DESCRIPTION
> **Please ignore this draft until it has been reviewed by @ChrisRackauckas.**

## Summary

- Add reusable `init`/`reinit!`/`solve!` caches for `HomotopySweep` and
  `KantorovichHomotopy`.
- Reuse continuation buffers and the inner nonlinear-solver cache across complete
  homotopy solves, including parameter, initial-value, and same-typed solver-option
  updates.
- Propagate option updates through every retained polyalgorithm subcache so later
  fallback uses the current tolerances.
- Keep dense ForwardDiff Jacobian writes and continuation correctors allocation-free
  on Julia 1.12.
- Add the documented `NonlinearSolveBase.solve_cache!` driver for nested solvers
  that need per-iteration observations without constructing a `NonlinearSolution`.
- Bump NonlinearSolveBase to 2.40.0 and NonlinearSolve to 4.24.0.

The first dense-Jacobian allocation fix is also available independently as #1116.
This PR retains the complete series needed by the reusable outer cache.

## Why

The continuation drivers already reused an inner nonlinear cache within one homotopy
sweep, but the outer `HomotopyProblem` interface only implemented one-shot `solve`.
A caller solving a sequence of same-typed homotopy problems therefore rebuilt the
outer buffers and inner solver workspace every time. This was the path used by
OrdinaryDiffEq's `HomotopyNonlinearSolveAlg` for successive implicit stages.

The new outer cache owns the problem, fixed-lambda residual, inner cache, continuation
buffers, and controller state. `reinit!` updates `u0`, `p`, and existing same-typed
options; `solve!` resets the path state in place and drives the cached corrector.
Resizing remains the caller's responsibility because a changed state dimension
requires rebuilding the typed inner workspace.

Failure solutions now retain the most recent inner residual on stalled/max-step
paths. This keeps the cached return type consistent and provides more information
than the previous `nothing` residual.

## Allocation behavior

On Julia 1.12.6, the warmed complete-cache `reinit!` plus `solve!` path allocates
exactly 0 bytes. The existing per-continuation-step regressions also remain exactly
zero after rebasing onto the current homotopy routing and
`FastShortcutHomotopyPolyalg` work.

The warmed `solve_cache!` path with a stateful step observer also allocates exactly
0 bytes. This is the cache driver used by the dependent ImplicitDiscreteSolve change
to collect Newton contraction rates without reaching into NonlinearSolve internals.

## Local validation

- Exact head `dca80d83c` on `upstream/master` `22190d403`.
- Official root `NONLINEARSOLVE_TEST_GROUP=Core` on Julia 1.12.6:
  `Testing NonlinearSolve tests passed`.
- Allocation-free observed cache solve: 8/8 passed, with exact warmed 0-byte
  allocation.
- Reusable outer cache: 24/24 passed.
- Concrete inner cache and exact zero-allocation stepping: 17/17 passed.
- Kantorovich controller: 51/51 passed.
- Current-master standard-algorithm routing and fast homotopy polyalgorithm:
  19/19 and 12/12 passed.
- Official NonlinearSolveBase Core on Julia 1.12.6:
  `Testing NonlinearSolveBase tests passed`, including Jacobian/restructure
  allocation fast paths 6/6 and dense LU allocation checks 14/14.
- Released SciMLTesting 2.6.0 prevents Base QA from starting due the
  already-fixed Aqua `treat_as_own` conversion bug. Against the merged SciMLTesting
  [SciMLTesting.jl#37](https://github.com/SciML/SciMLTesting.jl/pull/37) source,
  public API documentation passed 2/2 and 19/20 QA checks passed; the remaining
  pre-existing public-owner check is addressed by #1121.
- Repository-wide Runic `--check`: exit 0.
- `git diff --check`: exit 0.

No test was skipped, silenced, or loosened.
