### PR TITLE
Skip flaky bad_broyden Generalized Rosenbrock test (#1083)

### DIFF
--- a/test/Core/23_test_problems_tests__item7.jl
+++ b/test/Core/23_test_problems_tests__item7.jl
@@ -11,7 +11,14 @@ alg_ops = (
 
 broken_tests = Dict(alg => Int[] for alg in alg_ops)
 broken_tests[alg_ops[2]] = [1, 5, 8, 11, 18]
-broken_tests[alg_ops[4]] = [1, 5, 6, 11]
+broken_tests[alg_ops[4]] = [5, 6, 11]
+
+# Problem #1 (Generalized Rosenbrock) with bad_broyden + true_jacobian sits on a
+# knife-edge: ulp-level differences in the Jacobian inverse initialization flip it
+# between converging and not, so it randomly passes and fails. Skip rather than mark
+# broken, since an unexpected pass would also error. See SciML/NonlinearSolve.jl#1083.
+skip_tests = Dict(alg => Int[] for alg in alg_ops)
+skip_tests[alg_ops[4]] = [1]
 if Sys.isapple()
     broken_tests[alg_ops[1]] = [1, 5, 11]
     broken_tests[alg_ops[3]] = [1, 5, 6, 9, 11]
@@ -29,4 +36,4 @@ else
     broken_tests[alg_ops[5]] = [1, 5, 11]
 end
 
-test_on_library(problems, dicts, alg_ops, broken_tests, 1.0e-3)
+test_on_library(problems, dicts, alg_ops, broken_tests, 1.0e-3; skip_tests)


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.**

Fixes #1083.

### Problem

`test/Core/23_test_problems_tests__item7.jl`, problem #1 (Generalized Rosenbrock) solved with

```julia
Broyden(; init_jacobian = Val(:true_jacobian), update_rule = Val(:bad_broyden))
```

(alg #4) sits on a knife-edge. As noted in the issue, #1039 changed the quasi-Newton Jacobian-inverse initialization from `inv!(lu(A))` to `linsolve_identity!!` (solving `A·X = I`). The resulting ulp-level difference (~1e-13) flips this problem between converging and not converging, so it **randomly passes and fails**.

Marking it `broken` isn't sufficient: when it happens to converge, `@test ... broken=true` errors as an *unexpected pass*. So neither `broken=true` nor `broken=false` gives a stable result.

### Fix

Use the harness's existing `skip_tests` mechanism (already supported by `test_on_library` in `setup_robustnesstesting.jl`) to skip this single case, and remove problem #1 from `broken_tests[alg_ops[4]]` so it isn't double-counted.

### Verification

Ran the file locally (Julia 1.12):

```
Test Summary: | Pass  Broken  Total   Time
Broyden item7 |   95      20    115  29.6s
```

0 failures, 0 errors.