### PR TITLE
Reset the quasi-Newton update rule state on `reinit!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.26.0"
+version = "4.26.1"
 authors = ["SciML"]
 
 [deps]
@@ -98,9 +98,9 @@ NLSolvers = "0.5"
 NLsolve = "4.5"
 NaNMath = "1"
 NonlinearProblemLibrary = "0.1.2"
-NonlinearSolveBase = "2.42"
+NonlinearSolveBase = "2.43"
 NonlinearSolveFirstOrder = "2"
-NonlinearSolveQuasiNewton = "1.12"
+NonlinearSolveQuasiNewton = "1.15.2"
 NonlinearSolveSpectralMethods = "1.6"
 PETSc = "0.4.2"
 Pkg = "1.10"

--- a/docs/src/devdocs/internal_interfaces.md
+++ b/docs/src/devdocs/internal_interfaces.md
@@ -63,6 +63,7 @@ NonlinearSolveBase.AbstractApproximateJacobianStructure
 NonlinearSolveBase.AbstractJacobianInitialization
 NonlinearSolveBase.AbstractApproximateJacobianUpdateRule
 NonlinearSolveBase.AbstractApproximateJacobianUpdateRuleCache
+NonlinearSolveBase.reset_update_rule_state!
 NonlinearSolveBase.AbstractResetCondition
 ```
 

--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.42.0"
+version = "2.43.0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
+++ b/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
@@ -133,6 +133,7 @@ include("forward_diff.jl")
 @compat(public, (get_u, get_fu, get_nsteps))
 @compat(public, (construct_linear_solver, needs_square_A, needs_concrete_A, get_linear_cache))
 @compat(public, (construct_jacobian_cache, reused_jacobian))
