### PR TITLE
Fix the QA and Spell Check checks left red by the preconditioning hooks

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -14,3 +14,13 @@ MTK = "MTK"
 # NonlinearSolve specific terms
 LSO = "LSO"  # Legitimate abbreviation used in optimization contexts
 clos = "clos"  # Variable name for closure in Enzyme extension
+
+# Deliberate misspellings that are the point of the code they appear in. Scoped to
+# `*.jl` and to the exact identifier: an `extend-identifiers` entry is case-sensitive
+# and matches the whole identifier, so it cannot mask the same typo inside a compound
+# name or in prose. Extending the built-in `jl` type merges with it rather than
+# replacing it.
+[type.jl.extend-identifiers]
+# test/Core/core_tests__item23.jl asserts that a typo'd keyword name is rejected by
+# SciMLBase's common keyword whitelist, so the misspelling has to stay misspelled.
+postcondtion = "postcondtion"

--- a/docs/src/devdocs/internal_interfaces.md
+++ b/docs/src/devdocs/internal_interfaces.md
@@ -24,6 +24,22 @@ NonlinearSolveBase.AbstractNonlinearSolveAlgorithm
 NonlinearSolveBase.AbstractNonlinearSolveCache
 ```
 
+## Nonlinear Preconditioning
+
+Hooks backing the `precondition` and `postcondition` solve options described in
+[Nonlinear Preconditioning](@ref nonlinear_preconditioning). `transform_conditioned_problem`
+runs at the `solve`/`init` funnels, while `apply_postcondition!!` is called by each solver
+family at its iterate-commit points.
+
+```@docs
+NonlinearSolveBase.get_precondition
+NonlinearSolveBase.get_postcondition
+NonlinearSolveBase.needs_conditioning
+NonlinearSolveBase.transform_conditioned_problem
+NonlinearSolveBase.apply_postcondition!!
+NonlinearSolveBase.supports_postcondition
+```
+
 ## Descent Directions
 
 ```@docs
@@ -62,6 +78,17 @@ NonlinearSolveBase.AbstractDampingFunctionCache
 ```@docs
 NonlinearSolveBase.AbstractTrustRegionMethod
 NonlinearSolveBase.AbstractTrustRegionMethodCache
+```
+
+## Cache State
+
+Accessors for the state of a running solve. These are the only cache accessors a
+`postcondition` corrector should use on the cache it is handed.
+
+```@docs
+NonlinearSolveBase.get_u
+NonlinearSolveBase.get_fu
+NonlinearSolveBase.get_nsteps
 ```
 
 ## Cache Tolerances

