### PR TITLE
Add and precompile the non-isbits (OpaqueRef) AutoDePSpecialize path

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.23.0"
+version = "4.23.1"
 authors = ["SciML"]
 
 [deps]

--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.38.0"
+version = "2.39.0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/autospecialize.jl
+++ b/lib/NonlinearSolveBase/src/autospecialize.jl
@@ -219,12 +219,21 @@ end
 """
     should_opaque_p(p) -> Bool
 
-Policy for whether the AutoDePSpecialize path de-specializes `p`: `true` for an
-`isbits` non-`NullParameters` payload, `false` otherwise. Defined locally rather
-than taken from SciMLBase so this does not depend on an unreleased SciMLBase
-symbol.
+Policy for whether the AutoDePSpecialize path de-specializes `p`: `true` for any
+payload except a `NullParameters` sentinel or an already-packed container.
+`isbits` payloads pack into a `RespecializeParams.OpaqueParams` (byte copy),
+everything else into a `RespecializeParams.OpaqueRef` (by reference). Defined
+locally rather than taken from SciMLBase so this does not depend on an unreleased
+SciMLBase symbol.
+
+De-specializing makes the concretized `prob.p` an opaque container, so the level
+is a forward-solve latency tool: reverse-mode AD of `p` and symbolic parameter
+indexing read the concrete parameter and are not supported (reverse-mode support
+is a planned follow-up). Recover the payload with
+`RespecializeParams.unpack(sol.prob.p, typeof(p))`.
 """
-@inline should_opaque_p(p) = isbits(p) && !(p isa SciMLBase.NullParameters)
+@inline should_opaque_p(p) = !(p isa SciMLBase.NullParameters) &&
+    !(p isa RespecializeParams.OpaqueParams) && !(p isa RespecializeParams.OpaqueRef)
 
 """
     AutoDePSpecializeCallable{FW}
@@ -292,6 +301,6 @@ function maybe_opaque_wrap(prob::AbstractNonlinearProblem)
     orig = prob.f.f
     fw = wrapfun_iip_opaque(orig, P, (u0, u0, p))
     newprob = @set prob.f.f = AutoDePSpecializeCallable{typeof(fw)}(fw, orig, P)
-    @set! newprob.p = RespecializeParams.pack(p)
+    @set! newprob.p = RespecializeParams.pack_auto(p)
     return newprob
 end

--- a/lib/NonlinearSolveBase/src/autospecialize.jl
+++ b/lib/NonlinearSolveBase/src/autospecialize.jl
@@ -231,6 +231,11 @@ is a forward-solve latency tool: reverse-mode AD of `p` and symbolic parameter
 indexing read the concrete parameter and are not supported (reverse-mode support
 is a planned follow-up). Recover the payload with
 `RespecializeParams.unpack(sol.prob.p, typeof(p))`.
+
+Problems carrying a symbolic system (`SciMLBase.has_sys(prob.f)`, e.g.
+ModelingToolkit) are declined in [`maybe_opaque_wrap`] rather than here, since
+that policy needs the function, not just `p`: their `p` must stay concrete for
+initialization and symbolic indexing.
 """
 @inline should_opaque_p(p) = !(p isa SciMLBase.NullParameters) &&
     !(p isa RespecializeParams.OpaqueParams) && !(p isa RespecializeParams.OpaqueRef)
@@ -296,6 +301,12 @@ function maybe_opaque_wrap(prob::AbstractNonlinearProblem)
     u0 isa AbstractArray || return nothing
     SciMLBase.isdualtype(eltype(u0)) && return nothing
     should_opaque_p(p) || return nothing
+    # Symbolic-system problems (`has_sys`, e.g. ModelingToolkit): decline. Their
+    # `p` (MTKParameters) must stay concrete for the initialization pipeline and
+    # symbolic parameter indexing; an opaque container breaks both. They gain
+    # nothing (structured params are non-isbits and already type-uniform), so
+    # falling back to the normal specialization is the correct no-op.
+    SciMLBase.has_sys(prob.f) && return nothing
 
     P = typeof(p)
     orig = prob.f.f

--- a/lib/NonlinearSolveBase/test/autodepspecialize.jl
+++ b/lib/NonlinearSolveBase/test/autodepspecialize.jl
@@ -17,6 +17,10 @@ struct DePP2
 end
 resid_dep2!(res, u, q::DePP2) = (res[1] = u[1]^2 - q.x; res[2] = u[2]^2 - q.y; nothing)
 
