### PR TITLE
Skip machine-dependent Brown almost linear bad_broyden test (#1096)

### DIFF
--- a/test/Core/23_test_problems_tests__item7.jl
+++ b/test/Core/23_test_problems_tests__item7.jl
@@ -13,12 +13,14 @@ broken_tests = Dict(alg => Int[] for alg in alg_ops)
 broken_tests[alg_ops[2]] = [1, 5, 8, 11, 18]
 broken_tests[alg_ops[4]] = [5, 6, 11]
 
-# Problem #1 (Generalized Rosenbrock) with bad_broyden + true_jacobian sits on a
-# knife-edge: ulp-level differences in the Jacobian inverse initialization flip it
-# between converging and not, so it randomly passes and fails. Skip rather than mark
-# broken, since an unexpected pass would also error. See SciML/NonlinearSolve.jl#1083.
+# Problems #1 (Generalized Rosenbrock) and #8 (Brown almost linear) with bad_broyden +
+# true_jacobian sit on a knife-edge: ulp-level differences in the Jacobian inverse
+# initialization flip them between converging and not, so which side they land on is
+# BLAS/CPU dependent. Skip rather than mark broken, since an unexpected pass would also
+# error — both have failed in both directions across runners. See
+# SciML/NonlinearSolve.jl#1083 and SciML/NonlinearSolve.jl#1096.
 skip_tests = Dict(alg => Int[] for alg in alg_ops)
-skip_tests[alg_ops[4]] = [1]
+skip_tests[alg_ops[4]] = [1, 8]
 if Sys.isapple()
     broken_tests[alg_ops[1]] = [1, 5, 11]
     broken_tests[alg_ops[3]] = [1, 5, 6, 9, 11]


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

One-line test-expectation change: add problem #8 to the existing `skip_tests` entry for `Broyden(; init_jacobian = Val(:true_jacobian), update_rule = Val(:bad_broyden))` in `test/Core/23_test_problems_tests__item7.jl`.

```diff
-skip_tests[alg_ops[4]] = [1]
+skip_tests[alg_ops[4]] = [1, 8]
```

No source change.

## Why

Problem #8 (Brown almost linear) on algorithm #4 is the same knife-edge case as problem #1 (Generalized Rosenbrock), which https://github.com/SciML/NonlinearSolve.jl/pull/1108 already moved from `broken_tests` into `skip_tests` for this exact algorithm. Problem #8 was never moved.

https://github.com/SciML/NonlinearSolve.jl/commit/74405d3035f759a5631ea5f5776d27d4091063bc (#1051) removed 8 from that algorithm's broken list (`[5, 6, 8, 11]` → `[1, 5, 6, 11]`), validated in an environment where it converges. It does not converge on the SciML self-hosted pool or on current GitHub-hosted runners, where it returns the initial best residual `5.5`.

Per https://github.com/SciML/NonlinearSolve.jl/issues/1096, the outcome is deterministic per machine but flips with the BLAS kernel, and it has failed in **both** directions — the 2026-07-15 Downgrade run errored with "Unexpected Pass" while #8 was still marked broken. So neither an expected pass nor `@test_broken` is a stable expectation across the runner pool, which is precisely the case the harness's `skip_tests` mechanism exists for.

## Relationship to #1101

This supersedes https://github.com/SciML/NonlinearSolve.jl/pull/1101, which is now closed. That PR attempted a solver-side fix: a displacement limiter in `lib/NonlinearSolveQuasiNewton/src/broyden.jl` armed by the heuristic `norm(du) > 10 * max(norm(u), 1)`. That changes unglobalized bad-Broyden trajectories for every user whose first step trips the threshold, in order to push one marginal robustness-matrix entry onto the convergent side on one class of hardware — and it does not address the underlying machine dependence, so the next BLAS change can move a different problem across the same cliff. Unglobalized bad Broyden is genuinely unstable on this problem; recording that in the test matrix is the honest expectation.

## Local validation

Julia 1.12.6, `test/Core/23_test_problems_tests__item7.jl` run directly:

| Tree | Result |
| --- | --- |
| master (`81450a1c8`) | `95 pass / 20 broken / 115 total` |
| this branch | `94 pass / 21 broken / 115 total` |

This machine is one where #8 converges (as recorded in #1096), so exactly one test moves from pass to skip; nothing else changes. (`@test_skip` is reported in the `Broken` column.)

Runic 1.7.0 `--check` on the modified file and `git diff --check` both exit 0.