### PR TITLE
Sweep every workload problem through bare solve(prob)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.23.1"
+version = "4.23.2"
 authors = ["SciML"]
 
 [deps]

--- a/src/NonlinearSolve.jl
+++ b/src/NonlinearSolve.jl
@@ -121,10 +121,9 @@ include("forward_diff.jl")
     # AutoDePSpecialize opaque-p path. Both containers are covered: an isbits `p`
     # packs into an `OpaqueParams` and a non-isbits `p` into an `OpaqueRef`, each
     # a single wrapped-residual signature shared across every parameter type of
-    # its kind. These go through the polyalgorithm / no-algorithm sweeps below as
-    # well as the per-algorithm ones, since `solve(prob)` runs default algorithm
-    # selection — a separate code path from `solve(prob, alg)`.
-    depspecialize_problems = NonlinearProblem[
+    # its kind.
+    push!(
+        nonlinear_problems,
         NonlinearProblem(
             NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(
                 (du, u, p) -> (du .= u .* u .- p.a)
@@ -132,6 +131,9 @@ include("forward_diff.jl")
             [0.1],
             (a = 2.0,),
         ),
+    )
+    push!(
+        nonlinear_problems,
         NonlinearProblem(
             NonlinearFunction{true, SciMLBase.AutoDePSpecialize}(
                 (du, u, p) -> (du .= u .* u .- p[1])
@@ -139,8 +141,7 @@ include("forward_diff.jl")
             [0.1],
             [2.0],
         ),
-    ]
-    append!(nonlinear_problems, depspecialize_problems)
+    )
 
     nlp_algs = [NewtonRaphson(), TrustRegion(), LevenbergMarquardt()]
     nlls_algs = [GaussNewton(), TrustRegion(), LevenbergMarquardt()]
@@ -167,10 +168,12 @@ include("forward_diff.jl")
 
             # `solve(prob)` with no keyword arguments is a distinct
             # specialization from the kwarg-carrying calls above (the keyword
-            # NamedTuple's type participates), and it is what most user code
-            # writes. Measured on an opaque-p problem: 0.61s for the kwarg form
-            # against 1.68s bare, before this sweep was added.
-            for prob in depspecialize_problems
+            # NamedTuple's type participates), and it is the form most user code
+            # writes, so every problem gets a bare sweep too.
+            for prob in nonlinear_problems
+                Threads.@spawn CommonSolve.solve(prob)
+            end
+            for prob in nlls_problems
                 Threads.@spawn CommonSolve.solve(prob)
             end
         end


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

Follow-up to #1110, which flagged this as a pre-existing gap and scoped its fix to the opaque-p problems only.

The workload’s default sweep passes `abstol`/`verbose`. The keyword `NamedTuple`’s type participates in the specialization, so those calls do **not** cover the bare `solve(prob)` most user code writes. This extends the bare sweep to every nonlinear and NLLS problem.

### Benefit (fresh process, default-specialization problems, no algorithm)

| | kwarg form | bare, before | bare, after |
|---|---|---|---|
| `NonlinearProblem` | 0.53s | 1.54s | **0.53s** |
| NLLS problem | 0.63s | 2.04s | **0.63s** |

### Cost (measured by rebuilding both ways, not estimated)

| | master | this PR |
|---|---|---|
| precompile | 49.8s | 53.7s (+7.8%) |
| cache `.so` | 37.0 MB | 39.8 MB (+7.6%) |
| load time | 2.81s | 2.80s (noise) |

So ~8% more build buys ~1.0–1.4s off every bare first solve. That seemed clearly worth it, but it is a judgment call about workload size, so flagging the numbers explicitly rather than burying the change — happy to drop it if you would rather keep the build lean.

Also simplifies the #1110 `depspecialize_problems` intermediate back into direct `push!`es, since the bare sweep now covers all problems and the separate list no longer has a consumer.

Patch-bumps `NonlinearSolve` to 4.23.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuAbA8hSnrirMrJjFqxwn5