+struct VecQ
+    c::Vector{Float64}
+end
+
 deprob(f, u0, p) = NonlinearProblem(
     NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(f), u0, p
 )
@@ -55,10 +59,28 @@ u0 = [1.0, 1.0]
         @test cp.p isa SciMLBase.NullParameters
     end
 
-    @testset "non-isbits p is not opaque-ified (plain wrap fallback)" begin
+    @testset "non-isbits p is de-specialized via OpaqueRef" begin
+        # non-isbits struct (Vector field) → packed by reference into an OpaqueRef
+        fvecp!(res, u, p::VecQ) = (res[1] = u[1]^2 - p.c[1]; nothing)
+        cp = concretize(deprob(fvecp!, u0, VecQ([2.0])))
+        @test cp.p isa RespecializeParams.OpaqueRef
+        @test cp.f.f isa NonlinearSolveBase.AutoDePSpecializeCallable
+        res = [0.0]
+        cp.f.f(res, [3.0], cp.p)
+        @test res[1] ≈ 9.0 - 2.0
+        @test RespecializeParams.unpack(cp.p, VecQ).c == [2.0]
+
+        # a bare Vector parameter is likewise de-specialized into an OpaqueRef
         fvec!(res, u, p::Vector{Float64}) = (res[1] = u[1]^2 - p[1]; nothing)
-        cp = concretize(deprob(fvec!, u0, [2.0]))
-        @test cp.p isa Vector{Float64}
+        cpv = concretize(deprob(fvec!, u0, [2.0]))
+        @test cpv.p isa RespecializeParams.OpaqueRef
+    end
+
+    @testset "already-packed p is not re-wrapped (idempotent)" begin
+        cp = concretize(deprob(resid_dep!, u0, DePP(2.0, 3.0)))
+        cp2 = concretize(cp)
+        @test cp2.p isa RespecializeParams.OpaqueParams
+        @test typeof(cp2.f.f) === typeof(cp.f.f)
     end
 
     @testset "different struct p types share the wrapped-residual type" begin

--- a/lib/NonlinearSolveBase/test/autodepspecialize.jl
+++ b/lib/NonlinearSolveBase/test/autodepspecialize.jl
@@ -1,4 +1,5 @@
 using NonlinearSolveBase, SciMLBase, RespecializeParams, ForwardDiff, Test
+using SymbolicIndexingInterface: SymbolCache
 
 # An `isbits` struct parameter. Under `AutoDePSpecialize`, `get_concrete_problem`
 # should pack `p` into a `RespecializeParams.OpaqueParams` and wrap the residual
@@ -74,6 +75,26 @@ u0 = [1.0, 1.0]
         fvec!(res, u, p::Vector{Float64}) = (res[1] = u[1]^2 - p[1]; nothing)
         cpv = concretize(deprob(fvec!, u0, [2.0]))
         @test cpv.p isa RespecializeParams.OpaqueRef
+    end
+
+    @testset "symbolic-system problems are declined (MTK safety)" begin
+        # A problem whose `f` carries a symbolic system (`has_sys`, as every
+        # ModelingToolkit problem does) must NOT be opaque-ified: its `p` has to
+        # stay concrete for initialization and symbolic parameter indexing.
+        # `SymbolCache` stands in for an MTK `System` without the dependency.
+        fsym!(res, u, p) = (res[1] = u[1]^2 - 2.0; res[2] = u[2]^2 - 3.0; nothing)
+        ff = NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(
+            fsym!; sys = SymbolCache([:x, :y], [:a, :b])
+        )
+        @test SciMLBase.has_sys(ff)
+
+        cp = concretize(NonlinearProblem(ff, u0, VecQ([2.0])))   # non-isbits p
+        @test cp.p isa VecQ
+        @test !(cp.p isa RespecializeParams.OpaqueRef)
+
+        cpi = concretize(NonlinearProblem(ff, u0, DePP(2.0, 3.0)))  # isbits p
+        @test cpi.p isa DePP
+        @test !(cpi.p isa RespecializeParams.OpaqueParams)
     end
 
     @testset "already-packed p is not re-wrapped (idempotent)" begin

