### PR TITLE
Zero-initialize descent buffers handed to LinearSolve

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.44.0"
+version = "2.44.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/descent/damped_newton.jl
+++ b/lib/NonlinearSolveBase/src/descent/damped_newton.jl
@@ -74,9 +74,9 @@ function InternalAPI.init(
     length(fu) != length(u) &&
         @assert pre_inverted isa Val{false} "Precomputed Inverse for Non-Square Jacobian doesn't make sense."
 
-    @bb δu = similar(u)
+    @bb δu = zero(u)
     δus = Utils.unwrap_val(shared) ≤ 1 ? nothing : map(2:Utils.unwrap_val(shared)) do i
-            @bb δu_ = similar(u)
+            @bb δu_ = zero(u)
     end
 
     normal_form_damping = returns_norm_form_damping(alg.damping_fn)
@@ -147,7 +147,7 @@ function InternalAPI.init(
             J_cache = JᵀJ
         end
         J_damped = dampen_jacobian!!(J_cache, JᵀJ, D)
-        @bb z_cache = similar(fu)
+        @bb z_cache = zero(fu)
 
         A, b = Utils.maybe_symmetric(J_damped), Utils.safe_vec(fu)
         Jᵀfu, rhs_cache = nothing, nothing

--- a/lib/NonlinearSolveBase/src/descent/dogleg.jl
+++ b/lib/NonlinearSolveBase/src/descent/dogleg.jl
@@ -63,9 +63,9 @@ function InternalAPI.init(
         pre_inverted, linsolve_kwargs, abstol, reltol, shared, kwargs...
     )
 
-    @bb δu = similar(u)
+    @bb δu = zero(u)
     δus = Utils.unwrap_val(shared) ≤ 1 ? nothing : map(2:Utils.unwrap_val(shared)) do i
-            @bb δu_ = similar(u)
+            @bb δu_ = zero(u)
     end
     @bb δu_cache_1 = similar(u)
     @bb δu_cache_2 = similar(u)

--- a/lib/NonlinearSolveBase/src/descent/geodesic_acceleration.jl
+++ b/lib/NonlinearSolveBase/src/descent/geodesic_acceleration.jl
@@ -76,9 +76,9 @@ function InternalAPI.init(
         internalnorm::F = L2_NORM, kwargs...
     ) where {F}
     T = promote_type(eltype(u), eltype(fu))
-    @bb δu = similar(u)
+    @bb δu = zero(u)
     δus = Utils.unwrap_val(shared) ≤ 1 ? nothing : map(2:Utils.unwrap_val(shared)) do i
-            @bb δu_ = similar(u)
+            @bb δu_ = zero(u)
     end
     descent_cache = InternalAPI.init(
         prob, alg.descent, J, fu, u;

--- a/lib/NonlinearSolveBase/src/descent/newton.jl
+++ b/lib/NonlinearSolveBase/src/descent/newton.jl
@@ -31,9 +31,11 @@ function InternalAPI.init(
         abstol = nothing, reltol = nothing,
         timer = get_timer_output(), kwargs...
     )
-    @bb δu = similar(u)
+    # Descent buffers reach LinearSolve as `linu`, which iterative algorithms read as the
+    # initial guess before the first solve writes them, so they must start defined.
+    @bb δu = zero(u)
     δus = Utils.unwrap_val(shared) ≤ 1 ? nothing : map(2:Utils.unwrap_val(shared)) do i
-            @bb δu_ = similar(u)
+            @bb δu_ = zero(u)
     end
 
     if Utils.unwrap_val(pre_inverted)
@@ -62,9 +64,9 @@ function InternalAPI.init(
     length(fu) != length(u) &&
         @assert !Utils.unwrap_val(pre_inverted) "Precomputed Inverse for Non-Square Jacobian doesn't make sense."
 
-    @bb δu = similar(u)
+    @bb δu = zero(u)
     δus = Utils.unwrap_val(shared) ≤ 1 ? nothing : map(2:Utils.unwrap_val(shared)) do i
-            @bb δu_ = similar(u)
+            @bb δu_ = zero(u)
     end
     normal_form = needs_square_A(alg.linsolve, u)
     if normal_form

--- a/lib/NonlinearSolveBase/src/descent/steepest.jl
+++ b/lib/NonlinearSolveBase/src/descent/steepest.jl
@@ -32,9 +32,9 @@ function InternalAPI.init(
     if Utils.unwrap_val(pre_inverted)
         @assert length(fu) == length(u) "Non-Square Jacobian Inverse doesn't make sense."
     end
-    @bb δu = similar(u)
+    @bb δu = zero(u)
     δus = Utils.unwrap_val(shared) ≤ 1 ? nothing : map(2:Utils.unwrap_val(shared)) do i
-            @bb δu_ = similar(u)
+            @bb δu_ = zero(u)
     end
     if Utils.unwrap_val(pre_inverted)
 

--- a/lib/NonlinearSolveBase/test/descent_buffer_init.jl
+++ b/lib/NonlinearSolveBase/test/descent_buffer_init.jl
@@ -1,0 +1,43 @@
+using NonlinearSolveBase: NonlinearSolveBase, InternalAPI, NewtonDescent, SteepestDescent,
+    Utils
+using SciMLBase: SciMLBase, NonlinearProblem, NLStats
+using LinearAlgebra
+using Test
+
+# `similar` on a plain `Array` usually happens to hand back zeroed pages, which hides an
+# unwritten buffer; this type makes "unwritten" observable.
+struct DirtyVector{T} <: AbstractVector{T}
+    data::Vector{T}
+end
+
+Base.size(v::DirtyVector) = size(v.data)
+Base.getindex(v::DirtyVector, i::Int) = v.data[i]
+Base.setindex!(v::DirtyVector, x, i::Int) = (v.data[i] = x; v)
+function Base.similar(::DirtyVector, ::Type{T}, dims::Dims{1}) where {T <: Number}
+    return DirtyVector(fill(T(1.0e30), dims))
+end
+
+# A descent buffer is passed to LinearSolve as `linu`, which iterative algorithms read as
+# the initial guess *before* the first solve writes it (`WarmStart.Previous`/`Hegedus`).
+# Leaving it unwritten makes the linear solve, and hence any integrator driving it, depend
+# on whatever the allocator last left in that memory.
+@testset "descent caches start with a defined δu" begin
+    n = 4
+    u = DirtyVector(collect(1.0:n))
+    fu = DirtyVector(fill(0.5, n))
+    J = Matrix{Float64}(I, n, n)
+    prob = NonlinearProblem((du, y, p) -> (du .= y), collect(1.0:n))
+
+    # `pre_inverted` is chosen per algorithm so that no LinearSolve cache is built: the
+    # buffer under test is allocated before that branch either way.
+    for (alg, pre_inverted) in ((NewtonDescent(), Val(true)), (SteepestDescent(), Val(false)))
+        for shared in (Val(1), Val(2))
+            cache = InternalAPI.init(
+                prob, alg, J, fu, u; stats = NLStats(0, 0, 0, 0, 0), shared, pre_inverted
+            )
+            for idx in 1:Utils.unwrap_val(shared)
+                @test iszero(SciMLBase.get_du(cache, Val(idx)))
+            end
+        end
+    end
+end

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -165,6 +165,8 @@ run_tests(;
 
         @safetestset "Linear solver routing" include("linear_solver_routing.jl")
 
+        @safetestset "Descent buffers start defined" include("descent_buffer_init.jl")
+
         @safetestset "Jacobian and restructure allocation fast paths" include(
             "allocation_fastpaths.jl"
         )


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

A Newton-Krylov solve is not run-to-run reproducible: the same problem, same algorithm, same process, single-threaded, gives different iteration counts and — with a warm start that has no cosine guard — a different answer.

```
FBDF(linsolve = KrylovJL_GMRES(), nlsolve = NonlinearSolveAlg(NewtonRaphson()))
2D Brusselator 16x16x2, OPENBLAS_NUM_THREADS=1, julia -t1, 4 consecutive solves:

  Jv = [42830, 42830, 32942, 42830]   spread 1.300x   u[end][1,1,1]: 2 distinct values
```

`NLNewton` on the same problem is bit-reproducible.

### Cause

`InternalAPI.init` for the descent caches allocates the step buffer with `@bb δu = similar(u)`. That buffer is handed to LinearSolve as `linu`, where it becomes `LinearCache.u`. For an iterative algorithm, `_krylov_warm_start!` reads `cache.u` as "the previous solution" — but on the **first** solve there is no previous solution, so it reads memory nothing has written.

`NLNewton` is immune because it builds its linear problem with `u0 = _vec(dz)` where `dz = zero(u)`.

The `similar` is old; it became reachable when OrdinaryDiffEq started resolving `WarmStart.Auto → WarmStart.Hegedus` for Newton-Krylov paths (SciML/OrdinaryDiffEq.jl#3991). Before that `Auto` was a cold start — and `warm_start = None` is deterministic today, which is the same configuration.

### Proof that it is read-before-write

Filling the buffer with a sentinel at construction and sweeping its value changes the work count deterministically — the buffer's contents decide the result, so it is read before anything writes it:

```
sentinel = 0.0       Jv 41898
sentinel = 5.0e-17   Jv 41899
sentinel = 1.0e30    Jv 41899
sentinel = <uninit>  Jv 41899
```

Under a `_krylov_warm_start!` without the cosine guard the same sweep reproduces the reported numbers exactly, including the changed answer:

```
sentinel = 5e-17   Jv 42830
sentinel = 1e-3    Jv 32942   f 3528   u[end][1,1,1] = 0.51942129658263902
```

`1e-3` is the magnitude of a recycled residual buffer, which is why the large jump only appeared on repeat solves within a process. A second, independent instrument agrees: pre-fix, `MALLOC_PERTURB_=0` jitters 6299..6300 while `=1`, `=85`, `=170` each pin it to 6300 — forcing malloc to return nonzero bytes makes the "garbage" deterministic.

On released LinearSolve the cosine guard `abs(Aub) < 0.866·√d·‖b‖` rejects a near-orthogonal garbage direction, so the visible symptom there is only a wasted matvec (±1 Jv) rather than a changed answer.

### Fix

`similar` → `zero` for the descent buffers that can reach LinearSolve as `linu`, in `InternalAPI.init` only. Genuine warm starts from *later* solves are untouched — nothing is zeroed per-solve.

The cost is negative: it removes the wasted matvec spent computing a Hegedüs `Au` on garbage and then discarding it (6300→6299, 11193→11192, 41899→41898).

No behaviour change for immutable `u`: `MaybeInplace`'s `__zero(::CannotSetindex, x)` and `__similar(::CannotSetindex, x)` both return the input.

### Verification

15 repeats per row, heap poisoned and `GC.gc()` between solves, at rtol 1e-6 / 1e-9 / 1e-12:

```
                        before                       after
NSA  1e-06   Jv 6382..6398   solhash uniq=9    Jv 6382..6382   uniq=1
NSA  1e-09   Jv 11468..11692 solhash uniq=12   Jv 11568..11568 uniq=1
NSA  1e-12   Jv 32942..42830 solhash uniq=10   Jv 42828..42828 uniq=1
```

`solhash` fingerprints the whole trajectory, not one component. Across 21 configurations, only the three `NSA-GMRES` rows change (each by −1 matvec); `warm_start = None`, `LUFactorization`, the default linsolve, and both `NLNewton` rows are byte-identical.

**Scope**: iterative solvers only — `_krylov_warm_start!` has a single call site, `solve!(::LinearCache, ::KrylovJL)`; factorization algorithms never read `cache.u`. Not autodiff-specific (`AutoForwardDiff` and `AutoFiniteDiff` behave identically). Do *not* work around it with `warm_start = None`: that costs ~40% more matvecs (15114 vs 10811).

`GROUP=Core` passes for `NonlinearSolveBase` and `NonlinearSolveFirstOrder`. Runic clean. Patch bump 2.44.0 → 2.44.1.

### Test

`lib/NonlinearSolveBase/test/descent_buffer_init.jl` uses a `DirtyVector` whose `similar` returns `1e30`-filled memory, so it is deterministic rather than allocator-dependent (same idiom as the existing `NoFastScalarMatrix` test). Negative control against unfixed:

```
Expression: iszero(SciMLBase.get_du(cache, Val(idx)))
Test Summary: descent caches start with a defined δu | 6 fail, 6 total
```

With the fix: 6 pass.

### Noted while testing

`OrdinaryDiffEqNonlinearSolve`'s `GROUP=Core` has one pre-existing failure unrelated to this change — `linear_solver_tests.jl:15`, `sol.stats.njacs == 0` → `1 == 0`, a `Rosenbrock23` + `MatrixOperator` mass-matrix assertion with no nonlinear solver in the path. Identical with registry `NonlinearSolveBase` 2.44.0, so it is not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
