### PR TITLE
Use stable CMINPACK documentation links

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -51,10 +51,6 @@ makedocs(;
         "https://dl.acm.org/doi/10.1145/210089.210111",
         "https://www.sciencedirect.com/science/article/abs/pii/S0045782523007156",
         "https://github.com/SciML/ColPrac/blob/master/README.md",
-        "https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/hybrd1.c",
-        "https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/hybrd.c",
-        "https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/hybrj.c",
-        "https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/lmder.c",
         "https://net-informations.com/faq/net/stack-heap.htm",  # Unreliable external site
         "https://iopscience.iop.org/article/10.1088/1757-899X/1276/1/012010/",  # IOP redirects to PerimeterX bot validator from CI
     ],

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -115,15 +115,15 @@ The keyword argument `method` can take on different value depending on which met
 `fsolve` you are calling. The standard choices of `method` are:
 
   - `:hybr`: Modified version of Powell's algorithm. Uses MINPACK routine
-    [`hybrd1`](https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/hybrd1.c)
+    [`hybrd1`](https://devernay.github.io/cminpack/hybrd_.html)
   - `:lm`: Levenberg-Marquardt. Uses MINPACK routine
-    [`lmdif1`](https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/lmdif1.c)
+    [`lmdif1`](https://devernay.github.io/cminpack/lmdif_.html)
   - `:lmdif`: Advanced Levenberg-Marquardt (more options available with `; kwargs...`). See
-    MINPACK routine [`lmdif`](https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/lmdif.c)
+    MINPACK routine [`lmdif`](https://devernay.github.io/cminpack/lmdif_.html)
     for more information
   - `:hybrd`: Advanced modified version of Powell's algorithm (more options available with
     `; kwargs...`). See MINPACK routine
-    [`hybrd`](https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/hybrd.c)
+    [`hybrd`](https://devernay.github.io/cminpack/hybrd_.html)
     for more information
 
 If a Jacobian is supplied as part of the [`NonlinearFunction`](@ref nonlinearfunctions),
@@ -131,11 +131,11 @@ then the following methods are allowed:
 
   - `:hybr`: Advanced modified version of Powell's algorithm with user supplied Jacobian.
     Additional arguments are available via `; kwargs...`. See MINPACK routine
-    [`hybrj`](https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/hybrj.c)
+    [`hybrj`](https://devernay.github.io/cminpack/hybrj_.html)
     for more information
   - `:lm`: Advanced Levenberg-Marquardt with user supplied Jacobian. Additional arguments
     are available via `; kwargs...`. See MINPACK routine
-    [`lmder`](https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/lmder.c)
+    [`lmder`](https://devernay.github.io/cminpack/lmder_.html)
     for more information
 
 The default choice of `:auto` selects `:hybr` for NonlinearProblem and `:lm` for


### PR DESCRIPTION
> [!NOTE]
> This PR is part of an agent-assisted workflow. Please ignore it until it has been reviewed by @ChrisRackauckas.

## Summary

- Replace six CMINPACK GitHub blob-page links with the CMINPACK project's stable routine manuals.
- Remove the four corresponding `linkcheck_ignore` entries, so every CMINPACK reference is checked by Documenter.
- Keep strict link checking enabled; no warning mode, exception, retry suppression, or skipped check is added.

## Root cause

The CMINPACK links are valid, but GitHub intermittently rate-limits unauthenticated automated requests to blob pages. Three consecutive clean-master docs runs returned:

```text
linkcheck 'https://github.com/devernay/cminpack/blob/d1f5f5a273862ca1bbcf58394e4ac060d9e22c76/lmdif1.c' status: 429.
```

A later clean-master run from a fresh worktree and a direct request both returned 200, so this is external rate-limit behavior rather than a dead URL. Documenter 1.17 adds a bearer token to GitHub link checks when `GITHUB_TOKEN` is present, which explains why the authenticated build succeeds, but unauthenticated local docs builds remain flaky.

The replacement pages are the CMINPACK project's own manuals:

- `hybrd_.html` documents `hybrd` and `hybrd1`
- `hybrj_.html` documents `hybrj`
- `lmdif_.html` documents `lmdif` and `lmdif1`
- `lmder_.html` documents `lmder`

The source links entered the repository in `3432cfb40c` (#483). The rate limit is nondeterministic external state, so there is no meaningful introducing-commit bisect for the HTTP 429 itself. Four exemptions accumulated later as individual GitHub links caused builds to fail; this PR removes those exemptions instead of adding another one.

## Local validation

Julia 1.12.6 / Documenter 1.17.0:

- Documenter's exact unauthenticated HEAD request shape returned 200 for all four replacement URLs:

```text
200 https://devernay.github.io/cminpack/hybrd_.html
200 https://devernay.github.io/cminpack/hybrj_.html
200 https://devernay.github.io/cminpack/lmdif_.html
200 https://devernay.github.io/cminpack/lmder_.html
```

- Full unauthenticated docs build with strict link checking passed:

```text
$ unset GITHUB_TOKEN
$ julia +1.12 --startup-file=no --project=docs/ docs/make.jl
[ Info: CheckDocument: running document checks.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="4.23.2"` for inventory from ../Project.toml
exit code 0
```

  Current master has the independent SICNM docs failure addressed by #1122. The full passing run temporarily applied #1122's two-file correction as an uncommitted test prerequisite, then removed it; this PR's commit contains only the two CMINPACK-link files.

- Whole-repository Runic 1.7.0 check: exit 0.
- `git diff --check`: exit 0.

No test or docs check was skipped, silenced, loosened, or changed to warning-only.

## Agent-assisted process notes

The requested investigation was to isolate the clean-master HTTP 429, distinguish transient rate limiting from a dead external link, preserve strict checking, validate the replacement in a full docs build, and publish the smallest focused fix. The branch was created from clean current `upstream/master`; the commit includes the required Chris Rackauckas co-author trailer.