### PR TITLE
Bump NonlinearSolve subpackage versions

### DIFF
--- a/lib/BracketingNonlinearSolve/Project.toml
+++ b/lib/BracketingNonlinearSolve/Project.toml
@@ -1,6 +1,6 @@
 name = "BracketingNonlinearSolve"
 uuid = "70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
-version = "1.12.3"
+version = "1.12.4"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveFirstOrder/Project.toml
+++ b/lib/NonlinearSolveFirstOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveFirstOrder"
 uuid = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "2.2.2"
+version = "2.2.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/NonlinearSolveQuasiNewton/Project.toml
+++ b/lib/NonlinearSolveQuasiNewton/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveQuasiNewton"
 uuid = "9a2c21bd-3a47-402d-9113-8faf9a0ee114"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.14.1"
+version = "1.14.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/NonlinearSolveSpectralMethods/Project.toml
+++ b/lib/NonlinearSolveSpectralMethods/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveSpectralMethods"
 uuid = "26075421-4e9a-44e1-8bd1-420ed7ad02b2"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.7.3"
+version = "1.7.4"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/SimpleNonlinearSolve/Project.toml
+++ b/lib/SimpleNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleNonlinearSolve"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 authors = ["SciML"]
-version = "2.13.0"
+version = "2.13.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Bumps the following subpackages so their accumulated unreleased `src/` changes can be registered:

- `BracketingNonlinearSolve` v1.12.3 → **v1.12.4** (patch) — Enable rendered public API docs QA (#1090) (docs/QA/compat/internal; no public API or behavior break)
- `NonlinearSolveFirstOrder` v2.2.2 → **v2.2.3** (patch) — Enable rendered public API docs QA (#1090) (docs/QA/compat/internal; no public API or behavior break)
- `NonlinearSolveQuasiNewton` v1.14.1 → **v1.14.2** (patch) — Enable rendered public API docs QA (#1090) (docs/QA/compat/internal; no public API or behavior break)
- `NonlinearSolveSpectralMethods` v1.7.3 → **v1.7.4** (patch) — Enable rendered public API docs QA (#1090) (docs/QA/compat/internal; no public API or behavior break)
- `SimpleNonlinearSolve` v2.13.0 → **v2.13.1** (patch) — Enable rendered public API docs QA (#1090) (docs/QA/compat/internal; no public API or behavior break)

Each bump reflects the semantic level of its diff (patch unless new public API was added). Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)