### PR TITLE
Bump NonlinearSolveBase to v2.36.1 for release

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.36.0"
+version = "2.36.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
Releases the unreleased fix on master: restore GPU Broyden inverse initialization (#1066).

Detected by comparing the `git-tree-sha1` of the latest live registered version in General against the `src` subtree on the default branch. Only the `version` field in `Project.toml` is changed. No local test run — CI on this PR is the check. Please ignore until reviewed by @ChrisRackauckas.