### PR TITLE
Document SICNM in steady-state solver docs

### DIFF
--- a/docs/src/native/steadystatediffeq.md
+++ b/docs/src/native/steadystatediffeq.md
@@ -22,4 +22,5 @@ Pages = ["steadystatediffeq.md"]
 ```@docs
 DynamicSS
 SSRootfind
+SICNM
 ```

--- a/docs/src/solvers/nonlinear_system_solvers.md
+++ b/docs/src/solvers/nonlinear_system_solvers.md
@@ -22,7 +22,7 @@ fail to converge. Additionally, [`DynamicSS`](@ref) can be a good choice for hig
 if the root corresponds to a stable equilibrium.
 
 For ill-conditioned problems where even the robust Newton-type methods diverge — such as
-power-flow equations — `SICNM` (the semi-implicit continuous Newton method) is a
+power-flow equations — [`SICNM`](@ref) (the semi-implicit continuous Newton method) is a
 strong fallback. It reformulates `f(u) = 0` as a differential-algebraic equation whose
 equilibrium is the root and drives it to steady state with a stiffly stable ODE solver, so
 it converges from starting points where a direct Newton step would overshoot the basin of
@@ -129,7 +129,7 @@ often more computationally expensive than direct methods.
     terminates when close to the steady state.
   - [`SSRootfind()`](@ref): Uses a NonlinearSolve compatible solver to find the steady
     state.
-  - `SICNM()`: The semi-implicit continuous Newton method. Reformulates the
+  - [`SICNM()`](@ref): The semi-implicit continuous Newton method. Reformulates the
     nonlinear system as a differential-algebraic equation, `ẏ = z, 0 = J(y) z + f(y)`, and
     integrates it to steady state with a stiffly stable ODE solver. Highly robust on
     ill-conditioned problems where Newton-type methods diverge (e.g. power flow); more

--- a/docs/src/solvers/steady_state_solvers.md
+++ b/docs/src/solvers/steady_state_solvers.md
@@ -52,6 +52,11 @@ though often computationally more expensive than direct methods.
     internally uses the `TerminateSteadyState` callback from the Callback Library. The
     simulated time, for which the ODE is solved, can be limited by `tspan`.  If `tspan` is a
     number, it is equivalent to passing `(zero(tspan), tspan)`.
+  - [`SICNM`](@ref): The semi-implicit continuous Newton method. Reformulates the
+    steady-state problem as a differential-algebraic equation and integrates it to the
+    root with a stiffly stable ODE solver. It is particularly useful for ill-conditioned
+    problems where direct Newton methods diverge, though it is more expensive per solve.
+    `Rodas3d` is the recommended ODE algorithm: `SICNM(Rodas3d())`.
 
 Example usage:
 
@@ -63,6 +68,9 @@ sol = NLS.solve(prob, SSDE.DynamicSS(ODE.Tsit5()))
 
 import Sundials
 sol = NLS.solve(prob, SSDE.DynamicSS(Sundials.CVODE_BDF()), dt = 1.0)
+
+import OrdinaryDiffEqRosenbrock: Rodas3d
+sol = NLS.solve(prob, SSDE.SICNM(Rodas3d()))
 ```
 
 !!! note


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

SteadyStateDiffEq 2.12 exports the semi-implicit continuous Newton method, `SICNM`. This updates the dedicated steady-state solver guide to describe SICNM and its recommended `Rodas3d()` backend, adds the SICNM API autodoc entry, and restores SICNM cross-references in the nonlinear-system solver guide.

## Validation

- `julia --project=docs docs/make.jl` — completed with exit code 0; Documenter doctests and link checking completed successfully.
- `GROUP=QA julia --project --startup-file=no -e 'using Pkg; Pkg.test()'` — `QA | 28 pass / 28 total`.
- `julia --project=@runic -m Runic --check docs/src/native/steadystatediffeq.md docs/src/solvers/nonlinear_system_solvers.md docs/src/solvers/steady_state_solvers.md` — passed.
- `typos` on the three changed files — passed.
- `git diff --check` — passed.

The docs build emitted only non-fatal headless plotting and deployment-environment warnings.