### PR TITLE
NonlinearSolveBase 2.38.1: release an uncapped-SciMLBase version to unwedge the OrdinaryDiffEq stack

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.38.0"
+version = "2.38.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.** Opened as a draft.

Version bump only: `lib/NonlinearSolveBase` 2.38.0 → 2.38.1. No source change.

## Why

General [#162635](https://github.com/JuliaRegistries/General/pull/162635) retroactively capped NonlinearSolveBase 2.38.0 at `SciMLBase = "3.37.0 - 3.39"`, on the assumption that the release still consumed a SciMLOperators name that SciMLBase 3.40 stopped reexporting. It does not — `update_coefficients!` has come from its owner, SciMLOperators, since #1047 (July 12).

That cap wedges the entire OrdinaryDiffEq stack. SciML/OrdinaryDiffEq.jl#4059 raised OrdinaryDiffEqCore to `SciMLBase >= 3.40`, and every monorepo environment also resolves NonlinearSolveBase, so SciMLBase must satisfy both `>= 3.40.0` and `<= 3.39.1`:

```
Unsatisfiable requirements detected for package SciMLBase [0bca4576]:
 ├─restricted to versions 3.40.0 - 3 by OrdinaryDiffEqCore, leaving only versions: 3.40.0
 └─restricted by compatibility requirements with NonlinearSolveBase
     to versions: 3.19.0 - 3.39.1 — no versions left
```

Nothing in SciML/OrdinaryDiffEq.jl instantiates right now — `CI` (44 jobs), `Sublibrary CI`, `Downgrade`, `Downgrade Sublibraries` and `Documentation` are all failing on master at instantiate, before a single test runs.

## Why a release rather than only a registry fix

There is an open General PR to drop the bad cap ([JuliaRegistries/General#162820](https://github.com/JuliaRegistries/General/pull/162820)), but a manual compat edit is not eligible for AutoMerge and needs a General maintainer. Registering 2.38.1 unwedges the stack without that dependency — General already carries the forward compat row `["2.38.1 - 2"] → SciMLBase = "3.37.0 - 3"`, and this package's `[compat]` is already `SciMLBase = "3.37"`, so the new version registers with no upper bound. The two routes are complementary; whichever lands first fixes it.

## Source boundary

Registered 2.38.0 has tree `b94033b1ed73030ea66dc51ecc38f3b8dcea9cc2`. `git rev-parse cb25573a:lib/NonlinearSolveBase` on master returns exactly that, so the registered release and master are byte-identical — this bump ships the same code under a version the registry has not capped.

## Verification

Run locally against **SciMLBase 3.40.0**, not inferred from a source scan:

- `lib/NonlinearSolveBase` precompiles cleanly. If it still used a removed reexport this would fail here, which is the direct refutation of the cap's premise.
- Its test suite passes: `GROUP=Core`, `Testing NonlinearSolveBase tests passed`, exit 0.
- A/B on the actual failure, activating `lib/OrdinaryDiffEqNonlinearSolve` from SciML/OrdinaryDiffEq.jl master:
  - with **registered** NonlinearSolveBase 2.38.0 → `INSTANTIATE-FAILED`, reproducing the resolver error above verbatim;
  - with **this** NonlinearSolveBase → `INSTANTIATE-OK`, resolving SciMLBase v3.40.0.

So uncapping NonlinearSolveBase is both necessary and sufficient to unwedge the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KA1YU64UArbEbZrzF5Mvdz
