### PR TITLE
chore: fix trivial runic comment typo

### DIFF
--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseForwardDiffExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseForwardDiffExt.jl
@@ -84,7 +84,7 @@ end
 # wrapped callable is one inference cannot see through: a functor such as the homotopy
 # drivers' `FixLambda` / `AugmentedHomotopy` / `HomotopyResidual` residuals (the same reason
 # DiffEqBase hit this with many-parameter `ODEFunction`s). Binding each arglist as a
-# `::Type{A}` type parameter makes `FunctionWrapper{Nothing, A}(vff)` fully inferrable, so
+# `::Type{A}` type parameter makes `FunctionWrapper{Nothing, A}(vff)` fully inferable, so
 # `typeof(fwt)` — and the wrapper — stays concrete. `vff` is `@nospecialize`d because it is
 # already type-erased through `Void` (that is what makes the norecompile path precompile).
 function _make_fww_iip(


### PR DESCRIPTION
## Summary
- Fix a misspelling in `lib/NonlinearSolveBase/ext/NonlinearSolveBaseForwardDiffExt.jl` to satisfy runic typo/format checks.

## Verification
- `INPUT_RUNIC_EXTENSIONS=jl INPUT_RUNIC_DOCSTRINGS=false julia --project=@runic /tmp/fk_check.jl`
- `typos .`
- Both commands pass on a clean `master` checkout.

## PR notes
- This PR should be ignored until reviewed by @ChrisRackauckas.