--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.41.0"
+version = "2.41.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/abstract_types.jl
+++ b/lib/NonlinearSolveBase/src/abstract_types.jl
@@ -365,9 +365,40 @@ the cache:
 """
 abstract type AbstractNonlinearSolveCache <: AbstractNonlinearSolveBaseAPI end
 
+"""
+    get_u(cache)
+
+Return the current iterate held by a nonlinear solver cache.
+
+Defaults to the cache's `u` field. Caches that keep the iterate elsewhere should overload
+this hook: a `NonlinearSolvePolyAlgorithmCache` forwards to whichever subsolver is
+currently active, and the ForwardDiff cache forwards to the wrapped primal cache.
+"""
 get_u(cache::AbstractNonlinearSolveCache) = cache.u
+
+"""
+    get_fu(cache)
+
+Return the residual stored in a nonlinear solver cache: the most recent value of the
+problem's residual function the solver evaluated (the full residual vector, not its norm,
+for a `NonlinearLeastSquaresProblem`).
+
+Defaults to the cache's `fu` field, with the same overloading convention as
+[`get_u`](@ref). Between steps this is the residual at [`get_u`](@ref), but a solver
+mid-step commits the new iterate before re-evaluating there — a `postcondition` corrector
+runs at exactly such a point and so sees the residual at the previous accepted iterate.
+"""
 get_fu(cache::AbstractNonlinearSolveCache) = cache.fu
+
+"""
+    get_nsteps(cache)
+
+Return the number of solver iterations the cache has taken so far. This is the count
+checked against `maxiters`, and it counts steps of the solver loop rather than function
+or Jacobian evaluations, which are tracked separately in `cache.stats`.
+"""
 get_nsteps(cache::AbstractNonlinearSolveCache) = cache.nsteps
+
 set_fu!(cache::AbstractNonlinearSolveCache, fu) = (cache.fu = fu)
 SciMLBase.set_u!(cache::AbstractNonlinearSolveCache, u) = (cache.u = u)
 


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR should be ignored until reviewed by @ChrisRackauckas.**

Fixes two pre-existing red checks on master, both inherited from #1084 (which merged with those checks already failing):

1. the `NonlinearSolveBase` **QA** group — nine names went `public` without docstrings / `@docs` entries;
2. the **Spell Check** workflow — a deliberate misspelling in a test that #1084 added.

---

# 1. QA: undocumented public API

`SciMLTesting.run_api_docs` requires every name in `names(NonlinearSolveBase; all = false, imported = false)` (exports + `@compat public` names on Julia >= 1.11) to (a) have a docstring and (b) appear in a ` ```@docs ` block under `docs/src`.

## Reproduction (clean checkout of `origin/master` @ 4bd97b77f, Julia 1.12.4)

```
cd lib/NonlinearSolveBase && NONLINEARSOLVE_TEST_GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
```

```
public API has docstrings: Test Failed at SciMLTesting/v2jEQ/src/SciMLTesting.jl:1205
  Expression: isempty(undocumented)
   Evaluated: isempty([:get_fu, :get_nsteps, :get_u])

public API is rendered in docs: Test Failed at SciMLTesting/v2jEQ/src/SciMLTesting.jl:1221
  Expression: isempty(unrendered)
   Evaluated: isempty([:apply_postcondition!!, :get_fu, :get_nsteps, :get_postcondition, :get_precondition, :get_u, :needs_conditioning, :supports_postcondition, :transform_conditioned_problem])

Test Summary:                                  | Pass  Fail  Total   Time
QA                                             |   18     2     20  44.9s
  Quality Assurance                            |   18     2     20  40.2s
    ...
    Public API documentation                   |          2      2   2.3s
      public API has docstrings                |          1      1   2.2s
      public API is rendered in docs           |          1      1   0.0s
ERROR: LoadError: Some tests did not pass: 18 passed, 2 failed, 0 errored, 0 broken.
```

## Bisect

A single commit: **4aad48784** (#1084, "Nonlinear preconditioning hooks"). `git log -S` on both `@compat(public, ...)` lines in `lib/NonlinearSolveBase/src/NonlinearSolveBase.jl` returns only that commit, and it is the commit that adds `src/conditioning.jl`:

| Name | Made public by |
|---|---|
| `needs_conditioning`, `transform_conditioned_problem`, `apply_postcondition!!`, `get_precondition`, `get_postcondition`, `supports_postcondition` | 4aad48784 (#1084) — have docstrings in `conditioning.jl`, never added to a `@docs` block |
| `get_u`, `get_fu`, `get_nsteps` | 4aad48784 (#1084) — no docstring and no `@docs` entry |

`get_u`/`get_fu` predate #1084 as functions, and #1115 (664c39d9c) added the polyalgorithm-cache methods, but neither made them public — #1084 did, so `names()` only started reporting them there.

Confirmed empirically against the parent commit **9b7244889**: the public API there is 55 names with `undocumented == Symbol[]` and `unrendered == Symbol[]`; on 4bd97b77f it is 64 names with the 3 / 9 above failing. #1084 added exactly those 9.

## Changes

- **`lib/NonlinearSolveBase/src/abstract_types.jl`** — docstrings for `get_u`, `get_fu`, `get_nsteps`, written from the implementations. Notably `get_fu` documents that it is the last residual the solver *evaluated*, which mid-step (i.e. when a `postcondition` corrector is called) is the residual at the previous accepted iterate — matching what the preconditioning tutorial already tells corrector authors.
- **`docs/src/devdocs/internal_interfaces.md`** — two new sections following the file's existing structure: `## Nonlinear Preconditioning` (the six conditioning hooks, cross-linked to the `nonlinear_preconditioning` tutorial) and `## Cache State` (the three accessors, next to the existing `## Cache Tolerances` that already renders `get_abstol`/`get_reltol`).
- **`lib/NonlinearSolveBase/Project.toml`** — 2.41.0 → 2.41.1.

No `public` declaration was removed, no `api_docs = false`, no ignore list — the names stay public and are now actually documented.

---

# 2. Spell Check: deliberate misspelling in a test

## Reproduction

```
$ typos            # crate-ci/typos 1.48.0, the version SciML/.github pins
error: `postcondtion` should be `postcondition`
   ╭▸ ./test/Core/core_tests__item23.jl:38:47
   │
38 │     NonlinearProblem(circuit!, zeros(2), cp); postcondtion = H!
   ╰╴                                              ━━━━━━━━━━━━
EXIT=2
```

## The misspelling is load-bearing and must stay

```julia
# a typo in the option name is rejected by the common keyword whitelist
@test_throws SciMLBase.CommonKwargError solve(
    NonlinearProblem(circuit!, zeros(2), cp); postcondtion = H!
)
```

The test asserts that a *typo'd* keyword name is rejected by SciMLBase's common-keyword whitelist. Correcting the spelling would silently turn it into a test that the *correct* keyword is rejected — i.e. it would assert the opposite of the intended behaviour. So the checker has to be told the token is intentional, not the test changed.

## Pre-existing, not introduced by this PR

`gh run list --repo SciML/NonlinearSolve.jl --workflow "Spell Check"`: every run before 2026-08-05 is green; `nonlinear-preconditioning-hooks` (the branch that became #1084 / 4aad48784) fails from 97bce8701 onward, and it fails on this branch too:

```
failure  qa-document-public-api          2d55df2fe  2026-08-07
failure  nonlinear-preconditioning-hooks 6a4ccea9f  2026-08-06
failure  nonlinear-preconditioning-hooks 97bce8701  2026-08-05   <- first red
success  init-invalidations              1b38cfc46  2026-08-05
success  version-bump-20260805           31257aeee  2026-08-05
```

The workflow is `on: [pull_request]`, so master itself is never run directly — every PR inherits the failure.

## Mechanism chosen: `[type.jl.extend-identifiers]`

```toml
[type.jl.extend-identifiers]
postcondtion = "postcondtion"
```

Narrowest option that works, of the four considered:

| Option | Scope | |
|---|---|---|
| `[type.jl.extend-identifiers]` | exact case-sensitive identifier, `*.jl` only | **chosen** |
| `[default.extend-identifiers]` | exact case-sensitive identifier, all file types | works, wider |
| `[default.extend-words]` (what existing entries use) | case-insensitive word, matched *inside* any identifier, all file types | works, widest |
| `[files] extend-exclude` on the file | disables all spell checking for the whole file | rejected |

Per typos' design doc, identifiers are checked first and are case-sensitive; only if an identifier is unknown is it split into (case-insensitive) words. So an `extend-identifiers` entry allows exactly this token and nothing else.

A fifth option — a custom `[type.NAME]` with `extend-glob = ["core_tests__item23.jl"]`, scoping to the single file — also verified working, but rejected: "most specific glob wins" means it *replaces* the built-in `jl` type for that file, dropping its `modul`/`usig`/`egal`/`egals` allowances, and it pins the config to a mechanically-numbered filename. Extending `[type.jl]` instead merges with the built-in type — confirmed via `typos --dump-config -`, which still lists `modul = "modul"` et al. under `[type.jl.extend-words]` after the change.

## Local verification

Ran the pinned version (`typos-cli 1.48.0`, downloaded release binary, matching `crate-ci/typos@v1.48.0` in `SciML/.github/.github/workflows/spellcheck.yml@v1`) at the repo root:

```
$ typos ; echo "EXIT=$?"     # before
error: `postcondtion` should be `postcondition`  (test/Core/core_tests__item23.jl:38:47)
EXIT=2

$ typos ; echo "EXIT=$?"     # after
EXIT=0
```

Negative control, to show the allowance did not blanket the token — all of these are still caught:

```
error: `Postcondtion` should be `Postcondition`   ./probe.md:1:1       (different case, prose)
error: `postcondtion` should be `postcondition`   ./probe.md:1:21      (inside `my_postcondtion_hook`)
error: `Postcondtion` should be `Postcondition`   ./probe.jl:1:9       (different case, .jl)
error: `Postcondtion` should be `Postcondition`   ./probe.jl:2:14      (inside `applyPostcondtion`)
```

---

# Local test results (Julia 1.12.4)

`cd lib/NonlinearSolveBase`:

```
$ NONLINEARSOLVE_TEST_GROUP=QA julia --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
QA            |   20     20  43.4s
     Testing NonlinearSolveBase tests passed
QA_EXIT=0
```

```
$ NONLINEARSOLVE_TEST_GROUP=Core julia --project=. -e 'using Pkg; Pkg.test()'
...
Test Summary:                            | Pass  Total  Time
Nonlinear preconditioning options (#351) |   28     28  2.9s
Test Summary:                         | Pass  Total   Time
linsolve_identity!! workspace (#1020) |   52     52  16.2s
...
Test Summary:                        | Pass  Total  Time
Dense LU refactorization allocations |   14     14  2.0s
     Testing NonlinearSolveBase tests passed
CORE_EXIT=0
```

(20/20 QA, up from 18 passed / 2 failed on the same checkout without these changes; Core fully green.)

Runic clean.

# Merge-order note

`lib/NonlinearSolveBase/Project.toml` is bumped to **2.41.1** (patch — docs and CI config only, no API change). There is a separate in-flight PR taking the same file to 2.42.0; whichever lands second will need a trivial rebase on that one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9GHoo4pFa3DU9yhyTkevL
