### PR TITLE
Fix SICNM docs before its registered release

### DIFF
--- a/docs/src/native/steadystatediffeq.md
+++ b/docs/src/native/steadystatediffeq.md
@@ -22,5 +22,4 @@ Pages = ["steadystatediffeq.md"]
 ```@docs
 DynamicSS
 SSRootfind
-SICNM
 ```

--- a/docs/src/solvers/nonlinear_system_solvers.md
+++ b/docs/src/solvers/nonlinear_system_solvers.md
@@ -22,7 +22,7 @@ fail to converge. Additionally, [`DynamicSS`](@ref) can be a good choice for hig
 if the root corresponds to a stable equilibrium.
 
 For ill-conditioned problems where even the robust Newton-type methods diverge — such as
-power-flow equations — [`SICNM`](@ref) (the semi-implicit continuous Newton method) is a
+power-flow equations — `SICNM` (the semi-implicit continuous Newton method) is a
 strong fallback. It reformulates `f(u) = 0` as a differential-algebraic equation whose
 equilibrium is the root and drives it to steady state with a stiffly stable ODE solver, so
 it converges from starting points where a direct Newton step would overshoot the basin of
@@ -129,7 +129,7 @@ often more computationally expensive than direct methods.
     terminates when close to the steady state.
   - [`SSRootfind()`](@ref): Uses a NonlinearSolve compatible solver to find the steady
     state.
-  - [`SICNM()`](@ref): The semi-implicit continuous Newton method. Reformulates the
+  - `SICNM()`: The semi-implicit continuous Newton method. Reformulates the
     nonlinear system as a differential-algebraic equation, `ẏ = z, 0 = J(y) z + f(y)`, and
     integrates it to steady state with a stiffly stable ODE solver. Highly robust on
     ill-conditioned problems where Newton-type methods diverge (e.g. power flow); more


### PR DESCRIPTION
> [!NOTE]
> This PR is part of an agent-assisted workflow. Please ignore it until it has been reviewed by @ChrisRackauckas.

## Summary

Keep the SICNM solver guidance added by #1106, but stop treating `SICNM` as an available documented binding until its owning package has a registered release that contains it.

- remove `SICNM` from the SteadyStateDiffEq `@docs` block
- render `SICNM` and `SICNM()` as inline code instead of unresolved `@ref` links
- retain the full explanation and recommendation from #1106

## Root cause

The docs environment resolves the latest registered `SteadyStateDiffEq`, currently v2.11.3. `SICNM` was merged into SteadyStateDiffEq by SciML/SteadyStateDiffEq.jl#142 and exists on its v2.13.0 development version, but no release containing it is registered yet.

The introducing commit is `bf0992ecf` (#1106): its parent has no SICNM references, and that commit adds the `@docs` entry plus both API references without changing the docs dependency to an available release.

Clean `upstream/master` at `2b0dda5f6` reproduced:

```text
SteadyStateDiffEq v2.11.3
Error: undefined binding 'SICNM' in `@docs` block
Error: Cannot resolve @ref for md"[`SICNM`](@ref)"
Error: Cannot resolve @ref for md"[`SICNM()`](@ref)"
ERROR: `makedocs` encountered errors [:docs_block, :cross_references, :linkcheck]
```

The local unauthenticated clean-master run also received an unrelated transient response:

```text
linkcheck 'https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/lmdif1.c' status: 429.
```

That URL and linkcheck behavior are intentionally unchanged here. The CI-matched validation below used the configured GitHub credential, as Documenter does in CI.

## Local validation

Julia 1.12.6:

```text
$ julia +1.12 --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.status(["SteadyStateDiffEq", "NonlinearSolve"])'
NonlinearSolve v4.23.2 [local checkout]
SteadyStateDiffEq v2.11.3
```

Full docs build, including strict docs-block checks, cross-references, and authenticated link checks:

```text
$ GITHUB_TOKEN=<configured token> julia +1.12 --project=docs/ docs/make.jl
[ Info: CrossReferences: building cross-references.
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="4.23.2"` for inventory from ../Project.toml
[ Warning: Documenter could not auto-detect the building environment. Skipping deployment.
exit code 0
```

Whole-repository formatting check:

```text
$ julia +1.12 --project=<local Runic environment> -e 'using Runic; exit(Runic.main(["--check", "."]))'
exit code 0
```

`git diff --check` also exits 0.

## Agent-assisted process notes

The requested investigation was to reproduce the current master documentation failure, identify the introducing commit, make the smallest non-silencing correction, run the actual docs build and whole-repository Runic, and open a draft PR. No warning mode, skipped check, or linkcheck exception was added.