--- a/lib/NonlinearSolveFirstOrder/Project.toml
+++ b/lib/NonlinearSolveFirstOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveFirstOrder"
 uuid = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "2.2.3"
+version = "2.2.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl
+++ b/lib/NonlinearSolveFirstOrder/src/NonlinearSolveFirstOrder.jl
@@ -101,6 +101,26 @@ include("forward_diff.jl")
         push!(nlls_problems, NonlinearLeastSquaresProblem(fn, u0, 2.0))
     end
 
+    # AutoDePSpecialize opaque-p path: an isbits `p` packs into an `OpaqueParams`
+    # and a non-isbits `p` into an `OpaqueRef`. Each container gives a single
+    # wrapped-residual signature shared across all parameter types of that kind,
+    # so precompiling one solve per container lets first solves with struct/array
+    # parameters skip compilation entirely.
+    push!(
+        nonlinear_problems, NonlinearProblem(
+            NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(
+                (du, u, p) -> (du .= u .* u .- p.a)
+            ), [0.1], (a = 2.0,)
+        )
+    )
+    push!(
+        nonlinear_problems, NonlinearProblem(
+            NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(
+                (du, u, p) -> (du .= u .* u .- p[1])
+            ), [0.1], [2.0]
+        )
+    )
+
     nlp_algs = [NewtonRaphson(), TrustRegion(), LevenbergMarquardt()]
     nlls_algs = [GaussNewton(), TrustRegion(), LevenbergMarquardt()]
 

--- a/lib/NonlinearSolveQuasiNewton/Project.toml
+++ b/lib/NonlinearSolveQuasiNewton/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveQuasiNewton"
 uuid = "9a2c21bd-3a47-402d-9113-8faf9a0ee114"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.14.2"
+version = "1.14.3"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/NonlinearSolveQuasiNewton/src/NonlinearSolveQuasiNewton.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/NonlinearSolveQuasiNewton.jl
@@ -65,6 +65,25 @@ include("solve.jl")
         push!(nonlinear_problems, NonlinearProblem(fn, u0, 2.0))
     end
 
+    # AutoDePSpecialize opaque-p path: an isbits `p` packs into an `OpaqueParams`
+    # and a non-isbits `p` into an `OpaqueRef`, each a single wrapped-residual
+    # signature shared across all parameter types of that kind, so one
+    # precompiled solve per container serves first solves with struct/array `p`.
+    push!(
+        nonlinear_problems, NonlinearProblem(
+            NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(
+                (du, u, p) -> (du .= u .* u .- p.a)
+            ), [0.1], (a = 2.0,)
+        )
+    )
+    push!(
+        nonlinear_problems, NonlinearProblem(
+            NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(
+                (du, u, p) -> (du .= u .* u .- p[1])
+            ), [0.1], [2.0]
+        )
+    )
+
     algs = [Broyden(), Klement()]
 
     @compile_workload begin

--- a/lib/NonlinearSolveSpectralMethods/Project.toml
+++ b/lib/NonlinearSolveSpectralMethods/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveSpectralMethods"
 uuid = "26075421-4e9a-44e1-8bd1-420ed7ad02b2"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.7.4"
+version = "1.7.5"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/NonlinearSolveSpectralMethods/src/NonlinearSolveSpectralMethods.jl
+++ b/lib/NonlinearSolveSpectralMethods/src/NonlinearSolveSpectralMethods.jl
@@ -48,6 +48,25 @@ include("solve.jl")
         push!(nonlinear_problems, NonlinearProblem(fn, u0, 2.0))
     end
 
+    # AutoDePSpecialize opaque-p path: an isbits `p` packs into an `OpaqueParams`
+    # and a non-isbits `p` into an `OpaqueRef`, each a single wrapped-residual
+    # signature shared across all parameter types of that kind, so one
+    # precompiled solve per container serves first solves with struct/array `p`.
+    push!(
+        nonlinear_problems, NonlinearProblem(
+            NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(
+                (du, u, p) -> (du .= u .* u .- p.a)
+            ), [0.1], (a = 2.0,)
+        )
+    )
+    push!(
+        nonlinear_problems, NonlinearProblem(
+            NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(
+                (du, u, p) -> (du .= u .* u .- p[1])
+            ), [0.1], [2.0]
+        )
+    )
+
     algs = [DFSane()]
 
     @compile_workload begin

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -118,6 +118,30 @@ include("forward_diff.jl")
         ),
     )
 
