### PR TITLE
Dispatch evaluate_f/evaluate_f!! on iip instead of branching at runtime

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.39.0"
+version = "2.39.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/utils.jl
+++ b/lib/NonlinearSolveBase/src/utils.jl
@@ -172,27 +172,29 @@ maybe_unaliased(x::AbstractSciMLOperator, ::Bool) = x
 can_setindex(x) = ArrayInterface.can_setindex(x)
 can_setindex(::Number) = false
 
-function evaluate_f!!(prob::AbstractNonlinearProblem, fu, u, p = prob.p)
+# `iip` is a type parameter, so these dispatch rather than branch at runtime. That
+# matters on GPUs: an out-of-place solve must not have `similar(u)` anywhere in the
+# method body it compiles, even on a branch that constant-folding would drop, and the
+# out-of-place path must stay inlineable so an isbits problem (e.g.
+# `ImmutableNonlinearProblem`) can be solved inside a kernel without allocating.
+@inline function evaluate_f!!(prob::AbstractNonlinearProblem, fu, u, p = prob.p)
     return evaluate_f!!(prob.f, fu, u, p)
 end
 
-function evaluate_f!!(f::NonlinearFunction, fu, u, p)
-    if SciMLBase.isinplace(f)
-        f(fu, u, p)
-        return fu
-    end
-    return f(u, p)
+@inline evaluate_f!!(f::NonlinearFunction{false}, fu, u, p) = f(u, p)
+
+function evaluate_f!!(f::NonlinearFunction{true}, fu, u, p)
+    f(fu, u, p)
+    return fu
 end
 
-function evaluate_f(prob::AbstractNonlinearProblem, u)
-    if SciMLBase.isinplace(prob)
-        fu = prob.f.resid_prototype === nothing ? similar(u) :
-            similar(prob.f.resid_prototype)
-        prob.f(fu, u, prob.p)
-        return fu
-    else
-        return prob.f(u, prob.p)
-    end
+@inline evaluate_f(prob::AbstractNonlinearProblem{<:Any, false}, u) = prob.f(u, prob.p)
+
+function evaluate_f(prob::AbstractNonlinearProblem{<:Any, true}, u)
+    fu = prob.f.resid_prototype === nothing ? similar(u) :
+        similar(prob.f.resid_prototype)
+    prob.f(fu, u, prob.p)
+    return fu
 end
 
 function evaluate_f!(cache, u, p)


### PR DESCRIPTION
> **Please ignore until reviewed by @ChrisRackauckas.**

## Problem

`NonlinearSolveBase.Utils.evaluate_f` and `evaluate_f!!` picked the in-place vs out-of-place path with a runtime branch:

```julia
function evaluate_f(prob::AbstractNonlinearProblem, u)
    if SciMLBase.isinplace(prob)
        fu = prob.f.resid_prototype === nothing ? similar(u) : similar(prob.f.resid_prototype)
        prob.f(fu, u, prob.p)
        return fu
    else
        return prob.f(u, prob.p)
    end
end
```

`isinplace` is a type parameter so this folds to a constant, but the `similar(u)` allocation is still part of the one method body that gets compiled. For a GPU kernel solver that is not good enough: an out-of-place solve running per-thread needs a method body with no allocation in it, not one where the allocating branch is merely unreachable, and it needs to stay inlineable so an isbits problem can be solved inside the kernel.

The visible consequence is downstream piracy. ParallelParticleSwarms.jl carries this to make `SimpleNonlinearSolve` usable inside `simplebfgs_run!`:

```julia
@inline NLBUtils.evaluate_f(prob::ImmutableNonlinearProblem, u) = prob.f.f(u, prob.p)
@inline NLBUtils.evaluate_f!!(prob::ImmutableNonlinearProblem, fu, u) = prob.f.f(u, prob.p)
```

That is method piracy on an internal helper of another package — fragile for them, and a constraint on this package's internals that nobody agreed to.

## Change

Split each function into `{<:Any, false}` / `{<:Any, true}` methods and mark the out-of-place ones `@inline`. No behavior change; the out-of-place path just no longer emits `similar` at all, so the piracy stops being necessary.

Note this needs no new handling for `ImmutableNonlinearProblem` specifically — it is already an `AbstractNonlinearProblem`, and `(f::NonlinearFunction)(args...)` already exists in SciMLBase. The gap was only ever the shape of the branch.

## Verification

All five call paths return identical results to the previous implementation:

```
oop  NonlinearProblem          evaluate_f   = [-3.0, -5.0]
oop  ImmutableNonlinearProblem evaluate_f   = [-3.0, -5.0]
oop  ImmutableNonlinearProblem evaluate_f!! = [-3.0, -5.0]
iip  NonlinearProblem          evaluate_f   = [-3.0, -5.0]
iip  NonlinearProblem          evaluate_f!! = [-3.0, -5.0]
```

Dispatch selects the intended methods, and the allocating call is gone from the out-of-place body:

```
oop dispatches to: evaluate_f(prob::AbstractNonlinearProblem{<:Any, false}, u) @ utils.jl:191
iip dispatches to: evaluate_f(prob::AbstractNonlinearProblem{<:Any, true}, u)  @ utils.jl:193

`similar` present in out-of-place method body: false
```

**Not verified here:** the GPU-kernel benefit itself. There is no GPU on the machine I ran this on, so the claim that this removes the need for the downstream overloads is reasoned from the emitted code, not measured on device. Worth confirming against ParallelParticleSwarms' CUDA tests before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R1VkEmNsLeQTkYmc9pvEL3