### PR TITLE
Cover out-of-place `init` in the Jacobian cache inference tests

### DIFF
--- a/lib/NonlinearSolveFirstOrder/Project.toml
+++ b/lib/NonlinearSolveFirstOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveFirstOrder"
 uuid = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "2.2.3"
+version = "2.2.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -36,7 +36,7 @@ CommonSolve = "0.2.4"
 ConcreteStructs = "0.2.3"
 DifferentiationInterface = "0.7.3"
 Enzyme = "0.13.90"
-FiniteDiff = "2.24"
+FiniteDiff = "2.32.1"
 ForwardDiff = "0.10.36, 1"
 InteractiveUtils = "<0.0.1, 1"
 LineSearch = "0.1.4"

--- a/lib/NonlinearSolveFirstOrder/test/inference_tests__item1.jl
+++ b/lib/NonlinearSolveFirstOrder/test/inference_tests__item1.jl
@@ -3,6 +3,7 @@ using NonlinearSolveFirstOrder
 using ADTypes, NonlinearSolveBase, NonlinearSolveFirstOrder, SciMLBase, Test
 
 f_iip = NonlinearFunction{true}((du, u, p) -> du .= u .^ 2 .- p)
+f_oop = NonlinearFunction{false}((u, p) -> u .^ 2 .- p)
 
 u0 = [1.0, 2.0]
 p = [1.0, 4.0]
@@ -10,6 +11,7 @@ fu = similar(u0)
 f_iip(fu, u0, p)
 
 prob_iip = NonlinearProblem(f_iip, u0, p)
+prob_oop = NonlinearProblem(f_oop, u0, p)
 
 stats = NonlinearSolveBase.NLStats(0, 0, 0, 0, 0)
 alg = TrustRegion(autodiff = AutoFiniteDiff())
@@ -18,6 +20,12 @@ autodiff = AutoFiniteDiff()
 @testset "In-place, no analytic Jacobian" begin
     @inferred NonlinearSolveBase.construct_jacobian_cache(
         prob_iip, alg, prob_iip.f, fu, u0, p; stats, autodiff
+    )
+end
+
+@testset "Out-of-place, no analytic Jacobian" begin
+    @inferred NonlinearSolveBase.construct_jacobian_cache(
+        prob_oop, alg, prob_oop.f, fu, u0, p; stats, autodiff
     )
 end
 
@@ -35,10 +43,9 @@ end
     )
 end
 
-@testset "Full init: TrustRegion + AutoFiniteDiff" begin
-    @inferred SciMLBase.init(prob_iip, TrustRegion(autodiff = AutoFiniteDiff()))
-end
+@testset "Full init: $name, $(nameof(alg_ctor))" for (name, prob) in (
+            "in-place" => prob_iip, "out-of-place" => prob_oop,
+        ), alg_ctor in (TrustRegion, NewtonRaphson)
 
-@testset "Full init: NewtonRaphson + AutoFiniteDiff" begin
-    @inferred SciMLBase.init(prob_iip, NewtonRaphson(autodiff = AutoFiniteDiff()))
+    @inferred SciMLBase.init(prob, alg_ctor(autodiff = AutoFiniteDiff()))
 end


### PR DESCRIPTION
Fixes https://github.com/SciML/NonlinearSolve.jl/issues/1092.

**Please ignore until reviewed by @ChrisRackauckas.**

> ⚠️ **Blocked on a FiniteDiff release.** This bumps `FiniteDiff` to `2.32.1`, which carries
> the actual fix (https://github.com/JuliaDiff/FiniteDiff.jl/pull/229) and is not registered
> yet. CI here will fail to resolve until it is.

### Diagnosis

The reported instability is not in `NonlinearSolveFirstOrder`/`NonlinearSolveBase`. Walking
the cache construction:

- `DoglegCache` and `NewtonDescentCache` infer **fully concretely** when handed a concrete
  `J` — I checked `Base.return_types` on `InternalAPI.init(prob, alg.descent, J, fu, u; …)`
  in isolation and got the exact runtime type.
- The open `where`-bounds start at `construct_jacobian_cache`, which infers
  `JacobianCache{_A, _B, …} where {_A, _B}` — `J` and `J_destination`.
- `@report_opt` puts the origin at `jacobian.jl:129`:
  ```
  runtime dispatch detected: NonlinearSolveBase.JacobianCache(%56::Any, %56::Any, …)
  ```
  `%56` is the AD-computed `J`. With `AutoFiniteDiff`, `DI.jacobian` bottoms out in
  FiniteDiff's out-of-place `finite_difference_jacobian`, whose per-color closures assign
  variables that also live in the enclosing function's scope. That boxes the captures, so the
  function returns `Any`, and the `Any` propagates up through the Jacobian cache into the
  descent caches — exactly the shape reported in the issue.

Once https://github.com/JuliaDiff/FiniteDiff.jl/pull/229 lands, the issue's reproducer is
clean:

```julia
julia> f(u, p) = u .^ 2 .- 2.0
julia> prob = NonlinearProblem(f, [1.0])
julia> cache = @inferred SciMLBase.init(prob, TrustRegion(autodiff = AutoFiniteDiff()));   # OK
```

### What this PR changes

`inference_tests__item1.jl` only ever built **in-place** problems, which is why this went
unnoticed — the in-place FiniteDiff path in DI was already inferrable. This adds the
out-of-place problem to the Jacobian-cache testset and folds the two `Full init` testsets
into one loop over `{in-place, out-of-place} × {TrustRegion, NewtonRaphson}`. I confirmed
the new cases fail on FiniteDiff 2.32.0 and pass on the patched build.

The `FiniteDiff` lower bound moves `2.24 → 2.32.1` so Downgrade CI resolves a version where
these tests actually hold.

### Not fixed here

Two neighbouring instabilities that are *not* what #1092 reports, listed so they don't get
conflated:

- **Default `AutoForwardDiff()` on out-of-place problems.** `ForwardDiff.JacobianConfig`
  encodes the chunk size in its type and `pickchunksize(length(u))` is a runtime value, so
  the DI prep — and therefore the cache — cannot be inferred. Passing
  `AutoForwardDiff(chunksize = n)` makes it inferrable; I verified both. This is inherent to
  ForwardDiff, not something NonlinearSolve can paper over.
- **`LevenbergMarquardt`**, on every AD backend. Its `DampedNewtonDescentCache` init picks
  `mode` (`Val{:normal_form}` / `Val{:least_squares}` / …) at runtime, leaving
  `__T_lincache`, `__T_JᵀJ_cache`, `__T_mode` and friends as open bounds. Separate root
  cause in `damped_newton.jl`; happy to open an issue for it.

### Testing

`GROUP=Core` for `lib/NonlinearSolveFirstOrder` on Julia 1.10.11, against the patched
FiniteDiff:

```
     Testing NonlinearSolveFirstOrder tests passed
```

The new inference cases also pass on 1.11.9 and 1.12.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoeiVWqAEFJQK22kiXu48f