### PR TITLE
Seed `LimitedMemoryBroyden`'s low-rank inverse Jacobian with `+αI`

### DIFF
--- a/lib/NonlinearSolveQuasiNewton/Project.toml
+++ b/lib/NonlinearSolveQuasiNewton/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveQuasiNewton"
 uuid = "9a2c21bd-3a47-402d-9113-8faf9a0ee114"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.15.0"
+version = "1.15.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/NonlinearSolveQuasiNewton/src/initialization.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/initialization.jl
@@ -201,8 +201,10 @@ end
 """
     BroydenLowRankJacobian{T}(U, Vᵀ, idx, cache, alpha)
 
-Low Rank Approximation of the Jacobian Matrix. Currently only used for
-[`LimitedMemoryBroyden`](@ref). This computes the Jacobian as ``U \\times V^T``.
+Low Rank Approximation of the inverse Jacobian. Currently only used for
+[`LimitedMemoryBroyden`](@ref). This computes the inverse Jacobian as
+``\\alpha I + U \\times V^T``, matching the ``\\alpha I`` seed
+[`IdentityInitialization`](@ref) hands the other quasi-Newton methods after inversion.
 """
 @concrete mutable struct BroydenLowRankJacobian{T} <: AbstractSciMLOperator{T}
     U
@@ -246,38 +248,38 @@ function BroydenLowRankJacobian(fu, u; threshold::Int = 10, alpha = true)
 end
 
 function Base.:*(J::BroydenLowRankJacobian, x::AbstractVector)
-    J.idx == 0 && return -x
+    J.idx == 0 && return J.alpha .* x
     _, U, Vᵀ = get_components(J)
-    return U * (Vᵀ * x) .- J.alpha .* x
+    return U * (Vᵀ * x) .+ J.alpha .* x
 end
 
 function LinearAlgebra.mul!(y::AbstractVector, J::BroydenLowRankJacobian, x::AbstractVector)
     if J.idx == 0
-        @. y = -J.alpha * x
+        @. y = J.alpha * x
         return y
     end
     cache, U, Vᵀ = get_components(J)
     @bb cache = Vᵀ × x
     LinearAlgebra.mul!(y, U, cache)
-    @bb @. y -= J.alpha * x
+    @bb @. y += J.alpha * x
     return y
 end
 
 function Base.:*(x::AbstractVector, J::BroydenLowRankJacobian)
-    J.idx == 0 && return -x
+    J.idx == 0 && return J.alpha .* x
     _, U, Vᵀ = get_components(J)
-    return Vᵀ' * (U' * x) .- J.alpha .* x
+    return Vᵀ' * (U' * x) .+ J.alpha .* x
 end
 
 function LinearAlgebra.mul!(y::AbstractVector, x::AbstractVector, J::BroydenLowRankJacobian)
     if J.idx == 0
-        @. y = -J.alpha * x
+        @. y = J.alpha * x
         return y
     end
     cache, U, Vᵀ = get_components(J)
     @bb cache = transpose(U) × x
     LinearAlgebra.mul!(y, transpose(Vᵀ), cache)
-    @bb @. y -= J.alpha * x
+    @bb @. y += J.alpha * x
     return y
 end
 

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests.jl
@@ -8,3 +8,4 @@
 @safetestset "LimitedMemoryBroyden: Iterator Interface" include("core_tests__item8.jl")
 @safetestset "LimitedMemoryBroyden Termination Conditions" include("core_tests__item9.jl")
 @safetestset "Postcondition iterate correction" include("core_tests__item10.jl")
+@safetestset "LimitedMemoryBroyden: continuation from a nearby root" include("core_tests__item11.jl")

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests__item11.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests__item11.jl
@@ -1,0 +1,16 @@
+using NonlinearSolveQuasiNewton, SciMLBase, Test
+
+# Started at the root of a nearby parameter value the residual is tiny, so the seeded
+# `alpha * I` inverse Jacobian sets the whole first step. Seeded with the wrong sign that
+# step walks away from the root the solve started at.
+quadratic_f!(du, u, p) = (du .= u .^ 2 .- p; nothing)
+
+p_range = range(0.01, 2, length = 200)
+failures = map(2:length(p_range)) do i
+    prob = NonlinearProblem{true}(quadratic_f!, [sqrt(p_range[i - 1])], p_range[i])
+    sol = solve(prob, LimitedMemoryBroyden(); maxiters = 100, abstol = 1.0e-10)
+    converged = SciMLBase.successful_retcode(sol) &&
+        isapprox(sol.u[1], sqrt(p_range[i]); rtol = 1.0e-6)
+    return converged ? nothing : (; i, p = p_range[i], u = sol.u[1], sol.retcode)
+end
+@test isempty(filter(!isnothing, failures))


### PR DESCRIPTION
> **Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed and why

