### PR TITLE
QA: drop redundant api_docs_kwargs and deprecated JET override

### DIFF
--- a/lib/BracketingNonlinearSolve/test/qa/qa.jl
+++ b/lib/BracketingNonlinearSolve/test/qa/qa.jl
@@ -19,12 +19,7 @@ run_qa(
         piracies = (; treat_as_own = [IntervalNonlinearProblem]),
         ambiguities = (; recursive = false),
     ),
-    api_docs_kwargs = (;
-        rendered = true,
-        docs_src = NONLINEARSOLVE_DOCS_SRC,
-        ignore = BRACKETING_EXTERNAL_REEXPORTS,
-        rendered_ignore = BRACKETING_EXTERNAL_REEXPORTS,
-    ),
+    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # Still non-public in their owning packages. __solve dropped: now public in
         # SciMLBase.

--- a/lib/NonlinearSolveFirstOrder/test/qa/qa.jl
+++ b/lib/NonlinearSolveFirstOrder/test/qa/qa.jl
@@ -16,12 +16,7 @@ run_qa(
         piracies = (; treat_as_own = [NonlinearLeastSquaresProblem]),
         ambiguities = (; recursive = false),
     ),
-    api_docs_kwargs = (;
-        rendered = true,
-        docs_src = NONLINEARSOLVE_DOCS_SRC,
-        ignore = FIRST_ORDER_EXTERNAL_REEXPORTS,
-        rendered_ignore = FIRST_ORDER_EXTERNAL_REEXPORTS,
-    ),
+    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # Still non-public in their owning packages (NonlinearSolveBase's own internal API;
         # the sublibrary builds on it by design). __init / __solve dropped: now public in

--- a/lib/NonlinearSolveHomotopyContinuation/test/qa/qa.jl
+++ b/lib/NonlinearSolveHomotopyContinuation/test/qa/qa.jl
@@ -8,7 +8,7 @@ run_qa(
     NonlinearSolveHomotopyContinuation;
     explicit_imports = true,
     reexports_allow = HOMOTOPY_EXTERNAL_REEXPORTS,
-    api_docs_kwargs = (; rendered = true, docs_src = NONLINEARSOLVE_DOCS_SRC),
+    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     # persistent_tasks: intermittently errors on Julia >=1.11 because the registered
     # NonlinearSolveBase ships a leaked `[sources]` (SciMLJacobianOperators =
     # {path = "../SciMLJacobianOperators"}) that Pkg >=1.11 honors during Aqua's

--- a/lib/NonlinearSolveQuasiNewton/test/qa/qa.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/qa/qa.jl
@@ -17,12 +17,7 @@ run_qa(
         deps_compat = (; ignore = [:SciMLJacobianOperators]),
         ambiguities = (; recursive = false),
     ),
-    api_docs_kwargs = (;
-        rendered = true,
-        docs_src = NONLINEARSOLVE_DOCS_SRC,
-        ignore = QUASI_NEWTON_EXTERNAL_REEXPORTS,
-        rendered_ignore = QUASI_NEWTON_EXTERNAL_REEXPORTS,
-    ),
+    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # Still non-public in their owning packages (NonlinearSolveBase's own internal API;
         # the sublibrary builds on it by design). __init dropped: now public in SciMLBase.

--- a/lib/NonlinearSolveSciPy/test/qa/qa.jl
+++ b/lib/NonlinearSolveSciPy/test/qa/qa.jl
@@ -13,13 +13,7 @@ run_qa(
     NonlinearSolveSciPy;
     explicit_imports = true,
     reexports_allow = SCIPY_EXTERNAL_REEXPORTS,
-    jet_kwargs = (; target_defined_modules = true),
-    api_docs_kwargs = (;
-        rendered = true,
-        docs_src = NONLINEARSOLVE_DOCS_SRC,
-        ignore = SCIPY_EXTERNAL_REEXPORTS,
-        rendered_ignore = SCIPY_EXTERNAL_REEXPORTS,
-    ),
+    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     # persistent_tasks: intermittently errors on Julia >=1.11 because the registered
     # NonlinearSolveBase ships a leaked `[sources]` (SciMLJacobianOperators =
     # {path = "../SciMLJacobianOperators"}) that Pkg >=1.11 honors during Aqua's

--- a/lib/NonlinearSolveSpectralMethods/test/qa/qa.jl
+++ b/lib/NonlinearSolveSpectralMethods/test/qa/qa.jl
@@ -17,12 +17,7 @@ run_qa(
         deps_compat = (; ignore = [:SciMLJacobianOperators]),
         ambiguities = (; recursive = false),
     ),
-    api_docs_kwargs = (;
-        rendered = true,
-        docs_src = NONLINEARSOLVE_DOCS_SRC,
-        ignore = SPECTRAL_METHODS_EXTERNAL_REEXPORTS,
-        rendered_ignore = SPECTRAL_METHODS_EXTERNAL_REEXPORTS,
-    ),
+    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # Still non-public in their owning packages (NonlinearSolveBase's own internal API;
         # the sublibrary builds on it by design). __init dropped: now public in SciMLBase.

--- a/lib/SCCNonlinearSolve/test/qa/qa.jl
+++ b/lib/SCCNonlinearSolve/test/qa/qa.jl
@@ -11,7 +11,7 @@ run_qa(
         piracies = (; treat_as_own = [SCCNonlinearSolve.SciMLBase.solve]),
         ambiguities = (; recursive = false),
     ),
-    api_docs_kwargs = (; rendered = true, docs_src = NONLINEARSOLVE_DOCS_SRC),
+    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # Still non-public in their owning packages after the make-public round:
         #   SciMLBase: build_linear_solution, strip_solution;  Base: Cartesian

--- a/lib/SciMLJacobianOperators/test/qa/qa.jl
+++ b/lib/SciMLJacobianOperators/test/qa/qa.jl
@@ -5,7 +5,7 @@ const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs
 run_qa(
     SciMLJacobianOperators;
     explicit_imports = true,
-    api_docs_kwargs = (; rendered = true, docs_src = NONLINEARSOLVE_DOCS_SRC),
+    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # Still non-public in its owning package after the make-public round:
         #   SciMLBase: AbstractNonlinearFunction

--- a/lib/SimpleNonlinearSolve/test/qa/qa.jl
+++ b/lib/SimpleNonlinearSolve/test/qa/qa.jl
@@ -25,12 +25,7 @@ run_qa(
         ),
         ambiguities = (; recursive = false),
     ),
-    api_docs_kwargs = (;
-        rendered = true,
-        docs_src = NONLINEARSOLVE_DOCS_SRC,
-        ignore = SIMPLE_EXTERNAL_REEXPORTS,
-        rendered_ignore = SIMPLE_EXTERNAL_REEXPORTS,
-    ),
+    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # Still non-public in their owning packages, across the main module and the
         # Tracker / ReverseDiff / ChainRulesCore extensions. __init / __solve dropped:

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -81,11 +81,6 @@ run_qa(
             ],
         ),
     ),
