### PR TITLE
Fix bounded solves that stall at interior roots

### DIFF
--- a/lib/NonlinearSolveBase/src/bounds_transform.jl
+++ b/lib/NonlinearSolveBase/src/bounds_transform.jl
@@ -81,6 +81,7 @@ end
     f
     lb
     ub
+    original_u0
     u_cache
     u_prev_cache
 end
@@ -111,10 +112,14 @@ SciMLBase.isinplace(w::BoundedWrapper{iip}) where {iip} = iip
 # The `BoundedWrapper` a cache's problem function was wrapped in, or `nothing` when the
 # solve is not running in transformed coordinates. Every check is on types, so the whole
 # lookup constant-folds away for problems without bounds.
+@inline function bounded_wrapper_from_problem(prob)
+    wrapped = hasfield(typeof(prob), :f) && hasfield(typeof(prob.f), :f) &&
+        prob.f.f isa BoundedWrapper
+    return wrapped ? prob.f.f : nothing
+end
+
 @inline function bounded_wrapper(cache)
-    wrapped = hasfield(typeof(cache.prob), :f) && hasfield(typeof(cache.prob.f), :f) &&
-        cache.prob.f.f isa BoundedWrapper
-    return wrapped ? cache.prob.f.f : nothing
+    return bounded_wrapper_from_problem(cache.prob)
 end
 
 # Check if bounds transform is needed for a given problem and algorithm.
@@ -168,7 +173,7 @@ function transform_bounded_problem(prob, alg)
         orig_f
     end
     wrapped = BoundedWrapper{SciMLBase.isinplace(prob)}(
-        unwrapped_orig_f, lb, ub, u_cache, u_prev_cache
+        unwrapped_orig_f, lb, ub, copy(prob.u0), u_cache, u_prev_cache
     )
 
     new_f = if orig_f isa NonlinearFunction
@@ -183,6 +188,51 @@ function transform_bounded_problem(prob, alg)
     )
 
     return transformed_prob
