### PR TITLE
Add FastShortcutHomotopyPolyalg, the named autodiff-aware homotopy continuation default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.22.0"
+version = "4.23.0"
 authors = ["SciML"]
 
 [deps]
@@ -98,7 +98,7 @@ NLSolvers = "0.5"
 NLsolve = "4.5"
 NaNMath = "1"
 NonlinearProblemLibrary = "0.1.2"
-NonlinearSolveBase = "2.36"
+NonlinearSolveBase = "2.37"
 NonlinearSolveFirstOrder = "2"
 NonlinearSolveQuasiNewton = "1.12"
 NonlinearSolveSpectralMethods = "1.6"

--- a/docs/src/native/solvers.md
+++ b/docs/src/native/solvers.md
@@ -57,6 +57,7 @@ HomotopySweep
 KantorovichHomotopy
 ArcLengthContinuation
 HomotopyPolyAlgorithm
+FastShortcutHomotopyPolyalg
 ```
 
 ## Nonlinear Least Squares Solvers

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -151,7 +151,7 @@ end
 @reexport using LinearSolve
 
 # Poly Algorithms
-export NonlinearSolvePolyAlgorithm, FastShortcutNonlinearPolyalg
+export NonlinearSolvePolyAlgorithm, FastShortcutNonlinearPolyalg, FastShortcutHomotopyPolyalg
 
 # Extension Algorithms
 export LeastSquaresOptimJL, FastLevenbergMarquardtJL, NLsolveJL, NLSolversJL,

--- a/src/default.jl
+++ b/src/default.jl
@@ -52,3 +52,12 @@ end
 function NonlinearSolveBase.initialization_alg(::AbstractNonlinearProblem, autodiff)
     return FastShortcutNonlinearPolyalg(; autodiff)
 end
+
+# A `HomotopyProblem` initialization system (e.g. a Modelica `homotopy` operator) must be
+# continued, not solved at the target `λ`: the `AbstractNonlinearProblem` method above would
+# hand it a plain nonlinear polyalgorithm that fixes `λ` and solves only the `actual` system
+# (see `solve(::HomotopyProblem, ::AbstractNonlinearSolveAlgorithm)`), which can land on the
+# wrong branch. Route it to the continuation default instead, carrying the same `autodiff`.
+function NonlinearSolveBase.initialization_alg(::SciMLBase.HomotopyProblem, autodiff)
+    return FastShortcutHomotopyPolyalg(; autodiff)
+end

--- a/src/poly_algs.jl
+++ b/src/poly_algs.jl
@@ -90,3 +90,49 @@ function FastShortcutNonlinearPolyalg(
     end
     return NonlinearSolvePolyAlgorithm(algs; start_index)
 end
+
+"""
+    FastShortcutHomotopyPolyalg(
+        ::Type{T} = Float64;
+        autodiff = nothing, concrete_jac = nothing, linsolve = nothing,
+        vjp_autodiff = nothing, jvp_autodiff = nothing,
+        warm_handoff::Bool = true, store_original::Val = Val(false)
+    ) where {T}
+
+The recommended default [`HomotopyPolyAlgorithm`](@ref) for solving a
+[`SciMLBase.HomotopyProblem`](@ref) — e.g. a Modelica `homotopy(actual, simplified)`
+initialization system — by continuation. It is the homotopy analogue of
+[`FastShortcutNonlinearPolyalg`](@ref): a fast [`HomotopySweep`](@ref) (natural-parameter
+continuation) escalating to a robust [`ArcLengthContinuation`](@ref) (pseudo-arclength) on
+failure, with a [`FastShortcutNonlinearPolyalg`](@ref) built from the requested `autodiff`
+threaded in as the *inner corrector* of both stages.
+
+Solving a `HomotopyProblem` with a plain nonlinear algorithm instead fixes ``λ`` at the
+target and solves only the `actual` system, which can converge to the wrong branch. This
+sweeps ``λ`` from the `simplified` anchor to the `actual` system, tracking the intended
+branch.
+
+### Arguments
+
+  - `T`: the eltype of the initial guess, forwarded to the inner
+    [`FastShortcutNonlinearPolyalg`](@ref). Defaults to `Float64`.
+
+### Keyword Arguments
+
+  - `autodiff`, `concrete_jac`, `linsolve`, `vjp_autodiff`, `jvp_autodiff`: forwarded to the
+    inner [`FastShortcutNonlinearPolyalg`](@ref) that corrects each continuation step — this
+    is where the differentiation backend is chosen. A `HomotopyProblem` whose residual is not
+    ForwardDiff-safe is solved by passing `autodiff = AutoFiniteDiff()`.
+  - `warm_handoff`, `store_original`: forwarded to [`HomotopyPolyAlgorithm`](@ref).
+"""
+function FastShortcutHomotopyPolyalg(
+        ::Type{T} = Float64;
+        autodiff = nothing, concrete_jac = nothing, linsolve = nothing,
+        vjp_autodiff = nothing, jvp_autodiff = nothing,
+        warm_handoff::Bool = true, store_original::Val = Val(false)
+    ) where {T}
+    inner = FastShortcutNonlinearPolyalg(
+        T; autodiff, concrete_jac, linsolve, vjp_autodiff, jvp_autodiff
+    )
+    return HomotopyPolyAlgorithm(; inner, warm_handoff, store_original)
+end

--- a/test/Core/homotopy_polyalg_tests__item4.jl
+++ b/test/Core/homotopy_polyalg_tests__item4.jl
@@ -1,0 +1,49 @@
+using NonlinearSolve
+using SciMLBase
+using ADTypes
+using Test
+
+const NLB = NonlinearSolve.NonlinearSolveBase
+
+# `FastShortcutHomotopyPolyalg` is the named default continuation polyalgorithm for a
+# `HomotopyProblem`: a `HomotopyPolyAlgorithm` (fast sweep, then robust arclength) whose inner
+# corrector is a `FastShortcutNonlinearPolyalg` carrying the requested autodiff. It is the
+# homotopy analogue of `FastShortcutNonlinearPolyalg`.
+
+# branch selection: the target (λ = 1) system m² - 1 has roots ±1; from guess m = -3 a plain
+# Newton solve of that system lands on the unphysical -1, while continuation from the
+# simplified 2(m - 1) (anchored at +1) reaches the physical +1. A solve that returns +1 must
+# therefore have been continued, not target-λ solved.
+Hbranch(u, p, λ) = [(1 - λ) * 2 * (u[1] - 1) + λ * (u[1]^2 - 1)]
+
+@testset "FastShortcutHomotopyPolyalg wiring" begin
+    alg = FastShortcutHomotopyPolyalg()
+    @test alg isa NLB.HomotopyPolyAlgorithm
+    @test length(alg.algs) == 2
+    @test alg.algs[1] isa NLB.HomotopySweep
+    @test alg.algs[2] isa NLB.ArcLengthContinuation
+    # the inner corrector of each stage is the FastShortcut nonlinear polyalgorithm
+    @test alg.algs[1].inner isa NonlinearSolvePolyAlgorithm
+    @test alg.algs[2].inner isa NonlinearSolvePolyAlgorithm
+end
+
+@testset "FastShortcutHomotopyPolyalg continues to the physical branch" begin
+    prob = HomotopyProblem(Hbranch, [-3.0])
+    sol = solve(prob, FastShortcutHomotopyPolyalg())
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[1] ≈ 1.0 atol = 1.0e-6
+    # a plain nonlinear algorithm solves only the target (λ = 1) system -> unphysical -1
+    @test solve(prob, NewtonRaphson()).u[1] ≈ -1.0 atol = 1.0e-6
+    # the finite-diff configuration is accepted and solves end-to-end
+    sol_fd = solve(prob, FastShortcutHomotopyPolyalg(; autodiff = AutoFiniteDiff()))
+    @test sol_fd.u[1] ≈ 1.0 atol = 1.0e-6
+end
+
+@testset "initialization_alg(::HomotopyProblem) routes to continuation" begin
+    prob = HomotopyProblem(Hbranch, [-3.0])
+    # the AbstractNonlinearProblem fallback would return a FastShortcutNonlinearPolyalg, which
+    # target-λ solves the block -> wrong branch. The HomotopyProblem method must continue.
+    alg = NLB.initialization_alg(prob, AutoForwardDiff())
+    @test alg isa NLB.HomotopyPolyAlgorithm
+    @test solve(prob, alg).u[1] ≈ 1.0 atol = 1.0e-6
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,7 +106,8 @@ else
             @time @safetestset "Homotopy drivers retain the winning inner subalgorithm" include("Core/homotopy_retention_tests__item1.jl")
             @time @safetestset "HomotopyPolyAlgorithm stages, fallback, both-fail" include("Core/homotopy_polyalg_tests__item1.jl")
             @time @safetestset "HomotopyPolyAlgorithm warm sweep→fallback handoff" include("Core/homotopy_polyalg_tests__item2.jl")
-            return @time @safetestset "HomotopyProblem + standard nonlinear alg routes to continuation" include("Core/homotopy_polyalg_tests__item3.jl")
+            @time @safetestset "HomotopyProblem + standard nonlinear alg routes to continuation" include("Core/homotopy_polyalg_tests__item3.jl")
+            return @time @safetestset "FastShortcutHomotopyPolyalg + homotopy initialization_alg" include("Core/homotopy_polyalg_tests__item4.jl")
         end,
         groups = Dict(
             "PolyAlgorithms" => function ()


### PR DESCRIPTION
## What

Add `FastShortcutHomotopyPolyalg` — the named, autodiff-aware default continuation polyalgorithm for a `SciMLBase.HomotopyProblem`, the homotopy analogue of `FastShortcutNonlinearPolyalg`. It builds a `FastShortcutNonlinearPolyalg` from the requested `autodiff` and threads it in as the inner corrector of a `HomotopyPolyAlgorithm` (fast `HomotopySweep`, then robust `ArcLengthContinuation` on failure):

```julia
FastShortcutHomotopyPolyalg(; autodiff = AutoFiniteDiff())
# ≡ HomotopyPolyAlgorithm(; inner = FastShortcutNonlinearPolyalg(; autodiff = AutoFiniteDiff()))
```

- Defined in top-level `src/poly_algs.jl` (next to `FastShortcutNonlinearPolyalg`), exported, docstring'd, and added to the rendered docs (`docs/src/native/solvers.md`).
- Wired as the homotopy **initialization default**: `initialization_alg(::HomotopyProblem, autodiff)` now returns it (`src/default.jl`).

## Why

Until now the homotopy solve/init default was the bare `HomotopyPolyAlgorithm()` (each stage's own default inner), with no discoverable, autodiff-aware entry point paralleling `FastShortcutNonlinearPolyalg`. Downstream code (OrdinaryDiffEq init) had to hand-roll `HomotopyPolyAlgorithm((HomotopySweep(; inner), ArcLengthContinuation(; inner)))` with `inner = FastShortcutNonlinearPolyalg(; autodiff)`. This gives that construction a name.

It also closes a real gap in the init dispatch: `initialization_alg(::AbstractNonlinearProblem, autodiff)` returns a plain `FastShortcutNonlinearPolyalg`, and since `HomotopyProblem <: AbstractNonlinearProblem`, a homotopy initialization system hitting that fallback would be handed a standard nonlinear algorithm — which fixes `λ` at the target and solves only the `actual` system (`solve(::HomotopyProblem, ::AbstractNonlinearSolveAlgorithm)`), and can converge to the wrong branch. The new `initialization_alg(::HomotopyProblem, …)` method routes it to continuation instead, carrying the same `autodiff`. (An `SCCNonlinearProblem` init that *contains* homotopy blocks stays on the generic `FastShortcutNonlinearPolyalg` method — SCCNonlinearSolve #1104 continues those blocks per-block — so only the bare `HomotopyProblem` needed the override.)

## Test

`test/Core/homotopy_polyalg_tests__item4.jl`:

- **Wiring**: `FastShortcutHomotopyPolyalg()` is a `HomotopyPolyAlgorithm` of `(HomotopySweep, ArcLengthContinuation)`, each stage's `inner` a `NonlinearSolvePolyAlgorithm`.
- **Branch selection proves continuation**: block `(1-λ)·2(m-1) + λ·(m²-1)`; from guess `m=-3` the solve returns the physical `+1` (a plain `NewtonRaphson` returns the target-λ `-1`, asserted as control). The finite-diff configuration solves the same problem end-to-end.
- **Init routing**: `initialization_alg(::HomotopyProblem, autodiff)` returns a `HomotopyPolyAlgorithm` (not a `FastShortcutNonlinearPolyalg`) and reaches `+1`.

Verified locally against the fresh monorepo (`LinearSolve 5`, `NonlinearSolveBase 2.37`).

## Notes

- Uses `HomotopyPolyAlgorithm(; inner)` from NonlinearSolveBase 2.37 (SciML/NonlinearSolve.jl#1104, merged); top-level compat bumped `2.36 → 2.37`.
- Follow-up: SciML/OrdinaryDiffEq.jl#3989's `_homotopy_init_alg` collapses to `FastShortcutHomotopyPolyalg(; autodiff)` once this releases.

---

**Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
