### PR TITLE
Stabilize unglobalized bad Broyden steps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.23.2"
+version = "4.23.3"
 authors = ["SciML"]
 
 [deps]

--- a/lib/NonlinearSolveQuasiNewton/Project.toml
+++ b/lib/NonlinearSolveQuasiNewton/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveQuasiNewton"
 uuid = "9a2c21bd-3a47-402d-9113-8faf9a0ee114"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.14.3"
+version = "1.14.4"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/NonlinearSolveQuasiNewton/src/broyden.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/broyden.jl
@@ -122,6 +122,11 @@ end
     tight_step_limit::Bool
 end
 
+function InternalAPI.reinit!(cache::BroydenUpdateRuleCache; kwargs...)
+    cache.tight_step_limit = false
+    return
+end
+
 function unglobalized_step_size(cache::BroydenUpdateRuleCache, u, du, first_step::Bool)
     cache.rule isa BadBroydenUpdateRule || return true
     du_norm = cache.internalnorm(du)
@@ -130,9 +135,10 @@ function unglobalized_step_size(cache::BroydenUpdateRuleCache, u, du, first_step
     if first_step
         cache.tight_step_limit = du_norm > 10 * u_scale
     end
+    cache.tight_step_limit || return true
     # Bad Broyden updates propagate the first displacement through every later inverse
     # update, so retain a state-scale bound when the initial inverse produces a gross step.
-    step_limit = cache.tight_step_limit ? u_scale : 10 * u_scale
+    step_limit = u_scale
     du_norm ≤ step_limit && return true
     return step_limit / du_norm
 end

--- a/lib/NonlinearSolveQuasiNewton/src/broyden.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/broyden.jl
@@ -121,6 +121,17 @@ end
     rule <: Union{BadBroydenUpdateRule, GoodBroydenUpdateRule}
 end
 
+function unglobalized_step_size(cache::BroydenUpdateRuleCache, u, du)
+    cache.rule isa BadBroydenUpdateRule || return true
+    du_norm = cache.internalnorm(du)
+    iszero(du_norm) && return one(du_norm)
+    u_scale = max(cache.internalnorm(u), one(du_norm))
+    # Bad Broyden updates can magnify an oversized displacement in every later inverse
+    # update, so bound unglobalized steps to one order of magnitude relative to the state.
+    step_limit = 10 * u_scale
+    return min(one(du_norm), step_limit / du_norm)
+end
+
 function InternalAPI.solve!(
         cache::BroydenUpdateRuleCache, J⁻¹, fu, u, du; kwargs...
     )

--- a/lib/NonlinearSolveQuasiNewton/src/broyden.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/broyden.jl
@@ -108,7 +108,7 @@ function InternalAPI.init(
     else
         @bb du_cache = similar(du)
     end
-    return BroydenUpdateRuleCache(J⁻¹dfu, dfu, u_cache, du_cache, internalnorm, alg)
+    return BroydenUpdateRuleCache(J⁻¹dfu, dfu, u_cache, du_cache, internalnorm, alg, false)
 end
 
 @concrete mutable struct BroydenUpdateRuleCache <:
@@ -119,17 +119,22 @@ end
     du_cache
     internalnorm
     rule <: Union{BadBroydenUpdateRule, GoodBroydenUpdateRule}
+    tight_step_limit::Bool
 end
 
-function unglobalized_step_size(cache::BroydenUpdateRuleCache, u, du)
+function unglobalized_step_size(cache::BroydenUpdateRuleCache, u, du, first_step::Bool)
     cache.rule isa BadBroydenUpdateRule || return true
     du_norm = cache.internalnorm(du)
-    iszero(du_norm) && return one(du_norm)
+    iszero(du_norm) && return true
     u_scale = max(cache.internalnorm(u), one(du_norm))
-    # Bad Broyden updates can magnify an oversized displacement in every later inverse
-    # update, so bound unglobalized steps to one order of magnitude relative to the state.
-    step_limit = 10 * u_scale
-    return min(one(du_norm), step_limit / du_norm)
+    if first_step
+        cache.tight_step_limit = du_norm > 10 * u_scale
+    end
+    # Bad Broyden updates propagate the first displacement through every later inverse
+    # update, so retain a state-scale bound when the initial inverse produces a gross step.
+    step_limit = cache.tight_step_limit ? u_scale : 10 * u_scale
+    du_norm ≤ step_limit && return true
+    return step_limit / du_norm
 end
 
 function InternalAPI.solve!(

--- a/lib/NonlinearSolveQuasiNewton/src/solve.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/solve.jl
@@ -113,7 +113,7 @@ function NonlinearSolveBase.get_reltol(cache::QuasiNewtonCache)
     return NonlinearSolveBase.get_reltol(cache.termination_cache)
 end
 
-unglobalized_step_size(cache, u, du) = true
+unglobalized_step_size(cache, u, du, first_step) = true
 
 function InternalAPI.reinit_self!(
         cache::QuasiNewtonCache, args...; p = cache.p, u0 = cache.u,
@@ -429,8 +429,12 @@ function InternalAPI.step!(
             α = true
         elseif cache.globalization isa Val{:None}
             @static_timeit cache.timer "step" begin
-                α = unglobalized_step_size(cache.update_rule_cache, cache.u, δu)
-                @bb @. δu *= α
+                α = unglobalized_step_size(
+                    cache.update_rule_cache, cache.u, δu, iszero(cache.nsteps)
+                )
+                if α !== true
+                    @bb @. δu *= α
+                end
                 @bb axpy!(1, δu, cache.u)
                 Utils.evaluate_f!(cache, cache.u, cache.p)
             end

--- a/lib/NonlinearSolveQuasiNewton/src/solve.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/solve.jl
@@ -113,6 +113,8 @@ function NonlinearSolveBase.get_reltol(cache::QuasiNewtonCache)
     return NonlinearSolveBase.get_reltol(cache.termination_cache)
 end
 
+unglobalized_step_size(cache, u, du) = true
+
 function InternalAPI.reinit_self!(
         cache::QuasiNewtonCache, args...; p = cache.p, u0 = cache.u,
         alias_u0::Bool = hasproperty(cache, :alias_u0) ? cache.alias_u0 : false,
@@ -427,10 +429,11 @@ function InternalAPI.step!(
             α = true
         elseif cache.globalization isa Val{:None}
             @static_timeit cache.timer "step" begin
+                α = unglobalized_step_size(cache.update_rule_cache, cache.u, δu)
+                @bb @. δu *= α
                 @bb axpy!(1, δu, cache.u)
                 Utils.evaluate_f!(cache, cache.u, cache.p)
             end
-            α = true
         else
             error("Unknown Globalization Strategy: $(cache.globalization). Allowed values \
                    are (:LineSearch, :TrustRegion, :None)")

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests__item1.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests__item1.jl
@@ -12,6 +12,28 @@ if isempty(VERSION.prerelease) && VERSION < v"1.12"
     using Enzyme
 end
 
+@testset "Bad Broyden oversized-step safeguard" begin
+    function brown_almost_linear!(du, u, p)
+        n = length(u)
+        u_sum = sum(u)
+        for i in 1:(n - 1)
+            du[i] = u[i] + u_sum - (n + 1)
+        end
+        du[n] = prod(u) - 1
+        return nothing
+    end
+
+    prob = NonlinearProblem{true}(brown_almost_linear!, fill(0.5, 10))
+    alg = Broyden(
+        init_jacobian = Val(:true_jacobian), update_rule = Val(:bad_broyden)
+    )
+    cache = init(prob, alg; abstol = 1.0e-10, reltol = 1.0e-10)
+    sol = solve!(cache)
+
+    @test SciMLBase.successful_retcode(sol)
+    @test maximum(abs, sol.resid) < 1.0e-9
+end
+
 u0s = ([1.0, 1.0], @SVector[1.0, 1.0], 1.0)
 
 # Filter autodiff backends based on Julia version

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests__item1.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests__item1.jl
@@ -32,6 +32,12 @@ end
 
     @test SciMLBase.successful_retcode(sol)
     @test maximum(abs, sol.resid) < 1.0e-9
+
+    reinit!(cache; u0 = ones(10))
+    @test !cache.update_rule_cache.tight_step_limit
+    sol = solve!(cache)
+    @test SciMLBase.successful_retcode(sol)
+    @test maximum(abs, sol.resid) < 1.0e-9
 end
 
 u0s = ([1.0, 1.0], @SVector[1.0, 1.0], 1.0)


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- Guard unglobalized bad-Broyden steps without adding a function evaluation or allocation to the ordinary path.
- Activate the safeguard only when the initial inverse produces a gross displacement (`norm(du) > 10 * max(norm(u), 1)`), then retain a state-scale bound for that solve.
- Leave ordinary unscaled trajectories bit-for-bit unchanged by returning a sentinel and skipping the displacement mutation.
- Clear the safeguard through public `reinit!` so a reused solver cache cannot inherit limiter state.
- Add an in-place Brown-almost-linear regression through the cached public `init` / `solve!` / `reinit!` interface.
- Bump NonlinearSolve to `4.23.3` and NonlinearSolveQuasiNewton to `1.14.4`.

No test expectation, threshold, tolerance, skip, or broken-test classification is changed.

## Cause

Problem 8 in the robustness matrix, Brown almost linear, fails for algorithm 4:

```julia
Broyden(
    init_jacobian = Val(:true_jacobian),
    update_rule = Val(:bad_broyden),
)
```

At the standard start, the state norm is about `1.58`, while the true-Jacobian displacement norm is about `5288` and the full-step residual is about `1.09e28`. Bad-Broyden inverse updates then follow a roundoff-sensitive trajectory: the same source and dependency graph can converge or return the initial best residual `5.5` depending on the BLAS kernel.

The hard CI boundary is `74405d303` (#1051), which removed Brown from algorithm 4's expected-broken list without changing this solver path. Existing issue #1096 records the machine dependence. A controlled clean-master reproduction on Julia 1.12.6 with `OPENBLAS_CORETYPE=Sandybridge` returned `Unstable`, residual `5.5`, after five steps.

## Current rebase

- Base: `2b0dda5f64402c5177507d9b1bb2e73ed0db4e5b`
- Head: `fb57e9fbde97eaccaddc510d265a7d5c50a34180`
- The current master skip/expected-broken matrix is preserved unchanged.
- The final diff contains only the three source/regression files plus the two package version bumps.

## Local validation

From `lib/NonlinearSolveQuasiNewton` on Julia 1.12.6:

```sh
OPENBLAS_CORETYPE=Sandybridge GROUP=Core \
  julia +1.12 --startup-file=no --project=. \
  -e 'using Pkg; Pkg.test(; julia_args=["--check-bounds=auto", "--compiled-modules=yes", "--depwarn=yes"], force_latest_compatible_version=false, allow_reresolve=true)'
```

Passed all 1001 assertions:

- Broyden: `599 / 599`
- Broyden iterator: `2 / 2`
- Broyden termination: `27 / 27`
- Klement: `216 / 216`
- Klement iterator: `2 / 2`
- Klement termination: `27 / 27`
- LimitedMemoryBroyden: `99 / 99`
- LimitedMemoryBroyden iterator: `2 / 2`
- LimitedMemoryBroyden termination: `27 / 27`
- Final output: `Testing NonlinearSolveQuasiNewton tests passed`

Repository-wide Runic 1.7.0 `--check .` and `git diff --check` both exited successfully.

The previous macOS CI validation of the final safeguard reported the complete root Broyden matrix at `95 pass / 20 expected broken`; the remaining red Core jobs in that run were the separate homotopy allocation baseline tracked in #1076.