-    api_docs_kwargs = (;
-        rendered = true,
-        ignore = NONLINEARSOLVE_EXTERNAL_REEXPORTS,
-        rendered_ignore = NONLINEARSOLVE_EXTERNAL_REEXPORTS,
-    ),
     ei_kwargs = (;
         # NonDifferentiable is owned by NLSolversBase and re-exported through NLsolve
         # (where the NLsolve extension imports it from).


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

QA/docs infrastructure only — no solver code touched. The root and sublibrary `test/qa/qa.jl` files carried per-repo `api_docs_kwargs` that the standard SciMLTesting harness (2.8.0, the version every QA env resolves) now supplies itself:

- `rendered = true` — the default since SciMLTesting #25 (`run_api_docs(...; rendered = true)`). Removed from all 10 configs.
- `ignore = *_EXTERNAL_REEXPORTS` / `rendered_ignore = *_EXTERNAL_REEXPORTS` — the rendered check now skips names owned outside the package's module hierarchy structurally (`_requires_local_rendering`, SciMLTesting #30), and the docstring check follows a reexported binding to its source docstring and exempts reexported module names (SciMLTesting #45). Removed from the root config and the 6 sublibrary facades that had them.
- `NonlinearSolveSciPy`: `jet_kwargs = (; target_defined_modules = true)` — `target_defined_modules` is JET's deprecated spelling of `target_modules` (deprecated in JET 0.11, removed in 0.12 per its CHANGELOG), and the whole-NamedTuple override silently replaced `run_qa`'s default `mode = :typo`. Dropped, so the standard `target_modules = (pkg,), mode = :typo` applies.

Kept, deliberately:
- `docs_src = NONLINEARSOLVE_DOCS_SRC` in every sublibrary — points the sublibrary at the shared monorepo manual (`docs/src`), a package-layout requirement. (For the record, `SciMLTesting._default_docs_src` resolves to the same directory for all 10 sublibraries on this checkout, but the explicit path is kept as requested.)
- `reexports_allow = *_EXTERNAL_REEXPORTS` — `check_reexports` needs it: 177 externally owned public names per solver sublibrary, 224 for SimpleNonlinearSolve, 366 for the NonlinearSolve facade. Not an api-docs kwarg; irreducible while these packages reexport SciMLBase/NonlinearSolveBase/ADTypes/LinearSolve/LineSearch.
- Root `NONLINEARSOLVE_EXTERNAL_REEXPORTS` const stays because it feeds `reexports_allow`.

## Verification

Evidence that the removed `ignore`/`rendered_ignore` were redundant — a scratch script that builds each QA env and runs the SciMLTesting docstring and rendered checks **without** the ignore lists, on both CI QA Julia versions:

```
=== <Pkg>  julia 1.12.4  SciMLTesting 2.8.0      (and identically on julia 1.10.11)
docstring check WITHOUT ignore  -> failures: Symbol[]
rendered check WITHOUT rendered_ignore -> failures: Symbol[]
```
for all 11 packages: NonlinearSolve, NonlinearSolveBase, NonlinearSolveFirstOrder, NonlinearSolveQuasiNewton, NonlinearSolveSpectralMethods, SimpleNonlinearSolve, BracketingNonlinearSolve, SciMLJacobianOperators, SCCNonlinearSolve, NonlinearSolveHomotopyContinuation, NonlinearSolveSciPy.

Before/after for the JET override — master's SciPy QA on Julia 1.12 (JET 0.11.6) prints:
```
┌ Warning: `target_defined_modules::Bool` configuration is deprecated.
│ Please use `target_modules` instead and specify the modules you want to target with e.g. `target_modules=(pkgmod,)`
```
This branch's SciPy QA log has zero occurrences of `target_defined_modules`.

Full QA groups on this branch, `NONLINEARSOLVE_TEST_GROUP=QA julia --project -e 'using Pkg; Pkg.test()'`, Julia 1.12.4:
```
NonlinearSolve                     QA |   28            28  1m03.2s   Testing NonlinearSolve tests passed
NonlinearSolveBase                 QA |   20            20  60.0s
NonlinearSolveFirstOrder           QA |   20            20  48.4s
NonlinearSolveQuasiNewton          QA |   20            20  49.3s
NonlinearSolveSpectralMethods      QA |   20            20  42.2s
SimpleNonlinearSolve               QA |   20            20  1m08.5s
BracketingNonlinearSolve           QA |   20            20  47.8s
SciMLJacobianOperators             QA |   20            20  39.7s
SCCNonlinearSolve                  QA |   20            20  35.8s
NonlinearSolveHomotopyContinuation QA |   19  Broken 1  20  1m27.9s   (pre-existing aqua_broken persistent_tasks)
NonlinearSolveSciPy                QA |   20  Broken 1  21  2m11.4s   (pre-existing aqua_broken persistent_tasks)
```
All exit 0.

Also run locally, all clean: Runic 1.7 `--check --diff` on the 10 changed files (exit 0), `typos` on the changed files (exit 0), `TOML.parsefile` over every root/sublibrary/QA `Project.toml` (OK; no TOML was modified).

## What was not verified

- Full `Pkg.test()` QA groups on Julia 1.10 (lts) were launched but hit a local env artifact (Manifests left by the 1.12 runs in the same tree → `Could not locate the source code for the StyledStrings package`), so only the api-docs evidence script above was completed on 1.10. CI's lts QA lane will cover it.
- Downgrade / Downstream / GPU / docs-build lanes: not run (no docs or dependency changes).

## Judgment calls for the reviewer

- Removing `ignore` (docstring check) means the facades now rely on upstream (SciMLBase, NonlinearSolveBase, ADTypes, LinearSolve, LineSearch) keeping every public name documented — which is SciMLTesting's designed behavior ("the check follows the binding"). Today that holds for all 11 packages; if an upstream adds an undocumented public name the fix is upstream, not a new local ignore.
- Dropping the SciPy JET override changes that lane from JET's `BasicPass` to `run_qa`'s standard `TypoPass` (SciMLTesting #52 discusses this fleet-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH2QyqCobgjV3Vsd8xA3nN
