### PR TITLE
Add type-asserts for calls to `init()`

### DIFF
--- a/lib/NonlinearSolveBase/src/linear_solve.jl
+++ b/lib/NonlinearSolveBase/src/linear_solve.jl
@@ -86,6 +86,7 @@ function construct_linear_solver(
 
     u_fixed = fix_incompatible_linsolve_arguments(A, b, u)
     @bb u_cache = copy(u_fixed)
+    local linprob::LinearProblem
     if alias !== nothing
         # caller-forced aliasing: the caller owns A/b outright (e.g. the inverse-Jacobian
         # workspace), so no defensive copy of A is made

--- a/lib/NonlinearSolveFirstOrder/src/forward_diff.jl
+++ b/lib/NonlinearSolveFirstOrder/src/forward_diff.jl
@@ -15,7 +15,7 @@ function SciMLBase.__init(
     )
     p = NonlinearSolveBase.nodual_value(prob.p)
     newprob = SciMLBase.remake(prob; u0 = NonlinearSolveBase.nodual_value(prob.u0), p)
-    cache = init(newprob, alg, args...; kwargs...)
+    cache = init(newprob::AbstractNonlinearProblem, alg, args...; kwargs...)
     return NonlinearSolveForwardDiffCache(
         cache, newprob, alg, prob.p, p, ForwardDiff.partials(prob.p)
     )


### PR DESCRIPTION
Fixes these invalidations seen when loading CurveFit on 1.13:
```julia
 inserting kwcall(::NamedTuple, ::typeof(CommonSolve.init), 𝑭𝑿::Roots.ZeroProblem, p′) @ Roots ~/.julia/packages/Roots/J2qbU/src/find_zero.jl:279 invalidated:                                                                                 
   mt_backedges:  1: signature Tuple{typeof(Core.kwcall), NamedTuple, typeof(CommonSolve.init), Any, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}} triggered MethodInstance for NonlinearSolveFirstOrder.var"#__init#31"(::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(SciMLBase.__init), ::SciMLBase.NonlinearLeastSquaresProblem{<:Union{Number, var"#s34"} where var"#s34"<:AbstractArray, iip, <:Union{var"#s33", var"#s31"} where {var"#s33"<:ForwardDiff.Dual{T, V, P}, var"#s31"<:(AbstractArray{<:ForwardDiff.Dual{T, V, P}})}} where {iip, T, V, P}, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}) (0 children)                                                                                       
                  2: signature Tuple{typeof(Core.kwcall), NamedTuple, typeof(CommonSolve.init), Any, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}} triggered MethodInstance for NonlinearSolveFirstOrder.var"#__init#31"(::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(SciMLBase.__init), ::SciMLBase.NonlinearProblem{<:Union{Number, var"#s34"} where var"#s34"<:AbstractArray, iip, <:Union{var"#s33", var"#s31"} where {var"#s33"<:ForwardDiff.Dual{T, V, P}, var"#s31"<:(AbstractArray{<:ForwardDiff.Dual{T, V, P}})}} where {iip, T, V, P}, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}) (0 children)                                                                                                   
                  3: signature Tuple{typeof(Core.kwcall), NamedTuple, typeof(CommonSolve.init), Any, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}} triggered MethodInstance for NonlinearSolveFirstOrder.var"#__init#31"(::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(SciMLBase.__init), ::SciMLBase.NonlinearLeastSquaresProblem{<:Union{Number, var"#s34"} where var"#s34"<:AbstractArray, iip, <:Union{var"#s33", var"#s31"} where {var"#s33"<:ForwardDiff.Dual{T, V, P}, var"#s31"<:(AbstractArray{<:ForwardDiff.Dual{T, V, P}})}} where {iip, T, V, P}, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}) (0 children)                                                                                                                                                                                                                                    
                  4: signature Tuple{typeof(Core.kwcall), NamedTuple, typeof(CommonSolve.init), Any, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}} triggered MethodInstance for NonlinearSolveFirstOrder.var"#__init#31"(::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(SciMLBase.__init), ::SciMLBase.NonlinearProblem{<:Union{Number, var"#s34"} where var"#s34"<:AbstractArray, iip, <:Union{var"#s33", var"#s31"} where {var"#s33"<:ForwardDiff.Dual{T, V, P}, var"#s31"<:(AbstractArray{<:ForwardDiff.Dual{T, V, P}})}} where {iip, T, V, P}, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}) (0 children) 
                  5: signature Tuple{typeof(Core.kwcall), NamedTuple, typeof(CommonSolve.init), Any, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}} triggered MethodInstance for NonlinearSolveFirstOrder.var"#__init#31"(::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(SciMLBase.__init), ::SciMLBase.NonlinearLeastSquaresProblem{<:Union{Number, var"#s34"} where var"#s34"<:AbstractArray, iip, <:Union{var"#s33", var"#s31"} where {var"#s33"<:ForwardDiff.Dual{T, V, P}, var"#s31"<:(AbstractArray{<:ForwardDiff.Dual{T, V, P}})}} where {iip, T, V, P}, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}) (0 children)                                                                                                                                     
                  6: signature Tuple{typeof(Core.kwcall), NamedTuple, typeof(CommonSolve.init), Any, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}} triggered MethodInstance for NonlinearSolveFirstOrder.var"#__init#31"(::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(SciMLBase.__init), ::SciMLBase.NonlinearProblem{<:Union{Number, var"#s34"} where var"#s34"<:AbstractArray, iip, <:Union{var"#s33", var"#s31"} where {var"#s33"<:ForwardDiff.Dual{T, V, P}, var"#s31"<:(AbstractArray{<:ForwardDiff.Dual{T, V, P}})}} where {iip, T, V, P}, ::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}) (0 children)                                                                                                                                                 
                  7: signature Tuple{typeof(Core.kwcall), NamedTuple, typeof(CommonSolve.init), Any, Nothing} triggered MethodInstance for NonlinearSolveBase.var"#construct_linear_solver#42"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.construct_linear_solver), ::NonlinearSolveBase.SteepestDescent{Nothing}, ::Nothing, ::Any, ::Any, ::Float64, ::Float64) (4 children)                                                 
                  8: signature Tuple{typeof(Core.kwcall), NamedTuple, typeof(CommonSolve.init), Any, LinearSolve.CholeskyFactorization{LinearAlgebra.NoPivot, Nothing}} triggered MethodInstance for NonlinearSolveBase.var"#construct_linear_solver#42"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.construct_linear_solver), ::NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, ::LinearSolve.CholeskyFactorization{LinearAlgebra.NoPivot, Nothing}, ::Any, ::Any, ::Any, ::Float64) (5 children)                                                                            
                  9: signature Tuple{typeof(Core.kwcall), NamedTuple, typeof(CommonSolve.init), Any, Nothing} triggered MethodInstance for NonlinearSolveBase.var"#construct_linear_solver#42"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.construct_linear_solver), ::NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, ::Nothing, ::Any, ::Any, ::Float64, ::Float64) (11 children)                                                                                                                                                                                           
                 10: signature Tuple{typeof(Core.kwcall), NamedTuple, typeof(CommonSolve.init), Any, Nothing} triggered MethodInstance for NonlinearSolveBase.var"#construct_linear_solver#42"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.construct_linear_solver), ::NonlinearSolveBase.SteepestDescent{Nothing}, ::Nothing, ::Any, ::Any, ::Vector{Float64}, ::Float64) (13 children)                                        
                 11: signature Tuple{typeof(Core.kwcall), NamedTuple, typeof(CommonSolve.init), Any, Nothing} triggered MethodInstance for NonlinearSolveBase.var"#construct_linear_solver#42"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.construct_linear_solver), ::NonlinearSolveBase.NewtonDescent{Nothing}, ::Nothing, ::Any, ::Any, ::Float64, ::Float64) (19 children)                                                  
                 12: signature Tuple{typeof(Core.kwcall), NamedTuple, typeof(CommonSolve.init), Any, Nothing} triggered MethodInstance for NonlinearSolveBase.var"#construct_linear_solver#42"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.construct_linear_solver), ::NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, ::Nothing, ::Any, ::Any, ::Any, ::Float64) (41 children)                                                                                                                                                                                               
                 13: signature Tuple{typeof(Core.kwcall), NamedTuple, typeof(CommonSolve.init), Any, Nothing} triggered MethodInstance for NonlinearSolveBase.var"#construct_linear_solver#42"(::Any, ::Any, ::Base.Pairs{Symbol, _A, Nothing, A} where {_A, A<:NamedTuple}, ::typeof(NonlinearSolveBase.construct_linear_solver), ::NonlinearSolveBase.NewtonDescent{Nothing}, ::Nothing, ::Any, ::Any, ::Vector{Float64}, ::Float64) (73 children)                                          
```

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API