### PR TITLE
Bump 2 package versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.24.0"
+version = "4.24.1"
 authors = ["SciML"]
 
 [deps]

--- a/lib/SCCNonlinearSolve/Project.toml
+++ b/lib/SCCNonlinearSolve/Project.toml
@@ -1,6 +1,6 @@
 name = "SCCNonlinearSolve"
 uuid = "9dfe8606-65a1-4bb3-9748-cb89d1561431"
-version = "1.14.0"
+version = "1.14.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
        These packages have unreleased changes to `src`, `ext`, or `Project.toml` relative to the
        tree recorded in the General registry for their current version, but the version was never
        bumped — so the changes cannot be released.

        | package | from | to | kind | why |
        |---|---|---|---|---|
        | `NonlinearSolve` | 4.24.0 | **4.24.1** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |
| `SCCNonlinearSolve` | 1.14.0 | **1.14.1** | patch | unreleased changes to `src`/`ext`/`Project.toml` since the registered tree |

        ### How the versions were chosen

        Patch by default. A package was promoted to a **minor** bump only where it gained public API
        or a user-facing capability. For `0.y.z` packages the non-breaking slot is `z`, so those stay
        in the patch position regardless of what they added.

        No package in this PR needs a major bump: comparing the exported/`@public` name sets between
        each package's released commit and master, **no name that the package itself defines was
        removed**. The removals that do appear are blanket reexports of names owned by other packages
        (e.g. `BVPJacobianAlgorithm` and `integral`, which belong to `BoundaryValueDiffEqCore`), which
        SciML does not treat as documented public API.

        Registration follows once this merges.

        ---

        Found by a `/sciml-release-sweep` pass over the org. **Please ignore until reviewed by @ChrisRackauckas.**
