### PR TITLE
Fix intentional sublibrary re-export QA failures

### DIFF
--- a/lib/BracketingNonlinearSolve/test/qa/qa.jl
+++ b/lib/BracketingNonlinearSolve/test/qa/qa.jl
@@ -5,12 +5,14 @@ const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs
 
 const BRACKETING_EXTERNAL_REEXPORTS = union(
     public_api_names(BracketingNonlinearSolve.SciMLBase),
-    (:SciMLBase,),
+    public_api_names(BracketingNonlinearSolve.NonlinearSolveBase),
+    (:SciMLBase, :NonlinearSolveBase),
 )
 
 run_qa(
     BracketingNonlinearSolve;
     explicit_imports = true,
+    reexports_allow = BRACKETING_EXTERNAL_REEXPORTS,
     aqua_kwargs = (;
         stale_deps = (; ignore = [:SciMLJacobianOperators]),
         deps_compat = (; ignore = [:SciMLJacobianOperators]),

--- a/lib/NonlinearSolveFirstOrder/test/qa/qa.jl
+++ b/lib/NonlinearSolveFirstOrder/test/qa/qa.jl
@@ -4,12 +4,14 @@ const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs
 
 const FIRST_ORDER_EXTERNAL_REEXPORTS = union(
     public_api_names(NonlinearSolveFirstOrder.SciMLBase),
-    (:SciMLBase,),
+    public_api_names(NonlinearSolveFirstOrder.NonlinearSolveBase),
+    (:SciMLBase, :NonlinearSolveBase),
 )
 
 run_qa(
     NonlinearSolveFirstOrder;
     explicit_imports = true,
+    reexports_allow = FIRST_ORDER_EXTERNAL_REEXPORTS,
     aqua_kwargs = (;
         piracies = (; treat_as_own = [NonlinearLeastSquaresProblem]),
         ambiguities = (; recursive = false),

--- a/lib/NonlinearSolveHomotopyContinuation/test/qa/qa.jl
+++ b/lib/NonlinearSolveHomotopyContinuation/test/qa/qa.jl
@@ -2,9 +2,12 @@ using SciMLTesting, NonlinearSolveHomotopyContinuation, Test
 
 const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs", "src")
 
+const HOMOTOPY_EXTERNAL_REEXPORTS = (:HomotopyNonlinearFunction,)
+
 run_qa(
     NonlinearSolveHomotopyContinuation;
     explicit_imports = true,
+    reexports_allow = HOMOTOPY_EXTERNAL_REEXPORTS,
     api_docs_kwargs = (; rendered = true, docs_src = NONLINEARSOLVE_DOCS_SRC),
     # persistent_tasks: intermittently errors on Julia >=1.11 because the registered
     # NonlinearSolveBase ships a leaked `[sources]` (SciMLJacobianOperators =

--- a/lib/NonlinearSolveQuasiNewton/test/qa/qa.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/qa/qa.jl
@@ -4,12 +4,14 @@ const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs
 
 const QUASI_NEWTON_EXTERNAL_REEXPORTS = union(
     public_api_names(NonlinearSolveQuasiNewton.SciMLBase),
-    (:SciMLBase,),
+    public_api_names(NonlinearSolveQuasiNewton.NonlinearSolveBase),
+    (:SciMLBase, :NonlinearSolveBase),
 )
 
 run_qa(
     NonlinearSolveQuasiNewton;
     explicit_imports = true,
+    reexports_allow = QUASI_NEWTON_EXTERNAL_REEXPORTS,
     aqua_kwargs = (;
         stale_deps = (; ignore = [:SciMLJacobianOperators]),
         deps_compat = (; ignore = [:SciMLJacobianOperators]),

--- a/lib/NonlinearSolveSciPy/test/qa/qa.jl
+++ b/lib/NonlinearSolveSciPy/test/qa/qa.jl
@@ -5,12 +5,14 @@ const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs
 
 const SCIPY_EXTERNAL_REEXPORTS = union(
     public_api_names(NonlinearSolveSciPy.SciMLBase),
-    (:SciMLBase,),
+    public_api_names(NonlinearSolveSciPy.NonlinearSolveBase),
+    (:SciMLBase, :NonlinearSolveBase),
 )
 
 run_qa(
     NonlinearSolveSciPy;
     explicit_imports = true,
+    reexports_allow = SCIPY_EXTERNAL_REEXPORTS,
     jet_kwargs = (; target_defined_modules = true),
     api_docs_kwargs = (;
         rendered = true,

--- a/lib/NonlinearSolveSpectralMethods/test/qa/qa.jl
+++ b/lib/NonlinearSolveSpectralMethods/test/qa/qa.jl
@@ -4,12 +4,14 @@ const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs
 
 const SPECTRAL_METHODS_EXTERNAL_REEXPORTS = union(
     public_api_names(NonlinearSolveSpectralMethods.SciMLBase),
-    (:SciMLBase,),
+    public_api_names(NonlinearSolveSpectralMethods.NonlinearSolveBase),
+    (:SciMLBase, :NonlinearSolveBase),
 )
 
 run_qa(
     NonlinearSolveSpectralMethods;
     explicit_imports = true,
+    reexports_allow = SPECTRAL_METHODS_EXTERNAL_REEXPORTS,
     aqua_kwargs = (;
         stale_deps = (; ignore = [:SciMLJacobianOperators]),
         deps_compat = (; ignore = [:SciMLJacobianOperators]),

--- a/lib/SimpleNonlinearSolve/test/qa/qa.jl
+++ b/lib/SimpleNonlinearSolve/test/qa/qa.jl
@@ -6,12 +6,15 @@ const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs
 const SIMPLE_EXTERNAL_REEXPORTS = union(
     public_api_names(SimpleNonlinearSolve.ADTypes),
     public_api_names(SimpleNonlinearSolve.SciMLBase),
-    (:ADTypes, :SciMLBase),
+    public_api_names(SimpleNonlinearSolve.BracketingNonlinearSolve),
+    public_api_names(SimpleNonlinearSolve.NonlinearSolveBase),
+    (:ADTypes, :SciMLBase, :BracketingNonlinearSolve, :NonlinearSolveBase),
 )
 
 run_qa(
     SimpleNonlinearSolve;
     explicit_imports = true,
+    reexports_allow = SIMPLE_EXTERNAL_REEXPORTS,
     aqua_kwargs = (;
         stale_deps = (; ignore = [:SciMLJacobianOperators]),
         deps_compat = (; ignore = [:SciMLJacobianOperators]),


### PR DESCRIPTION
> **Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Summary

- allow the public APIs that the facade sublibraries intentionally re-export
- keep the homotopy allowlist limited to `HomotopyNonlinearFunction`
- leave package exports and runtime behavior unchanged

## Root cause

`SciMLTesting.run_qa` now checks re-exports, but these seven sublibraries intentionally use `@reexport` and did not pass their dependency API allowlists through `reexports_allow`. Their intended facade APIs were therefore reported as accidental re-exports.

Closes #1119.

## Validation

Ran each affected sublibrary's official QA group with Julia 1.12:

- BracketingNonlinearSolve: 20 passed
- NonlinearSolveFirstOrder: 20 passed
- NonlinearSolveHomotopyContinuation: 19 passed, 1 pre-existing broken
- SimpleNonlinearSolve: 20 passed
- NonlinearSolveQuasiNewton: 20 passed
- NonlinearSolveSpectralMethods: 20 passed
- NonlinearSolveSciPy: 20 passed, 1 pre-existing broken

Command:

```sh
NONLINEARSOLVE_TEST_GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
```

Also ran the whole-repository Runic 1.7.0 check successfully:

```sh
julia +1.12 --project=../.runic_env -e 'using Runic; exit(Runic.main(["--check", "."]))'
```