`BroydenLowRankJacobian` seeded its inverse Jacobian with `-αI`, opposite in sign to the `+αI` every other quasi-Newton method ends up with from `IdentityInitialization` after inversion. The magnitude already matched — both come from `inv(initial_jacobian_scaling_alpha(...))` — only the sign differed. Since `NewtonDescent` computes `δu = -J⁻¹ fu`, the wrong sign points the first step of every `LimitedMemoryBroyden` solve *away* from the root. Started far from a root the secant updates recover, which is why the existing suite passes; started near one, where the seed sets essentially the whole first step, they do not.

Found while fixing #1140: correcting the `reinit!` bug there makes a reused cache follow the same trajectory as a fresh one, and that trajectory walks into this failure. This PR is the prerequisite; the #1140 fix is stacked on top of it.

Also fixed alongside it: `Base.:*` and `mul!` disagreed at `idx == 0`. `*` returned `-x`, dropping `alpha` entirely, while `mul!` returned `-alpha * x` — the two agree only when `alpha == 1`. Both now return `alpha * x`, consistent with each other and with the `idx > 0` branch.

## Failing before / passing after

The new test sweeps fresh `LimitedMemoryBroyden` caches along a parameter continuation of `u² = p`, each solve starting from the root of the previous parameter value.

Before (unmodified master, 4 of 199 states fail — one diverges, three land on the negative root):

```
Test Failed at lib/NonlinearSolveQuasiNewton/test/core_tests__item11.jl:16
  Expression: isempty(filter(!isnothing, failures))
   Evaluated: isempty([(i = 5, p = 0.05, u = 0.2, retcode = SciMLBase.ReturnCode.Unstable),
                       (i = 6, p = 0.06, u = -0.2449489742782929, retcode = ReturnCode.Success),
                       (i = 7, p = 0.07, u = -0.264575131103582,  retcode = ReturnCode.Success),
                       (i = 8, p = 0.08, u = -0.2828427124780166, retcode = ReturnCode.Success)])
```

`i = 5` is a genuine divergence, not a slow solve — the iterate runs away to `1e274` and then `NaN`:

```
i=5 trace, u0=0.20000000003657056 fu0=-0.00999999998537178
  step 1: u=-0.2999999999634294   du=-0.5
  step 2: u=0.10000000010971155   du=0.40000000007314096
  step 3: u=-0.09999999992685893  du=-0.20000000003657048
  step 4: u=2.1875540848613515e8  du=2.1875540858613515e8
  ...
  step 11: du=NaN  retcode=Unstable
```

After (this branch):

```
Test Summary:                                         | Pass  Total  Time
LimitedMemoryBroyden: continuation from a nearby root |    1      1  0.9s
```

## Verification

`GROUP=Core julia --project -e 'using Pkg; Pkg.test()'` in `lib/NonlinearSolveQuasiNewton` — 1001 assertions, all passing, including the unchanged `LimitedMemoryBroyden` suite:

```
Broyden                                               |  594    594  8m41.5s
Broyden: Iterator Interface                           |    2      2  2.6s
Broyden Termination Conditions                        |   27     27  8.6s
Klement                                               |  216    216  4m47.8s
Klement: Iterator Interface                           |    2      2  1.3s
Klement Termination Conditions                        |   27     27  7.0s
LimitedMemoryBroyden                                  |   99     99  2m14.9s
LimitedMemoryBroyden: Iterator Interface              |    2      2  2.3s
LimitedMemoryBroyden Termination Conditions           |   27     27  7.1s
Postcondition iterate correction                      |    4      4  2.5s
LimitedMemoryBroyden: continuation from a nearby root |    1      1  0.9s
```

`GROUP=QA` — `QA | 20 20 47.4s`, passing. Runic and `typos` clean.

## What I did not verify

- GPU and Downstream groups, and the `julia pre` job — not run.
- The wider `NonlinearSolve` top-level test groups. `LimitedMemoryBroyden` is not a member of `FastShortcutNonlinearPolyalg` or `RobustMultiNewton`, so the blast radius should be confined to this subpackage, but I did not run them to confirm.
- Docs build — not run for this branch (it was run for the stacked #1140 branch and passed).

## Worth pushing back on

This flips the sign of an algorithm's initial inverse-Jacobian seed, so it changes the iteration path of every `LimitedMemoryBroyden` solve, not just failing ones. My argument that `+αI` is the correct convention is (a) it matches what `Broyden`/`Klement` get from `IdentityInitialization` in both sign and magnitude, and (b) `δu = -J⁻¹ fu` means `-αI` provably ascends on the first step. But the existing `-αI` predates me and may have been deliberate — if it was, the reasoning is not recorded anywhere I could find, and the 99-test `LimitedMemoryBroyden` suite does not distinguish the two.

Version bumped: `NonlinearSolveQuasiNewton` 1.15.0 → 1.15.1.
