### PR TITLE
Fix the three QA failures on master (explicit import, piracy whitelist, check_reexports)

### DIFF
--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -10,7 +10,7 @@ using CommonSolve: CommonSolve, init, solve, solve!
 using LinearAlgebra: LinearAlgebra
 using LineSearch: BackTracking
 using NonlinearSolveBase: NonlinearSolveBase, AbstractNonlinearSolveAlgorithm,
-    NonlinearSolvePolyAlgorithm, pickchunksize, NonlinearVerbosity
+    NonlinearSolvePolyAlgorithm, HomotopyPolyAlgorithm, pickchunksize, NonlinearVerbosity
 
 using SciMLBase: SciMLBase, ReturnCode, AbstractNonlinearProblem,
     NonlinearFunction,

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -13,9 +13,31 @@ const NONLINEARSOLVE_EXTERNAL_REEXPORTS = union(
     (:ADTypes, :SciMLBase, :LineSearch, :LinearSolve),
 )
 
+# NonlinearSolve is a facade: it deliberately re-exports the whole solver stack, so every
+# public name of a sublibrary (and the sublibrary module names themselves) is an intended
+# public re-export rather than an accidental one. This is the allow-list for
+# `check_reexports`; the external re-exports above are intended in the same way.
+const NONLINEARSOLVE_SUBLIBRARY_REEXPORTS = union(
+    public_api_names(NonlinearSolve.NonlinearSolveBase),
+    public_api_names(NonlinearSolve.NonlinearSolveFirstOrder),
+    public_api_names(NonlinearSolve.NonlinearSolveSpectralMethods),
+    public_api_names(NonlinearSolve.NonlinearSolveQuasiNewton),
+    public_api_names(NonlinearSolve.SimpleNonlinearSolve),
+    public_api_names(NonlinearSolve.BracketingNonlinearSolve),
+    (
+        :NonlinearSolveBase, :NonlinearSolveFirstOrder, :NonlinearSolveSpectralMethods,
+        :NonlinearSolveQuasiNewton, :SimpleNonlinearSolve, :BracketingNonlinearSolve,
+    ),
+)
+
+const NONLINEARSOLVE_ALLOWED_REEXPORTS = union(
+    NONLINEARSOLVE_EXTERNAL_REEXPORTS, NONLINEARSOLVE_SUBLIBRARY_REEXPORTS
+)
+
 run_qa(
     NonlinearSolve;
     explicit_imports = true,
+    reexports_allow = NONLINEARSOLVE_ALLOWED_REEXPORTS,
     aqua_kwargs = (;
         # stale_deps / deps_compat are checked on the SimpleNonlinearSolve facade
         # below (with the SciMLJacobianOperators ignore); persistent_tasks stays off
@@ -28,6 +50,9 @@ run_qa(
             treat_as_own = [
                 NonlinearProblem, NonlinearLeastSquaresProblem,
                 SciMLBase.AbstractNonlinearProblem,
+                # `initialization_alg` is dispatched here for the continuation problem
+                # type too, alongside the `AbstractNonlinearProblem` method above.
+                SciMLBase.HomotopyProblem,
                 SimpleNonlinearSolve.AbstractSimpleNonlinearSolveAlgorithm,
             ],
         ),


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR should be ignored until reviewed by @ChrisRackauckas.**

Fixes the `tests / QA` job on master, which has been failing with `16 passed, 2 failed, 1 errored`. Three failures, two unrelated causes — none of them a defect in shipped behavior:

| Failure | Cause | Fix |
|---|---|---|
| `no_implicit_imports` — `HomotopyPolyAlgorithm` at `src/poly_algs.jl:137` | #1105 used the name via a reexport rather than an explicit import | add it to the `using NonlinearSolveBase: ...` list |
| `Piracy` — `initialization_alg(::SciMLBase.HomotopyProblem, autodiff)` at `src/default.jl:61` | #1105 added the continuation-problem dispatch; the sibling `AbstractNonlinearProblem` method was already whitelisted, this one wasn't | add `SciMLBase.HomotopyProblem` to the existing `piracies.treat_as_own` |
| `No unapproved public reexports` | **dependency bump, not a code change**: SciMLTesting 2.3.0 → 2.4.0 added `check_reexports` defaulting to `true`. First failing run was `b92a835e` (2026-07-21), the first to resolve 2.4.0 | pass `reexports_allow` — NonlinearSolve is a facade that deliberately reexports the whole stack |

For the third one I built the allow-list the same way the file already builds its docs-check ignore list: the public API names of each sublibrary (`NonlinearSolveBase`, `NonlinearSolveFirstOrder`, `NonlinearSolveSpectralMethods`, `NonlinearSolveQuasiNewton`, `SimpleNonlinearSolve`, `BracketingNonlinearSolve`) plus the module names, unioned with the existing external-reexport set (ADTypes/SciMLBase/LineSearch/LinearSolve). That keeps the check meaningful — an *accidental* public reexport from some other package would still fail — while accepting the intentional facade surface.

## Verification

`GROUP=QA julia --project -e 'using Pkg; Pkg.test()'` locally on Julia 1.12.4: **19/19 pass** (from 16 passed / 2 failed / 1 errored on the same checkout without these changes).

## Not fixed here (master is still red for two other reasons)

- **#1111** — Core allocation budget in `test/Core/homotopy_alloc_tests__item1.jl`. Root cause is Julia 1.12 removing the `reshape(a::Array, dims) === a` fast path, surfacing through ForwardDiff's `reshape_jacobian`; the real fix is upstream in ForwardDiff and the interim is a tolerance decision, so both are flagged for you there rather than done here.
- **#1083** — #1108 skipped problem 1 for `Broyden(true_jacobian, bad_broyden)` but problem 8 for the same algorithm still flips; commented on that issue, since the mechanism that fits is a test skip and needs your sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GHoo4pFa3DU9yhyTkevL
