### PR TITLE
Skip the knife-edge Brown almost linear problem for true-Jacobian Broyden

### DIFF
--- a/test/Core/23_test_problems_tests__item7.jl
+++ b/test/Core/23_test_problems_tests__item7.jl
@@ -10,7 +10,7 @@ alg_ops = (
 )
 
 broken_tests = Dict(alg => Int[] for alg in alg_ops)
-broken_tests[alg_ops[2]] = [1, 5, 8, 11, 18]
+broken_tests[alg_ops[2]] = [1, 5, 11, 18]
 broken_tests[alg_ops[4]] = [5, 6, 11]
 
 # Problems #1 (Generalized Rosenbrock) and #8 (Brown almost linear) with bad_broyden +
@@ -18,8 +18,11 @@ broken_tests[alg_ops[4]] = [5, 6, 11]
 # initialization flip them between converging and not, so which side they land on is
 # BLAS/CPU dependent. Skip rather than mark broken, since an unexpected pass would also
 # error — both have failed in both directions across runners. See
-# SciML/NonlinearSolve.jl#1083 and SciML/NonlinearSolve.jl#1096.
+# SciML/NonlinearSolve.jl#1083 and SciML/NonlinearSolve.jl#1096. Problem #8 with plain
+# true_jacobian Broyden (alg #2) sits on the same knife-edge: as of LinearSolve 5.6 it
+# converges on some runners (Unexpected Pass) and not on others.
 skip_tests = Dict(alg => Int[] for alg in alg_ops)
+skip_tests[alg_ops[2]] = [8]
 skip_tests[alg_ops[4]] = [1, 8]
 if Sys.isapple()
     broken_tests[alg_ops[1]] = [1, 5, 11]


### PR DESCRIPTION
⚠️ Draft — please ignore until reviewed by @ChrisRackauckas.

## What changed and why

Problem 8 (Brown almost linear function) with `Broyden(; init_jacobian = Val(:true_jacobian))` (alg #2 in the 23-test-problems Broyden set) is marked in `broken_tests`, but as of LinearSolve 5.6 it converges on some runners, so the broken marker errors with `Unexpected Pass`:

```
8: Brown almost linear function | alg #2: Error During Test at test/Core/setup_robustnesstesting.jl:25
 Unexpected Pass
 Expression: norm(res, Inf) ≤ ϵ
 Got correct result, please change to @test if no longer broken.
```

Other runners still see it fail, so flipping the marker to a plain `@test` would just fail in the other direction. This is the same knife-edge this file already documents for the `bad_broyden + true_jacobian` variant (#1083, #1096), and the fix is the same: move it from `broken_tests` to `skip_tests`.

This currently fails NonlinearSolve's own CI on master:
- https://github.com/SciML/NonlinearSolve.jl/actions/runs/31198048028 (`tests / Core (julia 1)` and `(julia pre)`, commit fdf1e69c, 2026-08-07) — same `Unexpected Pass`, against **released** LinearSolve v5.6.0.

and LinearSolve.jl's downstream job `NonlinearSolve.jl/Core / Downstream Tests - Core` on LinearSolve main (7 of the last 8 runs on 2026-08-08, e.g. https://github.com/SciML/LinearSolve.jl/actions/runs/31260420398/job/93110264191). The flake is runner-dependent: e.g. LinearSolve main run 31256578361 (12:08) passed between failures at 11:58 and 13:47 with no relevant code change, matching the CPU/BLAS dependence described in the existing comment.

## Verification

Julia 1.10.11, NonlinearSolve master (4.26.0) dev'd with released LinearSolve v5.6.0, running `test/Core/23_test_problems_tests__item7.jl`.

Before (unmodified master, reproduces both CI failures):

```
8: Brown almost linear function | alg #2: Error During Test at .../test/Core/setup_robustnesstesting.jl:25
 Unexpected Pass
Test Summary:                                               | Pass  Error  Broken  Total   Time
item7 before fix                                            |   94      1      20    115  28.3s
```

After (this patch):

```
Test Summary:   | Pass  Broken  Total   Time
item7 after fix |   94      21    115  26.4s
```

`julia -m Runic --check` passes on the edited file.

Not verified: the full Core group on all CI Julia versions (1.10/1/pre) — only this test file was run locally, on Julia 1.10.11. The change is test-marker-only, no source is touched.

## Links

- NonlinearSolve own-CI failure (released LinearSolve 5.6.0): https://github.com/SciML/NonlinearSolve.jl/actions/runs/31198048028
- LinearSolve downstream failure on main: https://github.com/SciML/LinearSolve.jl/actions/runs/31260420398/job/93110264191
- LinearSolve downstream PR-instance with identical signature: https://github.com/SciML/LinearSolve.jl/actions/runs/31274523916/job/93145856079
- Prior knife-edge history: https://github.com/SciML/NonlinearSolve.jl/issues/1083, https://github.com/SciML/NonlinearSolve.jl/issues/1096

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGVN6qeNL2jGCtaYg1386X