+@compat(public, (reset_update_rule_state!,))
 @compat(
     public,
     (

--- a/lib/NonlinearSolveBase/src/abstract_types.jl
+++ b/lib/NonlinearSolveBase/src/abstract_types.jl
@@ -588,6 +588,8 @@ Abstract Type for all Approximate Jacobian Update Rule Caches used in NonlinearS
 ### Interface Functions
 
   - `store_inverse_jacobian(cache)`: Return `store_inverse_jacobian(cache.rule)`
+  - `reset_update_rule_state!(cache, fu)`: Reseed any residual the cache carries between
+    iterations with `fu`.
 
 ### `InternalAPI.solve!` specification
 
@@ -602,6 +604,21 @@ abstract type AbstractApproximateJacobianUpdateRuleCache <: AbstractNonlinearSol
 function store_inverse_jacobian(cache::AbstractApproximateJacobianUpdateRuleCache)
     return store_inverse_jacobian(cache.rule)
 end
+
+"""
+    reset_update_rule_state!(cache::AbstractApproximateJacobianUpdateRuleCache, fu)
+
+Reseed the update rule cache with `fu`, the residual at the iterate the enclosing solver
+cache is being (re)initialized at, exactly as `InternalAPI.init` seeds it.
+
+Secant-type update rules difference the current residual against the previous iterate's,
+which they store across iterations. That stored residual is not reachable from
+`InternalAPI.reinit_self!`, which runs on the nested caches before the enclosing cache has
+evaluated the residual at the new iterate, so the enclosing cache calls this afterwards
+instead. The default is a no-op, which is correct for update rules whose cache holds only
+scratch buffers.
+"""
+reset_update_rule_state!(::AbstractApproximateJacobianUpdateRuleCache, fu) = nothing
 
 """
     AbstractResetCondition

--- a/lib/NonlinearSolveQuasiNewton/Project.toml
+++ b/lib/NonlinearSolveQuasiNewton/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveQuasiNewton"
 uuid = "9a2c21bd-3a47-402d-9113-8faf9a0ee114"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.15.1"
+version = "1.15.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -43,7 +43,7 @@ LinearAlgebra = "1.10"
 LinearSolve = "5"
 MaybeInplace = "0.1.4"
 NonlinearProblemLibrary = "0.1.2"
-NonlinearSolveBase = "2.41"
+NonlinearSolveBase = "2.43"
 PrecompileTools = "1.2"
 Reexport = "1.2.2"
 SciMLBase = "3.37"

--- a/lib/NonlinearSolveQuasiNewton/src/broyden.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/broyden.jl
@@ -121,6 +121,11 @@ end
     rule <: Union{BadBroydenUpdateRule, GoodBroydenUpdateRule}
 end
 
+function NonlinearSolveBase.reset_update_rule_state!(cache::BroydenUpdateRuleCache, fu)
+    @bb copyto!(cache.dfu, fu)
+    return
+end
+
 function InternalAPI.solve!(
         cache::BroydenUpdateRuleCache, J⁻¹, fu, u, du; kwargs...
     )

--- a/lib/NonlinearSolveQuasiNewton/src/klement.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/klement.jl
@@ -99,6 +99,11 @@ end
     rule <: KlementUpdateRule
 end
 
+function NonlinearSolveBase.reset_update_rule_state!(cache::KlementUpdateRuleCache, fu)
+    @bb copyto!(cache.fu_cache, fu)
+    return
+end
+
 function InternalAPI.solve!(
         cache::KlementUpdateRuleCache, J::Number, fu, u, du; kwargs...
     )

--- a/lib/NonlinearSolveQuasiNewton/src/solve.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/solve.jl
@@ -123,6 +123,10 @@ function InternalAPI.reinit_self!(
     )
     Utils.reinit_common!(cache, u0, p, alias_u0)
 
+    NonlinearSolveBase.reset_update_rule_state!(
+        cache.update_rule_cache, NonlinearSolveBase.get_fu(cache)
+    )
+
     InternalAPI.reinit!(cache.stats)
     cache.nsteps = 0
     cache.nresets = 0

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests.jl
@@ -9,3 +9,4 @@
 @safetestset "LimitedMemoryBroyden Termination Conditions" include("core_tests__item9.jl")
 @safetestset "Postcondition iterate correction" include("core_tests__item10.jl")
 @safetestset "LimitedMemoryBroyden: continuation from a nearby root" include("core_tests__item11.jl")
+@safetestset "reinit! resets the update rule state" include("core_tests__item12.jl")

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests__item12.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests__item12.jl
@@ -1,0 +1,44 @@
+using NonlinearSolveQuasiNewton, ForwardDiff, SciMLBase, Test
+
+# The update rules difference the current residual against the previous iterate's, which
+# they hold across iterations. `reinit!` has to reseed it, or the first secant update of
+# the reused cache differences against the residual at the previous problem's root.
+quadratic_f(u, p) = u .^ 2 .- p
+quadratic_f!(du, u, p) = (du .= u .^ 2 .- p; nothing)
+
+algs = (
+    "Broyden" => Broyden(),
+    "Broyden (bad)" => Broyden(; update_rule = Val(:bad_broyden)),
+    "Broyden (diagonal)" => Broyden(; update_rule = Val(:diagonal)),
+    "Broyden (true jacobian)" => Broyden(; init_jacobian = Val(:true_jacobian)),
+    "Klement" => Klement(),
+    "Klement (true jacobian diagonal)" => Klement(;
+        init_jacobian = Val(:true_jacobian_diagonal)
+    ),
+    "LimitedMemoryBroyden" => LimitedMemoryBroyden(),
+)
+
+problems = (
+    "oop" => (quadratic_f, [1.5, 1.5], [2.0, 3.0], [1.0, 1.0], [9.0, 16.0], false),
+    "iip" => (quadratic_f!, [1.5, 1.5], [2.0, 3.0], [1.0, 1.0], [9.0, 16.0], true),
+    "scalar" => (quadratic_f, 1.5, 2.0, 1.0, 9.0, false),
+)
+
+@testset "$(algname)" for (algname, alg) in algs
+    @testset "$(probname)" for (probname, (f, u0A, pA, u0B, pB, iip)) in problems
+        probA = NonlinearProblem{iip}(f, u0A, pA)
+        probB = NonlinearProblem{iip}(f, u0B, pB)
+
+        fresh = init(probB, alg)
+        solve!(fresh)
+
+        reused = init(probA, alg)
+        solve!(reused)
+        SciMLBase.reinit!(reused, u0B; p = pB)
+        solve!(reused)
+
+        @test reused.u == fresh.u
+        @test reused.nsteps == fresh.nsteps
+        @test reused.stats.nf == fresh.stats.nf
+    end
+end


### PR DESCRIPTION
> **Ignore this PR until it has been reviewed by @ChrisRackauckas.**
>
> Rebased onto `master` now that #1145 has merged; the diff is this fix alone.

Closes #1140.

## What changed and why

`SciMLBase.reinit!` on a `QuasiNewtonCache` left the update rule's own state alone, so `BroydenUpdateRuleCache.dfu` and `KlementUpdateRuleCache.fu_cache` still held the residual at the *previous* problem's root. The first secant update of the reused cache therefore differenced the new residual against a stale one.

The reason `InternalAPI.reinit_self!` cannot fix this in the update rule cache itself: `@internal_caches` generates a `reinit!` that recurses into the nested caches *first* and calls `reinit_self!` on the enclosing cache afterwards — but the residual at the new iterate is only computed inside that later call, by `Utils.reinit_common!`. The nested cache has nothing to reseed from at the time it runs, and the `::Any` fallback for `reinit_self!` silently leaves it untouched.

So `QuasiNewtonCache`'s `reinit_self!` reseeds the update rule cache right after `reinit_common!`, which is exactly the pattern it already uses for the termination cache two lines below. The hook is a new `NonlinearSolveBase.reset_update_rule_state!(cache, fu)` on `AbstractApproximateJacobianUpdateRuleCache`, with a no-op default — correct for update rules whose cache holds only scratch buffers.

`reset_update_rule_state!` is declared `public` in `NonlinearSolveBase` with a docstring and a `@docs` entry in the devdocs, rather than added to the ExplicitImports ignore list. (QA caught this: the first run failed `all_qualified_accesses_are_public`.)

## Failing before / passing after

New test: after `reinit!`, a reused cache must match a fresh cache **bitwise** in `u`, and exactly in `nsteps` and `stats.nf` — 7 algorithm configurations × oop/iip/scalar, 63 assertions.

Before (fix reverted, test kept):

```
Test Summary:                      | Pass  Fail  Total   Time
all                                |    9    54     63  16.8s
  Broyden                          |    1     8      9   4.9s
  Broyden (bad)                    |    3     6      9   0.9s
  Broyden (diagonal)               |    1     8      9   1.5s
  Broyden (true jacobian)          |          9      9   3.5s
  Klement                          |    1     8      9   0.8s
  Klement (true jacobian diagonal) |    2     7      9   1.0s
  LimitedMemoryBroyden             |    1     8      9   1.9s
```

After:

```
Test Summary: | Pass  Total     Time
all           |   63     63  1m13.7s
```

The issue's own reproducer, before and after:

```
                                   before              after
cache.update_rule_cache.dfu   [-1.66e-10, -3.06e-10]   [-8.0, -15.0]
f([1.0, 1.0], [9.0, 16.0])    [-8.0, -15.0]            [-8.0, -15.0]
nsteps  (fresh 14)            15                       14
nf      (fresh 16)            17                       16
```

## Why this needs #1145

With the reused cache now following the same trajectory as a fresh one, `core_tests__item8.jl` — a 200-point parameter continuation driven by `reinit!` — started failing. That turned out not to be a regression: a **fresh** cache on the state the continuation reaches at `i = 5` fails identically on unmodified master.

```
FRESH cache, u0=0.20000000003657056, p=0.05 -> u=0.2 (unchanged), retcode=Unstable
```

Sweeping fresh caches over all 199 continuation states on master: 4 fail (one diverges, three converge to the negative root). `item8` was passing only because the stale `dfu` happened to steer the loop around them. #1145 fixed that underlying `LimitedMemoryBroyden` bug and has since merged; `item8` is untouched by either PR.

## Verification

`GROUP=Core julia --project -e 'using Pkg; Pkg.test()'` in `lib/NonlinearSolveQuasiNewton` — 1064 assertions, all passing:

```
Broyden                                               |  594    594  8m35.3s
Broyden: Iterator Interface                           |    2      2  2.9s
Broyden Termination Conditions                        |   27     27  9.2s
Klement                                               |  216    216  4m45.9s
Klement: Iterator Interface                           |    2      2  1.3s
Klement Termination Conditions                        |   27     27  7.0s
LimitedMemoryBroyden                                  |   99     99  2m16.4s
LimitedMemoryBroyden: Iterator Interface              |    2      2  2.3s
LimitedMemoryBroyden Termination Conditions           |   27     27  7.1s
Postcondition iterate correction                      |    4      4  2.4s
LimitedMemoryBroyden: continuation from a nearby root |    1      1  0.9s
reinit! resets the update rule state                  |   63     63  11.2s
```

`GROUP=QA` — `NonlinearSolveQuasiNewton QA | 20 20 46.1s` and `NonlinearSolveBase QA | 20 20 50.8s`, both passing.

`julia --project=docs docs/make.jl` — exit 0, so the new `@docs` entry resolves.

Runic and `typos` clean.

## What I did not verify

- The OrdinaryDiffEq symptom described in the issue (`Broyden`/`Klement`/`FastShortcutNonlinearPolyalg` going `Unstable` on stiff problems because `NonlinearSolveAlg` calls `reinit!` on the inner cache every stage). This fixes the root cause the issue identifies, but I did not run OrdinaryDiffEq's suite to confirm the downstream symptom clears.
- GPU, Downstream, and `julia pre` jobs — not run.
- The `NonlinearSolve` top-level test groups — not run.

## Worth pushing back on

`reset_update_rule_state!` is new public API on `NonlinearSolveBase`, which is why that package gets a minor bump rather than a patch. The alternative was keeping it internal and widening the ExplicitImports ignore list; I went with public because the file's own comment flags those entries as "still non-public in their owning packages", i.e. a backlog rather than a target.

Versions bumped: `NonlinearSolveBase` 2.42.0 → 2.43.0 (new public API), `NonlinearSolveQuasiNewton` 1.15.1 → 1.15.2, `NonlinearSolve` 4.26.0 → 4.26.1, with the corresponding compat floors raised.