### PR TITLE
Approve intentional NonlinearSolve umbrella reexports

### DIFF
--- a/lib/NonlinearSolveQuasiNewton/test/qa/qa.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/qa/qa.jl
@@ -7,9 +7,16 @@ const QUASI_NEWTON_EXTERNAL_REEXPORTS = union(
     (:SciMLBase,),
 )
 
+const QUASI_NEWTON_REEXPORTS = union(
+    QUASI_NEWTON_EXTERNAL_REEXPORTS,
+    public_api_names(NonlinearSolveQuasiNewton.NonlinearSolveBase),
+    (:NonlinearSolveBase,),
+)
+
 run_qa(
     NonlinearSolveQuasiNewton;
     explicit_imports = true,
+    reexports_allow = QUASI_NEWTON_REEXPORTS,
     aqua_kwargs = (;
         stale_deps = (; ignore = [:SciMLJacobianOperators]),
         deps_compat = (; ignore = [:SciMLJacobianOperators]),

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -13,9 +13,25 @@ const NONLINEARSOLVE_EXTERNAL_REEXPORTS = union(
     (:ADTypes, :SciMLBase, :LineSearch, :LinearSolve),
 )
 
+const NONLINEARSOLVE_REEXPORTS = union(
+    NONLINEARSOLVE_EXTERNAL_REEXPORTS,
+    public_api_names(NonlinearSolve.NonlinearSolveBase),
+    public_api_names(NonlinearSolve.NonlinearSolveFirstOrder),
+    public_api_names(NonlinearSolve.NonlinearSolveSpectralMethods),
+    public_api_names(NonlinearSolve.NonlinearSolveQuasiNewton),
+    public_api_names(NonlinearSolve.SimpleNonlinearSolve),
+    public_api_names(NonlinearSolve.BracketingNonlinearSolve),
+    (
+        :NonlinearSolveBase, :NonlinearSolveFirstOrder,
+        :NonlinearSolveSpectralMethods, :NonlinearSolveQuasiNewton,
+        :SimpleNonlinearSolve, :BracketingNonlinearSolve,
+    ),
+)
+
 run_qa(
     NonlinearSolve;
     explicit_imports = true,
+    reexports_allow = NONLINEARSOLVE_REEXPORTS,
     aqua_kwargs = (;
         # stale_deps / deps_compat are checked on the SimpleNonlinearSolve facade
         # below (with the SciMLJacobianOperators ignore); persistent_tasks stays off


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- keep SciMLTesting public-reexport QA enabled
- allow the APIs deliberately reexported by the NonlinearSolve umbrella and NonlinearSolveQuasiNewton facade
- derive each allowlist from the public APIs of its explicit `@reexport` owner modules, so unrelated accidental reexports still fail QA

## Root cause

SciMLTesting 2.4.0 enabled `check_reexports` by default. NonlinearSolve and NonlinearSolveQuasiNewton already computed partial allowlists for external APIs in rendered-doc QA, but did not pass complete facade allowlists to the new check. Clean master therefore reported 393 root reexports and 211 QuasiNewton reexports as unapproved.

On the same clean master and Julia 1.12.6, pinning SciMLTesting 2.3.0 passes 18/18 root QA checks; SciMLTesting 2.4.0 fails only the new reexport check. The default-on change is SciMLTesting commit `2881f4c15fb715f0934009a800d42765751587b1`.

## Local verification

- root `GROUP=QA julia +1.12 --project=. -e "using Pkg; Pkg.test()"` with SciMLTesting 2.4.0: 19/19 passed
- NonlinearSolveQuasiNewton `GROUP=QA julia +1.12 --project=. -e "using Pkg; Pkg.test()"`: 20/20 passed
- Runic 1.7.0 over the full repository: passed
- `git diff --check`: passed
