### PR TITLE
Gate Base.ispublic contract test on Julia >= 1.11

### DIFF
--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -43,7 +43,12 @@ run_tests(;
                     termination_condition_result
                 using SciMLBase: NonlinearProblem, ReturnCode, init
 
-                @test Base.ispublic(NonlinearSolveBase, :termination_condition_result)
+                # `public` (and `Base.ispublic`) only exist on Julia >= 1.11; on the
+                # 1.10 LTS `@compat public` expands to nothing, so there is no
+                # publicness marker to inspect.
+                @static if VERSION ≥ v"1.11"
+                    @test Base.ispublic(NonlinearSolveBase, :termination_condition_result)
+                end
 
                 prob = NonlinearProblem((u, p) -> u, [1.0])
                 internalnorm = x -> maximum(abs, x)


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

`master` (6e133a3e) fails the `lib/NonlinearSolveBase` Downgrade Sublibraries job, which runs Julia `lts` (1.10):

```
termination_condition_result public contract: Error During Test at lib/NonlinearSolveBase/test/runtests.jl:46
  Test threw exception
  Expression: Base.ispublic(NonlinearSolveBase, :termination_condition_result)
  UndefVarError: `ispublic` not defined
```

Failing master job: https://github.com/SciML/NonlinearSolve.jl/actions/runs/30767740423

`Base.ispublic` was added in Julia 1.11. NonlinearSolveBase declares `julia = "1.10"`, and on 1.10 `@compat public` expands to nothing, so there is no publicness marker to inspect in the first place. The assertion was introduced by #1135.

## Fix

Gate the assertion on `VERSION >= v"1.11"`. The rest of the testset (importing `termination_condition_result` and checking its behavior on standard and safe-best caches) is unchanged and still runs on every version.

## Verification (run locally)

Julia 1.10 — `NONLINEARSOLVE_TEST_GROUP=Core julia +1.10 --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test()'`:

```
Termination Conditions | 4  4  ...
     Testing NonlinearSolveBase tests passed
```

(before this change: `4 passed, 1 errored`, package errored during testing)

Julia 1.11 — same command with `julia +1.11`, confirming the publicness check still runs where it exists:

```
Termination Conditions | 5  5  ...
     Testing NonlinearSolveBase tests passed
```

QA group on 1.10 also passes (`QA | 18 18`).

Runic-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjhM9rJVjRo7fxitFfh9cs