### PR TITLE
SCCNonlinearSolve: continue HomotopyProblem blocks with the block algorithm as inner corrector

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.36.0"
+version = "2.37.0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/homotopy_polyalg.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_polyalg.jl
@@ -1,6 +1,6 @@
 """
     HomotopyPolyAlgorithm(algs::Tuple; warm_handoff = true, store_original = Val(false))
-    HomotopyPolyAlgorithm(; warm_handoff = true, store_original = Val(false))
+    HomotopyPolyAlgorithm(; inner = nothing, warm_handoff = true, store_original = Val(false))
 
 A polyalgorithm for [`SciMLBase.HomotopyProblem`](@ref): a container for a tuple of
 continuation algorithms that are tried in order until one returns a solution with a
@@ -73,6 +73,11 @@ below) — by default it is dropped so the returned solution stays concretely ty
 
 ### Keyword Arguments
 
+  - `inner`: an inner nonlinear algorithm threaded into both default stages
+    ([`HomotopySweep`](@ref) and [`ArcLengthContinuation`](@ref)) as their corrector, so a
+    `HomotopyProblem` is continued with that specific algorithm — e.g. one carrying a chosen
+    autodiff backend. `nothing` (default) leaves each stage its own default inner. Ignored
+    when `algs` is passed explicitly.
   - `warm_handoff`: when `true` (default), a stage following a partway-failed
     [`HomotopySweep`](@ref) or [`KantorovichHomotopy`](@ref) first attempts the remaining
     `(λ_h, λspan[2])` stretch from the natural-parameter stage's last accepted iterate
@@ -111,11 +116,14 @@ function HomotopyPolyAlgorithm(
 end
 
 function HomotopyPolyAlgorithm(;
-        warm_handoff::Bool = true, store_original::Val = Val(false)
+        inner = nothing, warm_handoff::Bool = true, store_original::Val = Val(false)
     )
-    return HomotopyPolyAlgorithm(
-        (HomotopySweep(), ArcLengthContinuation()); warm_handoff, store_original
-    )
+    # `inner` threads a shared inner corrector into the default stages — used to solve a
+    # `HomotopyProblem` by continuation with a specific inner algorithm (e.g. one carrying a
+    # chosen autodiff backend). `nothing` keeps each stage's own default inner.
+    sweep = inner === nothing ? HomotopySweep() : HomotopySweep(; inner)
+    arclength = inner === nothing ? ArcLengthContinuation() : ArcLengthContinuation(; inner)
+    return HomotopyPolyAlgorithm((sweep, arclength); warm_handoff, store_original)
 end
 
 # Step-size *caps* of the bundled continuation stages are fractions of the λspan

--- a/lib/SCCNonlinearSolve/Project.toml
+++ b/lib/SCCNonlinearSolve/Project.toml
@@ -1,10 +1,11 @@
 name = "SCCNonlinearSolve"
 uuid = "9dfe8606-65a1-4bb3-9748-cb89d1561431"
-version = "1.13.3"
+version = "1.14.0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+NonlinearSolveBase = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
@@ -35,7 +36,7 @@ InteractiveUtils = "<0.0.1, 1"
 LinearAlgebra = "1.10"
 NonlinearProblemLibrary = "0.1.2"
 NonlinearSolve = "4.8"
-NonlinearSolveBase = "2.23"
+NonlinearSolveBase = "2.37"
 NonlinearSolveFirstOrder = "2.1.2"
 PrecompileTools = "1.2"
 Reexport = "1.2.2"

--- a/lib/SCCNonlinearSolve/src/SCCNonlinearSolve.jl
+++ b/lib/SCCNonlinearSolve/src/SCCNonlinearSolve.jl
@@ -2,6 +2,7 @@ module SCCNonlinearSolve
 
 import SciMLBase
 import CommonSolve
+import NonlinearSolveBase
 import SymbolicIndexingInterface
 import SciMLBase: NonlinearProblem, NonlinearLeastSquaresProblem, LinearProblem
 
@@ -92,7 +93,18 @@ function solve_single_scc(alg, prob, explicitfun, sols; kwargs...)
             SciMLBase.build_solution(nlprob, nothing, sol.u, resid, retcode = sol.retcode)
         )
     else
-        sol = SciMLBase.solve(prob, alg.nlalg; kwargs...)
+        # A `HomotopyProblem` block (e.g. a Modelica `homotopy` operator block from
+        # ModelingToolkit) is solved by continuation, not by the SCC's nonlinear algorithm
+        # directly: that algorithm would only solve the block's target-λ system (see
+        # `solve(::HomotopyProblem, ::AbstractNonlinearSolveAlgorithm)`). It is threaded in
+        # as the *inner corrector* instead, so its autodiff / linear-solver choices are
+        # honored while the block is swept from `simplified` to `actual`.
+        blockalg = if prob isa SciMLBase.HomotopyProblem
+            NonlinearSolveBase.HomotopyPolyAlgorithm(; inner = alg.nlalg)
+        else
+            alg.nlalg
+        end
+        sol = SciMLBase.solve(prob, blockalg; kwargs...)
         SciMLBase.strip_solution(
             SciMLBase.build_solution(
                 prob, nothing, sol.u, sol.resid, retcode = sol.retcode

--- a/lib/SCCNonlinearSolve/test/core_tests.jl
+++ b/lib/SCCNonlinearSolve/test/core_tests.jl
@@ -2,3 +2,4 @@
 @safetestset "SCCNonlinearProblem solve without explicit u0 (issue #758)" include("core_tests__item2.jl")
 @safetestset "SCC Residuals Transfer" include("core_tests__item3.jl")
 @safetestset "Vector-form SCCNonlinearProblem with FunctionWrappers" include("core_tests__item4.jl")
+@safetestset "HomotopyProblem SCC block is continued (autodiff threaded)" include("core_tests__item5.jl")

--- a/lib/SCCNonlinearSolve/test/core_tests__item5.jl
+++ b/lib/SCCNonlinearSolve/test/core_tests__item5.jl
@@ -1,0 +1,56 @@
+using SCCNonlinearSolve
+using NonlinearSolve
+using SciMLBase
+using Test
+
+# A `HomotopyProblem` block of an `SCCNonlinearProblem` is solved by continuation (using the
+# SCC's nonlinear algorithm as the inner corrector), not by that algorithm applied directly
+# to the block's target-λ system.
+
+# branch selection: actual m² - 1 has roots ±1; from the guess m = -3 a Newton solve of the
+# target (λ = 1) system lands on the UNPHYSICAL -1, while continuation from the simplified
+# 2(m-1) (whose anchor is +1) reaches the physical +1. So a passing test *requires* the block
+# to have been continued.
+Hbranch(u, p, λ) = [(1 - λ) * 2 * (u[1] - 1) + λ * (u[1]^2 - 1)]
+homblock = HomotopyProblem(Hbranch, [-3.0])
+nlblock = NonlinearProblem((u, p) -> [u[1]^2 - 4], [1.5])   # plain block, root 2
+
+# control: the algorithm applied directly to the block solves the target system -> -1
+@test solve(homblock, NewtonRaphson()).u[1] ≈ -1.0 atol = 1.0e-6
+
+@testset "homotopy SCC block is continued, not target-λ solved" begin
+    sccprob = SciMLBase.SCCNonlinearProblem(
+        (homblock, nlblock),
+        SciMLBase.Void{Any}.([Returns(nothing), Returns(nothing)])
+    )
+    sol = solve(sccprob, SCCNonlinearSolve.SCCAlg(nlalg = NewtonRaphson(), linalg = nothing))
+    @test sol[1] ≈ 1.0 atol = 1.0e-6      # homotopy block continued to the physical root
+    @test sol[2] ≈ 2.0 atol = 1.0e-6      # plain block
+end
+
+@testset "the inner corrector's autodiff is honored" begin
+    # a ForwardDiff-hostile residual can only be finite-differenced; passing a finite-diff
+    # Newton as the SCC algorithm must thread that AD into the continuation's inner corrector.
+    badf(x::Float64) = x^2 - 1
+    badf(x) = throw(ArgumentError("residual differentiated by ForwardDiff (dual seen)"))
+    Hbad(u, p, λ) = [(1 - λ) * 2 * (u[1] - 1) + λ * badf(u[1])]
+    sccprob = SciMLBase.SCCNonlinearProblem(
+        (HomotopyProblem(Hbad, [-3.0]),), SciMLBase.Void{Any}.([Returns(nothing)])
+    )
+    sol_fd = solve(
+        sccprob,
+        SCCNonlinearSolve.SCCAlg(nlalg = NewtonRaphson(autodiff = AutoFiniteDiff()), linalg = nothing)
+    )
+    @test sol_fd[1] ≈ 1.0 atol = 1.0e-6
+
+    threw = false
+    try
+        solve(
+            sccprob,
+            SCCNonlinearSolve.SCCAlg(nlalg = NewtonRaphson(autodiff = AutoForwardDiff()), linalg = nothing)
+        )
+    catch
+        threw = true
+    end
+    @test threw
+end


### PR DESCRIPTION
## What

Route a `HomotopyProblem` block of an `SCCNonlinearProblem` through **continuation** instead of solving it directly at the target `λ`, and thread the SCC's own nonlinear algorithm in as the continuation's **inner corrector** so its autodiff / linear-solver choices are honored per block.

Two coordinated pieces in this monorepo:

1. **NonlinearSolveBase** — add a `HomotopyPolyAlgorithm(; inner = nothing, ...)` convenience constructor that threads a shared inner algorithm into both default stages (`HomotopySweep` and `ArcLengthContinuation`). `inner === nothing` keeps each stage's own default. (`2.36.0 → 2.37.0`, additive API, docstring updated.)

2. **SCCNonlinearSolve** — in `solve_single_scc`, when a block `prob isa HomotopyProblem`, solve it with `HomotopyPolyAlgorithm(; inner = alg.nlalg)` rather than `alg.nlalg` directly. (`1.13.3 → 1.14.0`, gains a `NonlinearSolveBase` dep.)

## Why

`solve(::HomotopyProblem, ::AbstractNonlinearSolveAlgorithm)` (SciML/NonlinearSolve.jl#1085) makes a standard nonlinear algorithm solve the block's **target-λ** system by fixing `λ = λspan[2]`. That is the right default for a bare `HomotopyProblem`, but it is *not* what a Modelica `homotopy(actual, simplified)` operator asks for: the whole point of the operator is to be **continued** from the `simplified` anchor to the `actual` system so initialization lands on the physical branch. When such a block sits inside an `SCCNonlinearProblem` (ModelingToolkit now emits homotopy blocks per-SCC, SciML/ModelingToolkit.jl#4766), the SCC solver was handing it straight to the block algorithm — silently solving the target system and, on any multi-branch residual, potentially converging to the wrong root.

Routing the block through `HomotopyPolyAlgorithm` restores continuation. Passing `alg.nlalg` as the inner corrector keeps the per-block algorithm choice (crucially its autodiff backend) intact — an OverrideInit / SCC init that selected finite differencing for a ForwardDiff-hostile residual still finite-differences inside the continuation.

## Test

`test/core_tests__item5.jl` (registered in `core_tests.jl`):

- **Branch selection proves continuation happened.** Block residual `(1-λ)·2(m-1) + λ·(m²-1)`: the target (`λ=1`) system `m²-1` has roots `±1`; from guess `m=-3` a direct Newton solve lands on the unphysical `-1` (asserted as a control), while continuation from the simplified `2(m-1)` (anchored at `+1`) reaches the physical `+1`. The SCC solve returns `+1`, so the block *must* have been continued. A neighboring plain block is unaffected.
- **Inner autodiff is honored.** A ForwardDiff-hostile residual (`badf(::Float64)` computes, `badf(::Any)` throws) is solved when the SCC algorithm carries `AutoFiniteDiff()` and throws under `AutoForwardDiff()` — confirming the block algorithm's AD reaches the continuation's inner corrector.

Verified locally against the fresh monorepo (`LinearSolve 5`): item5 green (control + 4 assertions), and the pre-existing SCC suite (items 1–4) still passes.

## Coordination

- Builds on SciML/NonlinearSolve.jl#1085 (target-λ fallback — the behavior this deliberately overrides for SCC homotopy blocks).
- Complements SciML/ModelingToolkit.jl#4766 (per-SCC homotopy routing in MTK init).
- Unblocks SciML/OrdinaryDiffEq.jl#3989: with this routing landed, the SCC `default_nlsolve` init methods can return a standard `FastShortcutNonlinearPolyalg(; autodiff)` and rely on this per-block routing to continue homotopy blocks with that autodiff, instead of falling back to `nothing`.

---

**Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
