### PR TITLE
qa: use standard SciMLTesting docs discovery

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -55,6 +55,7 @@ makedocs(;
         "https://iopscience.iop.org/article/10.1088/1757-899X/1276/1/012010/",  # IOP redirects to PerimeterX bot validator from CI
     ],
     checkdocs = :exports,
+    warnonly = [:missing_docs],
     plugins = [bib, interlinks],
     format = Documenter.HTML(
         assets = ["assets/favicon.ico", "assets/citations.css"],

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -55,7 +55,6 @@ makedocs(;
         "https://iopscience.iop.org/article/10.1088/1757-899X/1276/1/012010/",  # IOP redirects to PerimeterX bot validator from CI
     ],
     checkdocs = :exports,
-    warnonly = [:missing_docs],
     plugins = [bib, interlinks],
     format = Documenter.HTML(
         assets = ["assets/favicon.ico", "assets/citations.css"],

--- a/lib/BracketingNonlinearSolve/test/qa/qa.jl
+++ b/lib/BracketingNonlinearSolve/test/qa/qa.jl
@@ -1,7 +1,6 @@
 using SciMLTesting, BracketingNonlinearSolve, Test
 import ForwardDiff
 
-const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs", "src")
 
 const BRACKETING_EXTERNAL_REEXPORTS = union(
     public_api_names(BracketingNonlinearSolve.SciMLBase),
@@ -19,7 +18,6 @@ run_qa(
         piracies = (; treat_as_own = [IntervalNonlinearProblem]),
         ambiguities = (; recursive = false),
     ),
-    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # Still non-public in their owning packages. __solve dropped: now public in
         # SciMLBase.

--- a/lib/NonlinearSolveBase/test/qa/qa.jl
+++ b/lib/NonlinearSolveBase/test/qa/qa.jl
@@ -2,7 +2,6 @@ using SciMLTesting, NonlinearSolveBase, Test
 using NonlinearSolveBase: AbstractNonlinearProblem, NonlinearProblem, SciMLBase
 import ForwardDiff, SparseArrays
 
-const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs", "src")
 
 run_qa(
     NonlinearSolveBase;
@@ -15,7 +14,6 @@ run_qa(
         ),
         ambiguities = (; recursive = false),
     ),
-    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # SciMLLogging preset names reached only through the @verbosity_specifier macro
         # expansion (None/Minimal/Standard/Detailed/All as bare constructors in

--- a/lib/NonlinearSolveFirstOrder/test/qa/qa.jl
+++ b/lib/NonlinearSolveFirstOrder/test/qa/qa.jl
@@ -1,6 +1,5 @@
 using SciMLTesting, NonlinearSolveFirstOrder, Test
 
-const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs", "src")
 
 const FIRST_ORDER_EXTERNAL_REEXPORTS = union(
     public_api_names(NonlinearSolveFirstOrder.SciMLBase),
@@ -16,7 +15,6 @@ run_qa(
         piracies = (; treat_as_own = [NonlinearLeastSquaresProblem]),
         ambiguities = (; recursive = false),
     ),
-    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # Still non-public in their owning packages (NonlinearSolveBase's own internal API;
         # the sublibrary builds on it by design). __init / __solve dropped: now public in

--- a/lib/NonlinearSolveHomotopyContinuation/test/qa/qa.jl
+++ b/lib/NonlinearSolveHomotopyContinuation/test/qa/qa.jl
@@ -1,6 +1,5 @@
 using SciMLTesting, NonlinearSolveHomotopyContinuation, Test
 
-const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs", "src")
 
 const HOMOTOPY_EXTERNAL_REEXPORTS = (:HomotopyNonlinearFunction,)
 
@@ -8,7 +7,6 @@ run_qa(
     NonlinearSolveHomotopyContinuation;
     explicit_imports = true,
     reexports_allow = HOMOTOPY_EXTERNAL_REEXPORTS,
-    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     # persistent_tasks: intermittently errors on Julia >=1.11 because the registered
     # NonlinearSolveBase ships a leaked `[sources]` (SciMLJacobianOperators =
     # {path = "../SciMLJacobianOperators"}) that Pkg >=1.11 honors during Aqua's

--- a/lib/NonlinearSolveQuasiNewton/test/qa/qa.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/qa/qa.jl
@@ -1,6 +1,5 @@
 using SciMLTesting, NonlinearSolveQuasiNewton, Test
 
-const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs", "src")
 
 const QUASI_NEWTON_EXTERNAL_REEXPORTS = union(
     public_api_names(NonlinearSolveQuasiNewton.SciMLBase),
@@ -17,7 +16,6 @@ run_qa(
         deps_compat = (; ignore = [:SciMLJacobianOperators]),
         ambiguities = (; recursive = false),
     ),
-    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # Still non-public in their owning packages (NonlinearSolveBase's own internal API;
         # the sublibrary builds on it by design). __init dropped: now public in SciMLBase.

--- a/lib/NonlinearSolveSciPy/test/qa/qa.jl
+++ b/lib/NonlinearSolveSciPy/test/qa/qa.jl
@@ -1,7 +1,6 @@
 using SciMLTesting, NonlinearSolveSciPy, Test
 using JET
 
-const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs", "src")
 
 const SCIPY_EXTERNAL_REEXPORTS = union(
     public_api_names(NonlinearSolveSciPy.SciMLBase),
@@ -13,7 +12,6 @@ run_qa(
     NonlinearSolveSciPy;
     explicit_imports = true,
     reexports_allow = SCIPY_EXTERNAL_REEXPORTS,
-    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     # persistent_tasks: intermittently errors on Julia >=1.11 because the registered
     # NonlinearSolveBase ships a leaked `[sources]` (SciMLJacobianOperators =
     # {path = "../SciMLJacobianOperators"}) that Pkg >=1.11 honors during Aqua's

--- a/lib/NonlinearSolveSpectralMethods/test/qa/qa.jl
+++ b/lib/NonlinearSolveSpectralMethods/test/qa/qa.jl
@@ -1,6 +1,5 @@
 using SciMLTesting, NonlinearSolveSpectralMethods, Test
 
-const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs", "src")
 
 const SPECTRAL_METHODS_EXTERNAL_REEXPORTS = union(
     public_api_names(NonlinearSolveSpectralMethods.SciMLBase),
@@ -17,7 +16,6 @@ run_qa(
         deps_compat = (; ignore = [:SciMLJacobianOperators]),
         ambiguities = (; recursive = false),
     ),
-    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # Still non-public in their owning packages (NonlinearSolveBase's own internal API;
         # the sublibrary builds on it by design). __init dropped: now public in SciMLBase.

--- a/lib/SCCNonlinearSolve/test/qa/qa.jl
+++ b/lib/SCCNonlinearSolve/test/qa/qa.jl
@@ -1,6 +1,5 @@
 using SciMLTesting, SCCNonlinearSolve, Test
 
-const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs", "src")
 
 run_qa(
     SCCNonlinearSolve;
@@ -11,7 +10,6 @@ run_qa(
         piracies = (; treat_as_own = [SCCNonlinearSolve.SciMLBase.solve]),
         ambiguities = (; recursive = false),
     ),
-    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # Still non-public in their owning packages after the make-public round:
         #   SciMLBase: build_linear_solution, strip_solution;  Base: Cartesian

--- a/lib/SciMLJacobianOperators/test/qa/qa.jl
+++ b/lib/SciMLJacobianOperators/test/qa/qa.jl
@@ -1,11 +1,9 @@
 using SciMLTesting, SciMLJacobianOperators, Test
 
-const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs", "src")
 
 run_qa(
     SciMLJacobianOperators;
     explicit_imports = true,
-    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # Still non-public in its owning package after the make-public round:
         #   SciMLBase: AbstractNonlinearFunction

--- a/lib/SimpleNonlinearSolve/test/qa/qa.jl
+++ b/lib/SimpleNonlinearSolve/test/qa/qa.jl
@@ -1,7 +1,6 @@
 using SciMLTesting, SimpleNonlinearSolve, Test
 import ReverseDiff, Tracker, StaticArrays, Zygote
 
-const NONLINEARSOLVE_DOCS_SRC = joinpath(@__DIR__, "..", "..", "..", "..", "docs", "src")
 
 const SIMPLE_EXTERNAL_REEXPORTS = union(
     public_api_names(SimpleNonlinearSolve.ADTypes),
@@ -25,7 +24,6 @@ run_qa(
         ),
         ambiguities = (; recursive = false),
     ),
-    api_docs_kwargs = (; docs_src = NONLINEARSOLVE_DOCS_SRC),
     ei_kwargs = (;
         # Still non-public in their owning packages, across the main module and the
         # Tracker / ReverseDiff / ChainRulesCore extensions. __init / __solve dropped:


### PR DESCRIPTION
## Summary

Focused QA configuration cleanup. SciMLTesting 2.10 automatically discovers the repository-level `docs/src` manual for conventional `lib/<PackageName>` subpackages, so the ten duplicated `NONLINEARSOLVE_DOCS_SRC` constants and `api_docs_kwargs = (; docs_src = ...)` overrides are removed. Explicit-import and reexport exception lists are unchanged.

This PR does not change runtime behavior, compat metadata, public exports, or test suppression.

## Verification

- BracketingNonlinearSolve QA: `20/20`
- NonlinearSolveBase QA: `20/20`
- NonlinearSolveQuasiNewton QA: `20/20`
- NonlinearSolveHomotopyContinuation QA: `19 passed, 1 broken, 20 total`
- NonlinearSolveSciPy QA: `20 passed, 1 broken, 21 total`
- NonlinearSolveSpectralMethods QA: `20/20`
- SCCNonlinearSolve QA: `20/20`
- SciMLJacobianOperators QA: `20/20`
- SimpleNonlinearSolve QA: `20/20`
- Changed files pass Runic, `typos`, and `git diff --check`.

NonlinearSolveFirstOrder reports `19 passed, 1 errored` for the existing non-public imports of `residual_only_termination_mode` and `trace_is_active`. The same error reproduces on a clean `upstream/master` worktree with no changes from this PR; it is being investigated separately and is not suppressed here.

Please ignore this draft until reviewed by @ChrisRackauckas.

- `timeout 3600 julia --startup-file=no --project=docs docs/make.jl` -> completed with `DOCS_EXIT=0` after local docs instantiation.