### PR TITLE
Eliminate dense continuation step allocations

### DIFF
--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -218,8 +218,12 @@ function (cache::JacobianCache)(u)
         if SciMLBase.has_jac(f)
             f.jac(J, u, p)
         else
+            # ForwardDiff reshapes its destination internally. A full view preserves the
+            # matrix storage while letting Julia eliminate the temporary reshape wrapper.
+            J_dest = J isa Matrix && cache.autodiff isa AutoForwardDiff ?
+                view(J, axes(J)...) : J
             DI.jacobian!(
-                f, cache.fu, J, cache.di_extras, cache.autodiff, u, Constant(p)
+                f, cache.fu, J_dest, cache.di_extras, cache.autodiff, u, Constant(p)
             )
         end
         return J

--- a/lib/NonlinearSolveBase/src/utils.jl
+++ b/lib/NonlinearSolveBase/src/utils.jl
@@ -111,7 +111,7 @@ function restructure(
     @assert size(y) == size(x) "cannot restructure operators. ensure their sizes match."
     return x
 end
-restructure(y, x) = ArrayInterface.restructure(y, x)
+restructure(y, x) = y === x ? x : ArrayInterface.restructure(y, x)
 
 function safe_similar(x, args...; kwargs...)
     y = similar(x, args...; kwargs...)

--- a/lib/NonlinearSolveBase/test/allocation_fastpaths.jl
+++ b/lib/NonlinearSolveBase/test/allocation_fastpaths.jl
@@ -1,0 +1,47 @@
+using ADTypes: AutoForwardDiff
+using ForwardDiff
+using NonlinearSolveBase
+using SciMLBase
+using Test
+
+function dense_jacobian_cache_allocations()
+    function f!(du, u, p)
+        du[1] = u[1]^2 + u[2] + p
+        du[2] = u[1] + 3 * u[2] - p
+        return nothing
+    end
+
+    u = [2.0, 3.0]
+    p = 0.5
+    f = NonlinearFunction{true, SciMLBase.FullSpecialize}(f!)
+    prob = NonlinearProblem(f, u, p)
+    fu = similar(u)
+    f(fu, u, p)
+    cache = NonlinearSolveBase.construct_jacobian_cache(
+        prob, nothing, f, fu;
+        stats = SciMLBase.NLStats(0, 0, 0, 0, 0),
+        autodiff = AutoForwardDiff(; chunksize = 1),
+    )
+
+    cache(u)
+    cache(u)
+    J = copy(cache(u))
+    allocs = @allocated cache(u)
+    return J, allocs
+end
+
+J, jacobian_allocs = dense_jacobian_cache_allocations()
+@test J == [4.0 1.0; 1.0 3.0]
+@test jacobian_allocs == 0
+
+function same_buffer_restructure_allocations()
+    x = ones(4)
+    NonlinearSolveBase.Utils.restructure(x, x)
+    y = NonlinearSolveBase.Utils.restructure(x, x)
+    allocs = @allocated NonlinearSolveBase.Utils.restructure(x, x)
+    return x, y, allocs
+end
+
+x, y, restructure_allocs = same_buffer_restructure_allocations()
+@test y === x
+@test restructure_allocs == 0

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -128,6 +128,10 @@ run_tests(;
 
         @safetestset "Linear solver routing" include("linear_solver_routing.jl")
 
+        @safetestset "Jacobian and restructure allocation fast paths" include(
+            "allocation_fastpaths.jl"
+        )
+
         @safetestset "Operator Jacobian cache dispatch" begin
             using NonlinearSolveBase, SciMLBase, SciMLOperators
 


### PR DESCRIPTION
## Summary
- avoid temporary reshape wrappers in dense AutoForwardDiff Jacobian calculation
- preserve same-buffer restructure identity without an ArrayInterface allocation
- add warmed allocation regression coverage

## Validation
- `/home/crackauc/.juliaup/bin/julia +1.12 --project=. -e ... homotopy_alloc_tests__item1.jl`
- `GROUP=Core /home/crackauc/.juliaup/bin/julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` in `lib/NonlinearSolveBase`\n- Runic format check and `git diff --check`\n\nIgnore until reviewed by @ChrisRackauckas.