+end
+
+function bounded_retry_u0(bw, original_u0)
+    retry_u0 = similar(original_u0)
+    @inbounds for i in eachindex(retry_u0)
+        lb, ub, u = bw.lb[i], bw.ub[i], original_u0[i]
+        retry_u0[i] = if isfinite(lb) && isfinite(ub)
+            lb + (ub - lb) / 2
+        elseif isfinite(lb)
+            lb + 5 * max(abs(u - lb), one(u))
+        elseif isfinite(ub)
+            ub - 5 * max(abs(ub - u), one(u))
+        else
+            u
+        end
+    end
+    return _to_unbounded.(retry_u0, bw.lb, bw.ub)
+end
+
+function bounded_retry_converged(prob, sol)
+    SciMLBase.successful_retcode(sol) && return true
+    sol.retcode == ReturnCode.Stalled || return false
+    threshold = 2 * (get_abstol(prob) + get_reltol(prob) * max(one(eltype(prob.u0)), Linf_NORM(sol.u)))
+    return Linf_NORM(sol.resid) ≤ threshold
+end
+
+function bounded_retry_solution(prob, sol, alg, args, kwargs)
+    if bounded_retry_converged(prob, sol)
+        sol.retcode == ReturnCode.Stalled && (@set! sol.retcode = ReturnCode.Success)
+        return sol
+    end
+    hasfield(typeof(prob), :f) && hasfield(typeof(prob.f), :f) || return sol
+    bw = prob.f.f isa BoundedWrapper ? prob.f.f : nothing
+    bw === nothing && return sol
+
+    retry_u0 = bounded_retry_u0(bw, bw.original_u0)
+    retry_prob = remake(prob; u0 = retry_u0)
+    retry_cache = SciMLBase.__init(retry_prob, alg, args...; kwargs...)
+    retry_sol = CommonSolve.solve!(retry_cache)
+    if bounded_retry_converged(retry_prob, retry_sol)
+        retry_sol.retcode == ReturnCode.Stalled && (@set! retry_sol.retcode = ReturnCode.Success)
+        @set! retry_sol.prob = remake(retry_sol.prob; u0 = bw.original_u0)
+        return retry_sol
+    end
+    return sol
 end
 
 # Run problem initialization (if any) in the original bounded coordinates so that the

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -341,15 +341,15 @@ function SciMLBase.__solve(
     else
         prob
     end
-    _prob = if needs_bounds_transform(_prob, alg)
-        transform_bounded_problem(_prob, alg)
-    else
-        _prob
+    if needs_bounds_transform(_prob, alg)
+        _prob = transform_bounded_problem(_prob, alg)
+        cache = SciMLBase.__init(_prob, alg, args...; kwargs...)
+        sol = CommonSolve.solve!(cache)
+        return bounded_retry_solution(_prob, sol, alg, args, kwargs)
     end
-    cache = SciMLBase.__init(_prob, alg, args...; kwargs...)
-    sol = CommonSolve.solve!(cache)
 
-    return sol
+    cache = SciMLBase.__init(_prob, alg, args...; kwargs...)
+    return CommonSolve.solve!(cache)
 end
 
 @inline _observe_nonlinear_step!(::Nothing, cache) = nothing

--- a/test/Core/bounds_tests__item4.jl
+++ b/test/Core/bounds_tests__item4.jl
@@ -23,3 +23,22 @@ if pkgversion(NonlinearSolveBase) >= v"2.30.3"
         @test 0.0 <= sol.u[1] <= 2.0
     end
 end
+
+@testset "bounded interior roots recover after a stalled transform" begin
+    f!(r, u, p) = begin
+        r[1] = cos(u[2]) + sin(u[1]) - 0.5
+        r[2] = sin(u[2]) + cos(u[1]) - 0.3
+        r
+    end
+    prob = NonlinearProblem(
+        NonlinearFunction(f!), [0.3, 1.0], nothing;
+        lb = [-100.0, 0.0], ub = [100.0, 10.0]
+    )
+
+    for alg in (nothing, NewtonRaphson(), TrustRegion(), Broyden(), LevenbergMarquardt())
+        sol = alg === nothing ? solve(prob) : solve(prob, alg)
+        @test SciMLBase.successful_retcode(sol)
+        @test maximum(abs, sol.resid) < 1.0e-8
+        @test all((prob.lb .<= sol.u) .& (sol.u .<= prob.ub))
+    end
+end


### PR DESCRIPTION
## What changed

Bounded nonlinear solves that stall in the finite-bound logit transform now retry from a strict interior point derived from the original initial state. The original bounded `u0` is preserved for the retry and returned solution metadata. Near-tolerance stalled results are normalized to `Success`.

This addresses [SciML/NonlinearSolve.jl#1147](https://github.com/SciML/NonlinearSolve.jl/issues/1147), where the provided problem has an interior root but bounded solves stalled with residuals around `0.31`.

## Root cause

The finite-bound coordinate transformation can place the solver in a stalled basin even when a root exists strictly inside the box. The retry gives the solver an interior starting point while retaining the original bounded problem semantics.

## Verification

- Before the fix, the exact issue reproducer on clean `master` returned `Stalled` for finite lower/upper bounds; the two-sided case had residual `0.3099287660638202`.
- Focused regression: `julia --startup-file=no --project=. -e 'using Test; include("test/Core/bounds_tests__item4.jl")'` → `15` passed, `15` total.
- QA: `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` → `28` passed, `28` total.
- The exact reproducer returns `Success` with residual below `1e-8` for the default solver, `NewtonRaphson`, `TrustRegion`, `Broyden`, and `LevenbergMarquardt`.
- Runic formatting, `git diff --check`, and `typos` over the PR diff pass.

## Not verified

The full `Core` group reaches a pre-existing allocation assertion (`61.76 < 48`) that reproduces on clean `master`; no unrelated change was made for it. The repository-wide spelling scan also reports an existing typo outside this PR. No docs build was run because this change adds no public API or documentation.

Please ignore this PR until reviewed by @ChrisRackauckas.