### PR TITLE
Unwrap AutoSpecialize through SciMLBase

### DIFF
--- a/lib/NonlinearSolveBase/src/autospecialize.jl
+++ b/lib/NonlinearSolveBase/src/autospecialize.jl
@@ -60,6 +60,7 @@ Otherwise return `f` unchanged.
 """
 get_raw_f(f) = f
 get_raw_f(f::AutoSpecializeCallable) = f.orig
+SciMLBase.unwrapped_f(f::AutoSpecializeCallable) = f.orig
 
 """
     _uses_enzyme_ad(ad) -> Bool

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -124,9 +124,9 @@ run_tests(;
 
             # Vector{Float64} u0 — wraps.
             prob_f64 = NonlinearProblem(f, [1.0, 2.0], [0.5, 0.25])
-            @test NonlinearSolveBase.is_fw_wrapped(
-                NonlinearSolveBase.maybe_wrap_nonlinear_f(prob_f64)
-            )
+            wrapped_f64 = NonlinearSolveBase.maybe_wrap_nonlinear_f(prob_f64)
+            @test NonlinearSolveBase.is_fw_wrapped(wrapped_f64)
+            @test SciMLBase.unwrapped_f(wrapped_f64) === resid!
 
             # Vector{Dual} u0 — must NOT wrap.
             DualF = ForwardDiff.Dual{ForwardDiff.Tag{typeof(identity), Float64}, Float64, 2}


### PR DESCRIPTION
## What changed and why

Teach the public `SciMLBase.unwrapped_f` interface how to unwrap `NonlinearSolveBase.AutoSpecializeCallable`, and add a regression assertion alongside the wrapper construction tests.

The wrapper fallback removal in https://github.com/SciML/NonlinearSolve.jl/commit/d3e16922710be6bc0d4b99a0e67a72e157784c75 exposed a downstream failure in the archived SciMLNLSolve package: its nested ForwardDiff tag does not match the wrappers precompiled by NonlinearSolveBase. NonlinearSolveBase 2.19.0 passes that downstream test, while 2.20.0 and later fail. SciMLNLSolve can now unwrap through a documented public SciMLBase API instead of reaching into NonlinearSolveBase internals.

This PR should be ignored until reviewed by @ChrisRackauckas.

## Verification

Failing before the fix on clean current master (`f16755710`), with the regression assertion applied:

```text
NONLINEARSOLVE_TEST_GROUP=Core julia +release --project=lib/NonlinearSolveBase --startup-file=no -e 'using Pkg; Pkg.test()'
Test Summary:                                                                   | Pass  Fail  Total  Time
maybe_wrap_nonlinear_f wraps non-dual IIP array problems of any eltype or ndims |    4     1      5  3.7s
ERROR: Some tests did not pass: 4 passed, 1 failed, 0 errored, 0 broken.
```

Passing with this fix:

```text
NONLINEARSOLVE_TEST_GROUP=Core julia +release --project=lib/NonlinearSolveBase --startup-file=no -e 'using Pkg; Pkg.test()'
Test Summary:                                                                   | Pass  Total  Time
maybe_wrap_nonlinear_f wraps non-dual IIP array problems of any eltype or ndims |    5      5  0.5s
...
Testing NonlinearSolveBase tests passed

NONLINEARSOLVE_TEST_GROUP=QA julia +release --project=lib/NonlinearSolveBase --startup-file=no -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
QA            |   20     20  49.3s
Testing NonlinearSolveBase tests passed
```

I also applied the method to a checkout of NonlinearSolveBase 2.30.3 and developed that checkout into SciMLNLSolve. Its full test suite then passed:

```text
Basic:      14/14
Autodiff:    1/1
FiniteDiff:  1/1
```

Other local checks:

```text
julia +release --startup-file=no -m Runic --check .
# exited 0

typos lib/NonlinearSolveBase/src/autospecialize.jl lib/NonlinearSolveBase/test/runtests.jl
# exited 0

julia +release --project=docs --startup-file=no -e 'using Pkg; Pkg.instantiate()'
julia +release --project=docs --startup-file=no docs/make.jl
# exited 0 after doctests, examples, and HTML rendering

git diff --check
# exited 0
```

## Not verified

I did not run the monorepo root/full `Everything` suite, GPU jobs, or downstream packages other than SciMLNLSolve. The docs build emitted its existing missing-docstring and output-size warnings but completed successfully.

The fix still needs a 2.30.x backport/release to affect SciMLNLSolve's currently resolvable dependency set. SciMLNLSolve itself is archived, so its public-API downstream adjustment cannot be submitted until the repository is unarchived.
