### PR TITLE
Document SICNM in the nonlinear solver guide (#330)

### DIFF
--- a/docs/src/native/steadystatediffeq.md
+++ b/docs/src/native/steadystatediffeq.md
@@ -22,4 +22,5 @@ Pages = ["steadystatediffeq.md"]
 ```@docs
 DynamicSS
 SSRootfind
+SICNM
 ```

--- a/docs/src/solvers/nonlinear_system_solvers.md
+++ b/docs/src/solvers/nonlinear_system_solvers.md
@@ -21,6 +21,14 @@ attempts a set of the most robust methods in succession and only fails if all of
 fail to converge. Additionally, [`DynamicSS`](@ref) can be a good choice for high stability
 if the root corresponds to a stable equilibrium.
 
+For ill-conditioned problems where even the robust Newton-type methods diverge — such as
+power-flow equations — [`SICNM`](@ref) (the semi-implicit continuous Newton method) is a
+strong fallback. It reformulates `f(u) = 0` as a differential-algebraic equation whose
+equilibrium is the root and drives it to steady state with a stiffly stable ODE solver, so
+it converges from starting points where a direct Newton step would overshoot the basin of
+attraction. It is more expensive per solve than the direct methods, so it is best reserved
+for the hard, ill-conditioned cases rather than used as a default.
+
 As a balance, [`NewtonRaphson`](@ref) is a good choice for most problems that aren't too
 difficult yet need high performance, and  [`TrustRegion`](@ref) is a bit less performant but
 more stable. If the problem is well-conditioned, [`Klement`](@ref) or [`Broyden`](@ref) may
@@ -121,6 +129,13 @@ often more computationally expensive than direct methods.
     terminates when close to the steady state.
   - [`SSRootfind()`](@ref): Uses a NonlinearSolve compatible solver to find the steady
     state.
+  - [`SICNM()`](@ref): The semi-implicit continuous Newton method. Reformulates the
+    nonlinear system as a differential-algebraic equation, `ẏ = z, 0 = J(y) z + f(y)`, and
+    integrates it to steady state with a stiffly stable ODE solver. Highly robust on
+    ill-conditioned problems where Newton-type methods diverge (e.g. power flow); more
+    expensive than direct methods, so best used as a robustness fallback. The recommended
+    ODE engine is `Rodas3d` (constructed for this method) or another stiffly accurate
+    Rosenbrock method such as `Rodas5P`: `SICNM(Rodas3d())`.
 
 ### NLsolve.jl
 


### PR DESCRIPTION
> [!NOTE]
> This PR is part of an agent-assisted workflow. Please ignore until it has been reviewed by @ChrisRackauckas.

# Document SICNM in the NonlinearSolve solver guide

Closes the documentation side of #330. The semi-implicit continuous Newton method (SICNM) from that issue was implemented in SciML/SteadyStateDiffEq.jl#142 (with its `Rodas3d` ODE engine in SciML/OrdinaryDiffEq.jl#3931); this documents it here so users choosing a solver can find it.

## Changes

- **`docs/src/native/steadystatediffeq.md`** — add `SICNM` to the SteadyStateDiffEq solver-API `@docs` block (next to `DynamicSS`/`SSRootfind`).
- **`docs/src/solvers/nonlinear_system_solvers.md`** —
  - In *Recommended Methods*, add SICNM as the robustness fallback for ill-conditioned problems where even the robust Newton-type methods diverge (e.g. power flow), noting it's more expensive per solve and best reserved for the hard cases.
  - In the *SteadyStateDiffEq.jl* full-list section, add the `SICNM()` entry describing the DAE reformulation `ẏ = z, 0 = J(y)z + f(y)` and recommending `Rodas3d` (or `Rodas5P`) as the ODE engine: `SICNM(Rodas3d())`.

## What SICNM is (for reviewers)

It reformulates `f(u) = 0` as an index-1 DAE whose equilibrium is the root and integrates it to steady state with a stiffly stable Rosenbrock method, terminating on the residual. Newton's method is exactly explicit Euler on this same continuous-Newton flow, so integrating it implicitly with step-size control converges from starting points where a direct Newton step overshoots the basin of attraction. Benchmarks (in SciML/SteadyStateDiffEq.jl#142) show it solving classic Newton-divergent problems (atan from a far start, Powell badly scaled, near-singular Chandrasekhar) and confirm it is a robustness fallback, not a default — direct methods are cheaper when they converge.

## Note on CI

The `@docs SICNM` entry renders once **SteadyStateDiffEq ≥ 2.13.0** (which exports `SICNM`, merged in #142) is registered in General; the registry currently tops out at 2.11.3, so the docs build here is expected to stay red until that release is registered. The docs `[compat]` already allows it (`SteadyStateDiffEq = "2"`), so no further change is needed once it lands. Verified locally that `SICNM` is exported and carries a full docstring at 2.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