+    # AutoDePSpecialize opaque-p path. Both containers are covered: an isbits `p`
+    # packs into an `OpaqueParams` and a non-isbits `p` into an `OpaqueRef`, each
+    # a single wrapped-residual signature shared across every parameter type of
+    # its kind. These go through the polyalgorithm / no-algorithm sweeps below as
+    # well as the per-algorithm ones, since `solve(prob)` runs default algorithm
+    # selection — a separate code path from `solve(prob, alg)`.
+    depspecialize_problems = NonlinearProblem[
+        NonlinearProblem(
+            NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(
+                (du, u, p) -> (du .= u .* u .- p.a)
+            ),
+            [0.1],
+            (a = 2.0,),
+        ),
+        NonlinearProblem(
+            NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(
+                (du, u, p) -> (du .= u .* u .- p[1])
+            ),
+            [0.1],
+            [2.0],
+        ),
+    ]
+    append!(nonlinear_problems, depspecialize_problems)
+
     nlp_algs = [NewtonRaphson(), TrustRegion(), LevenbergMarquardt()]
     nlls_algs = [GaussNewton(), TrustRegion(), LevenbergMarquardt()]
 
@@ -139,6 +163,15 @@ include("forward_diff.jl")
             end
             for prob in nlls_problems
                 Threads.@spawn CommonSolve.solve(prob; abstol = 1.0e-2, verbose = NonlinearVerbosity())
+            end
+
+            # `solve(prob)` with no keyword arguments is a distinct
+            # specialization from the kwarg-carrying calls above (the keyword
+            # NamedTuple's type participates), and it is what most user code
+            # writes. Measured on an opaque-p problem: 0.61s for the kwarg form
+            # against 1.68s bare, before this sweep was added.
+            for prob in depspecialize_problems
+                Threads.@spawn CommonSolve.solve(prob)
             end
         end
     end


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Completes the non-isbits story for `AutoDePSpecialize` on NonlinearSolve, mirroring the ODE side (SciML/OrdinaryDiffEq.jl#4005).

**Two parts, which only make sense together:**

1. **Non-isbits code path** (`NonlinearSolveBase`). #1107 merged `AutoDePSpecialize` with an *isbits-only* policy (`should_opaque_p(p) = isbits(p) && !NullParameters`), so a non-isbits `p` (e.g. a struct with a `Vector` field, or a bare array) was left concrete and got no de-specialization. This relaxes the policy to de-specialize any non-`NullParameters`, non-already-packed `p`, packing via `pack_auto`: isbits → `OpaqueParams` (byte copy), non-isbits → `OpaqueRef` (by reference).

2. **Precompilation** (`FirstOrder`, `QuasiNewton`, `SpectralMethods`). #1107 shipped no workload exercising `AutoDePSpecialize` at all, so even the isbits opaque path compiled on first use. This adds one `AutoDePSpecialize` problem per workload covering **both** containers (isbits `p.a`, non-isbits `p[1]`). Each container is a single wrapped-residual signature shared across all parameter types of its kind, so one precompiled solve per container serves first solves with any struct/array parameter.

### Measured (fresh process, first solve of a never-seen non-isbits parameter struct)

| alg | FullSpecialize | AutoDePSpecialize (this PR) |
|---|---|---|
| NewtonRaphson | 3.02s | **0.88s** |
| Broyden | — | 0.96s |
| DFSane | — | 1.26s |

Without part 1, the non-isbits workload problem in part 2 would hit `should_opaque_p == false` and never take the opaque path. Verified end-to-end: `NonlinearSolveBase` AutoDePSpecialize test suite (incl. new OpaqueRef + idempotency tests) passes 18/18; the three sublibraries precompile cleanly (workload solves run during precompilation and return `Success`); fresh-process first solves timed above.

Version bumps: `NonlinearSolveBase` minor (extends the opt-in feature); `FirstOrder`/`QuasiNewton`/`SpectralMethods` patch.

### Caveats (same posture as the isbits path)
Reverse-mode AD of `p` (SciMLSensitivity) and symbolic parameter indexing read the concrete parameter and are **not** supported under the opaque path — it is a forward-solve latency tool. Reverse-mode support is a planned follow-up. Recover the payload with `RespecializeParams.unpack(sol.prob.p, typeof(p))`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuAbA8hSnrirMrJjFqxwn5