### PR TITLE
Forward IntervalNonlinearProblem kwargs into bracketing solvers

### DIFF
--- a/lib/BracketingNonlinearSolve/src/BracketingNonlinearSolve.jl
+++ b/lib/BracketingNonlinearSolve/src/BracketingNonlinearSolve.jl
@@ -55,6 +55,10 @@ function CommonSolve.solve(
         prob::IntervalNonlinearProblem,
         alg::AbstractBracketingAlgorithm, args...; sensealg = nothing, kwargs...
     )
+    # IntervalNonlinearProblem kwargs are solver options (SciMLBase contract). Merge
+    # here so they bind before __solve defaults (e.g. abstol = nothing). Solve kwargs
+    # override problem kwargs, matching NonlinearSolveBase.solve_call.
+    kwargs = isempty(prob.kwargs) ? kwargs : merge(values(prob.kwargs)::NamedTuple, kwargs)
     return bracketingnonlinear_solve_up(
         prob::IntervalNonlinearProblem, sensealg, prob.p, alg, args...; kwargs...
     )

--- a/lib/BracketingNonlinearSolve/test/rootfind_tests.jl
+++ b/lib/BracketingNonlinearSolve/test/rootfind_tests.jl
@@ -4,3 +4,4 @@
 @safetestset "ForwardDiff with Duals in tspan" include("rootfind_tests__item4.jl")
 @safetestset "ModAB non-shrinking iteration" include("rootfind_tests__item5.jl")
 @safetestset "Flipped Signs and Reversed Tspan" include("rootfind_tests__item6.jl")
+@safetestset "Problem kwargs forwarded to solvers" include("rootfind_tests__item7.jl")

--- a/lib/BracketingNonlinearSolve/test/rootfind_tests__item7.jl
+++ b/lib/BracketingNonlinearSolve/test/rootfind_tests__item7.jl
@@ -1,0 +1,41 @@
+using BracketingNonlinearSolve
+include("setup_rootfindingtestsnippet.jl")
+
+ϵ = eps(Float64)
+
+@testset "Problem kwargs forwarded to solvers (#522)" begin
+    abstol = 1.0e-3
+    # Default abstol when omitted is ~eps^(4/5) ≈ 3e-13. With problem abstol, solvers
+    # that honor a loose tolerance must not refine to max precision (same check as
+    # the tolerance tests). Solve kwargs must override problem kwargs.
+    prob = IntervalNonlinearProblem(quadratic_f, (1.0, 20.0), 2.0; abstol)
+
+    @testset for alg in (Bisection(), Falsi(), ITP(), Muller())
+        sol_from_prob = solve(prob, alg)
+        sol_from_solve = solve(
+            IntervalNonlinearProblem(quadratic_f, (1.0, 20.0), 2.0), alg; abstol
+        )
+
+        result_tol = abs(sol_from_prob.u - sqrt(2))
+        @test result_tol < abstol
+        @test result_tol > ϵ
+        @test sol_from_prob.u == sol_from_solve.u
+        @test sol_from_prob.left == sol_from_solve.left
+        @test sol_from_prob.right == sol_from_solve.right
+
+        sol_override = solve(prob, alg; abstol = 1.0e-6)
+        @test abs(sol_override.u - sqrt(2)) < 1.0e-6
+    end
+
+    # Brent / Ridder / ModAB can overshoot loose abstol to machine precision; still
+    # require problem kwargs and solve kwargs to produce the same bracket.
+    @testset for alg in (Brent(), Ridder(), ModAB())
+        sol_from_prob = solve(prob, alg)
+        sol_from_solve = solve(
+            IntervalNonlinearProblem(quadratic_f, (1.0, 20.0), 2.0), alg; abstol
+        )
+        @test sol_from_prob.u == sol_from_solve.u
+        @test sol_from_prob.left == sol_from_solve.left
+        @test sol_from_prob.right == sol_from_solve.right
+    end
+end


### PR DESCRIPTION
## Summary
- IntervalNonlinearProblem kwargs (for example abstol) were dropped by BracketingNonlinearSolve's CommonSolve.solve entry, so only solve-call kwargs reached __solve.
- Merge prob.kwargs before calling __solve, with solve kwargs winning, matching NonlinearSolveBase.solve_call.
- Add a regression test for problem kwargs vs solve kwargs / override.

Fixes #522

## Test plan
- [ ] BracketingNonlinearSolve core tests, especially the new problem-kwargs safetestset
- [ ] Reproduce the issue MWE: IntervalNonlinearProblem with abstol on the problem, then solve(prob, ITP()) should match solve(prob, ITP(); abstol=...)
