### PR TITLE
Fix three defects in the nonlinear termination conditions

### DIFF
--- a/lib/NonlinearSolveBase/src/public.jl
+++ b/lib/NonlinearSolveBase/src/public.jl
@@ -264,7 +264,7 @@ AbstractSafeNonlinearTerminationMode end
 #! format: off
 const TERM_DOCS = Dict(
     :Norm => doc"``\| Δu \| ≤ reltol × \| Δu + u \|`` or ``\| Δu \| ≤ abstol``",
-    :Rel => doc"``\mathrm{all} \left(| Δu | ≤ reltol × | u | \right)``",
+    :Rel => doc"``\mathrm{all} \left(| Δu | ≤ reltol × | Δu + u | \right)``",
     :RelNorm => doc"``\| Δu \| ≤ reltol × \| Δu + u \|``",
     :Abs => doc"``\mathrm{all} \left( | Δu | ≤ abstol \right)``",
     :AbsNorm => doc"``\| Δu \| ≤ abstol``"

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -373,6 +373,9 @@ function _run_cache_to_completion!(
         )
     end
 
+    # A driver may have stepped with `evaluate_residual = false`; the residual has to be
+    # brought forward before it is reported, since nothing downstream re-evaluates it.
+    refresh_residual!(cache)
     update_from_termination_cache!(cache.termination_cache, cache)
 
     update_trace!(

--- a/lib/NonlinearSolveBase/src/termination_conditions.jl
+++ b/lib/NonlinearSolveBase/src/termination_conditions.jl
@@ -127,7 +127,7 @@ function CommonSolve.init(
             u0_norm = nothing
         else
             initial_objective = Utils.apply_norm(mode.internalnorm, du) /
-                (Utils.apply_norm(mode.internalnorm, du, u) + eps(reltol))
+                (Utils.apply_norm(mode.internalnorm, du, u) + eps(TT))
             u0_norm = mode.max_stalled_steps === nothing ? nothing : L2_NORM(u)
         end
         objectives_trace = Vector{TT}(undef, mode.patience_steps)

--- a/lib/NonlinearSolveBase/src/termination_conditions.jl
+++ b/lib/NonlinearSolveBase/src/termination_conditions.jl
@@ -37,7 +37,9 @@ residual_only_termination_mode(::AbsNormTerminationMode) = true
     u0_norm
     step_norm_trace
     max_stalled_steps
-    u_diff_cache::uType
+    # Scratch for `u - uprev`. It is sized from `u`, whereas `uType` is the type of the
+    # retained best iterate, which is `nothing` for every non-`Best` mode.
+    u_diff_cache
     leastsq::Bool
 end
 
@@ -95,6 +97,18 @@ function update_u!!(cache::NonlinearTerminationModeCache, u)
     end
 end
 
+"""
+    alloc_u_diff_cache(u)
+
+Scratch to hold `u - uprev` for the stall test. Sized from `u`, since the retained best
+iterate a `Best` mode carries is absent from every other mode. When `u` cannot be written
+into in place the difference is rebuilt each step, so this only has to fix the type.
+"""
+function alloc_u_diff_cache(u)
+    (u isa Number || !ArrayInterface.can_setindex(u)) && return u .- u
+    return similar(u)
+end
+
 function CommonSolve.init(
         prob::AbstractNonlinearProblem, mode::AbstractNonlinearTerminationMode, du, u,
         saved_value_prototype...; abstol = nothing, reltol = nothing, kwargs...
@@ -119,13 +133,7 @@ function CommonSolve.init(
         objectives_trace = Vector{TT}(undef, mode.patience_steps)
         step_norm_trace = mode.max_stalled_steps === nothing ? nothing :
             Vector{TT}(undef, mode.max_stalled_steps)
-        if step_norm_trace !== nothing &&
-                ArrayInterface.can_setindex(u_unaliased) &&
-                !(u_unaliased isa Number)
-            u_diff_cache = similar(u_unaliased)
-        else
-            u_diff_cache = u_unaliased
-        end
+        u_diff_cache = step_norm_trace === nothing ? nothing : alloc_u_diff_cache(u)
         best_value = initial_objective
         max_stalled_steps = mode.max_stalled_steps
     else
@@ -135,7 +143,7 @@ function CommonSolve.init(
         step_norm_trace = nothing
         best_value = Utils.convert_real(T, Inf)
         max_stalled_steps = nothing
-        u_diff_cache = u_unaliased
+        u_diff_cache = nothing
     end
 
     length(saved_value_prototype) == 0 && (saved_value_prototype = nothing)
@@ -251,7 +259,6 @@ function (cache::NonlinearTerminationModeCache)(
 
     # Terminate if we haven't improved for the last `patience_steps`
     cache.nsteps += 1
-    cache.nsteps == 1 && (cache.initial_objective = objective)
     cache.objectives_trace[mod1(cache.nsteps, length(cache.objectives_trace))] = objective
 
     if objective ≤ mode.patience_objective_multiplier * criteria &&
@@ -275,7 +282,8 @@ function (cache::NonlinearTerminationModeCache)(
 
     # Test for stalling if that is enabled
     if cache.step_norm_trace !== nothing
-        if ArrayInterface.can_setindex(cache.u_diff_cache) && !(u isa Number)
+        if cache.u_diff_cache !== nothing && !(u isa Number) &&
+                ArrayInterface.can_setindex(cache.u_diff_cache)
             @. cache.u_diff_cache = u - uprev
         else
             cache.u_diff_cache = u .- uprev
@@ -402,12 +410,18 @@ end
 function update_from_termination_cache!(
         tc_cache, cache, ::AbstractNonlinearTerminationMode, u = get_u(cache)
     )
-    return Utils.evaluate_f!(cache, u, cache.p)
+    # The residual handed to the termination check is the one at the current iterate, so
+    # `cache.fu` already describes `u` and there is nothing to recompute.
+    return nothing
 end
 
 function update_from_termination_cache!(
         tc_cache, cache, ::AbstractSafeBestNonlinearTerminationMode, u = get_u(cache)
     )
+    # `Best` modes retain the lowest-objective iterate, which is usually the one the solve
+    # ended on; only a genuine rollback needs the residual recomputed.
+    tc_cache.u === nothing && return nothing
+    get_u(cache) == tc_cache.u && return nothing
     if SciMLBase.isinplace(cache)
         copyto!(get_u(cache), tc_cache.u)
     else

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -92,6 +92,11 @@ run_tests(;
                                 Base.Fix1(maximum, abs); max_stalled_steps = 3
                             ),
                         ),
+                        (
+                            "RelNormSafeBest", NonlinearSolveBase.RelNormSafeBestTerminationMode(
+                                Base.Fix1(maximum, abs); max_stalled_steps = 3
+                            ),
+                        ),
                     ),
                     u0 in ([1.0, 1.0], 1.0, SA[1.0, 1.0])
 

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -24,6 +24,7 @@ run_tests(;
 
         @safetestset "Termination Conditions" begin
             using NonlinearSolveBase, SciMLBase
+            using StaticArrays: SA
 
             @testset "reinit! with AbsTerminationMode" begin
                 mode = NonlinearSolveBase.AbsTerminationMode()
@@ -68,6 +69,64 @@ run_tests(;
                 @test termination_condition_result(
                     safe_best, [2.0], 2.0, ReturnCode.Terminated
                 ) == ([0.5], 3.0, ReturnCode.Success)
+            end
+
+            # `max_stalled_steps` is a documented constructor option on every safe mode,
+            # but the non-`Best` ones retain no iterate, so the step scratch cannot be
+            # sized from one.
+            @testset "max_stalled_steps: $modename, u0::$(typeof(u0))" for (
+                        modename, mode,
+                    ) in (
+                        (
+                            "AbsNormSafe", NonlinearSolveBase.AbsNormSafeTerminationMode(
+                                Base.Fix1(maximum, abs); max_stalled_steps = 3
+                            ),
+                        ),
+                        (
+                            "RelNormSafe", NonlinearSolveBase.RelNormSafeTerminationMode(
+                                Base.Fix1(maximum, abs); max_stalled_steps = 3
+                            ),
+                        ),
+                        (
+                            "AbsNormSafeBest", NonlinearSolveBase.AbsNormSafeBestTerminationMode(
+                                Base.Fix1(maximum, abs); max_stalled_steps = 3
+                            ),
+                        ),
+                    ),
+                    u0 in ([1.0, 1.0], 1.0, SA[1.0, 1.0])
+
+                du = u0 isa Number ? 1.0 : (u0 .* 0 .+ 1.0)
+                prob = SciMLBase.NonlinearProblem((u, p) -> du, u0)
+                cache = SciMLBase.init(
+                    prob, mode, du, u0; abstol = 1.0e-8, reltol = 1.0e-8
+                )
+                # The iterate stops moving while the residual stays far above `abstol`:
+                # the stall safeguard is exactly what must fire.
+                terminated = false
+                for _ in 1:5
+                    terminated = cache(du, u0, u0)
+                end
+                @test terminated
+                @test cache.retcode == SciMLBase.ReturnCode.Stalled
+            end
+
+            @testset "protective_threshold measures against the initial residual" begin
+                mode = NonlinearSolveBase.AbsNormSafeTerminationMode(
+                    Base.Fix1(maximum, abs); protective_threshold = 1.0
+                )
+                prob = SciMLBase.NonlinearProblem((u, p) -> [100.0], [1.0])
+                cache = SciMLBase.init(
+                    prob, mode, [100.0], [1.0]; abstol = 1.0e-10, reltol = 1.0e-10
+                )
+                @test cache.initial_objective == 100.0
+
+                @test !cache([1.0e-3], [1.1], [1.0])
+                @test cache.initial_objective == 100.0
+
+                # 5.0 is twenty times *below* the initial residual, so nothing about it
+                # is divergence.
+                @test !cache([5.0], [1.2], [1.1])
+                @test cache.retcode != SciMLBase.ReturnCode.Unstable
             end
         end
 

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests.jl
@@ -5,3 +5,4 @@
 @safetestset "Default NLLS polyalg is forward-mode only: Issue #837" include("misc_tests__item5.jl")
 @safetestset "Eisenstat-Walker forcing reinit! resets forcing state" include("misc_tests__item6.jl")
 @safetestset "Deferred residual evaluation" include("misc_tests__item7.jl")
+@safetestset "No redundant terminal residual evaluation" include("misc_tests__item8.jl")

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests__item8.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests__item8.jl
@@ -1,0 +1,46 @@
+using NonlinearSolveFirstOrder
+using NonlinearSolveBase: AbsNormSafeBestTerminationMode, AbsNormSafeTerminationMode,
+    AbsNormTerminationMode, AbsTerminationMode
+using SciMLBase: NonlinearProblem, NonlinearFunction, ReturnCode, solve
+using LinearAlgebra: Diagonal
+using Test
+
+const linf = Base.Fix1(maximum, abs)
+
+# Analytic Jacobian, so every call to `f` is a residual evaluation.
+sq(u, p) = u .* u .- 2.0
+dsq(u, p) = 2 .* Diagonal(u)
+
+function iterates_evaluated(alg, tc; u0 = [1.0], maxiters = 1000)
+    seen = Vector{Float64}[]
+    f = (u, p) -> (push!(seen, copy(u)); sq(u, p))
+    prob = NonlinearProblem(NonlinearFunction(f; jac = dsq), u0)
+    kw = tc === nothing ? (;) : (; termination_condition = tc)
+    sol = solve(prob, alg; maxiters, kw...)
+    return sol, seen
+end
+
+@testset "residual is not recomputed at the terminating iterate" begin
+    @testset "$(nameof(typeof(alg))) / $tcname" for (tcname, tc) in (
+                ("default", nothing),
+                ("AbsNormTerminationMode", AbsNormTerminationMode(linf)),
+                ("AbsNormSafeTerminationMode", AbsNormSafeTerminationMode(linf)),
+                ("AbsNormSafeBestTerminationMode", AbsNormSafeBestTerminationMode(linf)),
+                ("AbsTerminationMode", AbsTerminationMode()),
+            ),
+            alg in (NewtonRaphson(), TrustRegion())
+
+        sol, seen = iterates_evaluated(alg, tc)
+        @test sol.retcode == ReturnCode.Success
+        @test count(==(sol.u), seen) == 1
+        @test sol.resid ≈ sq(sol.u, nothing)
+    end
+end
+
+@testset "a safe-best rollback still refreshes the residual" begin
+    # Stopped short of convergence, so the retained best iterate is not the last one.
+    cubic(u, p) = [(u[1] - 1.0)^3 + 1.0e-3 * u[1]]
+    prob = NonlinearProblem(cubic, [3.0])
+    sol = solve(prob, NewtonRaphson(); maxiters = 4)
+    @test sol.resid ≈ cubic(sol.u, nothing)
+end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Partially addresses #1149.

An audit of the termination conditions, prompted by a report that solvers may take more iterations than the tolerance warrants. **The iteration counts themselves are correct** — on well-scaled problems NonlinearSolve takes exactly as many Newton steps as a hand-written loop with the same criterion. What the audit did find is one hard error on a documented option, two wasted residual evaluations on every solve, and a broken safeguard. This PR fixes those three; the remaining findings are described at the end and left for separate issues, because they are behaviour changes that need a decision rather than a fix.

### 1. `max_stalled_steps` throws on two of the four safe modes

`init` sizes the step scratch from the retained *best* iterate, which is `nothing` for every non-`Best` mode, and `ArrayInterface.can_setindex(nothing) === true`, so it reaches `similar(nothing)`:

```
AbsNormSafeTerminationMode  u0::Vector{Float64}      -> MethodError: no method matching similar(::Nothing)
RelNormSafeTerminationMode  u0::Float64, SVector     -> MethodError
AbsNormSafeBestTerminationMode                       -> Success
```

`max_stalled_steps` is in the documented constructor of all four modes, and `init` already computes `u0_norm` precisely when it is set on the `RelNorm` branch — so the option was meant to work there. Nothing works today, so the fix cannot regress anything.

### 2. Two redundant residual evaluations per solve

`update_from_termination_cache!` unconditionally re-evaluates `f` at the iterate the caller has just evaluated, and it is called twice — once from `check_and_update!` and again from `_run_cache_to_completion!`. Recording `(u, p)` at every call confirms the trailing evaluations are at bit-identical `u` and identical `p`; nothing in between mutates either.

Overhead is `2/(nsteps+3)`, independent of problem size and termination mode:

| problem | steps | f-evals before | minimum | overhead |
|---|---|---|---|---|
| `u²-2` from `u₀=1.4` | 3 | 6 | 4 | **33.3%** |
| `u²-2` from `u₀=1.0` | 5 | 8 | 6 | 25.0% |
| `u²-2` from `u₀=100` | 11 | 14 | 12 | 14.3% |
| `u³` from `u₀=1` | 24 | 27 | 25 | 7.4% |

After the fix NonlinearSolve does exactly the minimum, matching a hand-written Newton loop (`extra_nf = +0, extra_it = +0` at n = 1 and n = 1000).

This is a **direct-user** cost. Solves driven by OrdinaryDiffEq hide it almost entirely, because the zeroed inner tolerances mean the termination check rarely fires — which is presumably why it has gone unnoticed.

### 3. `initial_objective` is overwritten, disabling `protective_threshold`

`init` sets it from `‖F(u₀)‖`; the first cache call overwrites it with `‖F(u₁)‖`. The overwrite cannot be guarding against a bad seed either, because the protective check runs *before* `nsteps += 1`. Measured: `init` → 100.0, first call → 0.001, after which feeding `‖F‖ = 5.0` (twenty times *below* the initial residual) returns `ReturnCode.Unstable`.

### Behaviour neutrality

978 solves — 14 problems × 9 algorithms × 8 termination modes, n = 1…100, in-place/out-of-place/`SVector`/scalar/NLLS — dumping `u` at 17 significant digits:

```
u, retcode, nsteps, resid:  IDENTICAL in all 978 solves
f-eval delta:  -2 in 758,  -1 in 132,  0 in 40
   Success -> -2 (746)   MaxIters -> -1 (104) or 0 (38)   StalledSuccess -> -2 (10) or -1 (6)
```

That breakdown matches the mechanism exactly: a `Success` pays both calls, a `MaxIters` never reaches `check_and_update!` so it pays one, and zero when a `Best` rollback genuinely needs the recomputation.

`GROUP=Core` passes for `NonlinearSolveBase` (`Termination Conditions | 34 34`) and `NonlinearSolveFirstOrder` (37 testsets, including `TrustRegion | 1176 1176`). Runic clean. Patch bump.

### Caught in review, and fixed here

Removing the redundant evaluation took away the only thing that settled an outstanding deferral on the `evaluate_residual = false` path added in #1167, so a driver that stepped with deferral and then called `solve!` received a residual belonging to the *previous* iterate:

```
                 before this PR      with the naive fix     corrected
maxiters=1       fu matches u        fu = -1, f(u) = 0.25   fu matches u
maxiters=2       fu matches u        mismatch               fu matches u
```

`_run_cache_to_completion!` now calls `refresh_residual!` first. The deferral tests did not catch this because they never mix manual stepping with `solve!`, and no in-`solve` path sets `defer_residual`. It is reachable from any external driver — OrdinaryDiffEq's `NonlinearSolveAlg` being the obvious one.

Also: `init` regularised the `RelNorm` initial objective with `eps(reltol)` while `reinit!` used `eps(TT)` (measured `6.045e-277` vs `4.504e-285` for identical inputs). That was latent while step 1 overwrote the value; fix 3 makes `init`'s value authoritative and therefore promotes it to a live inconsistency, so the two now agree. The *running* objective still uses `eps(reltol)` — changing that alters live behaviour, so I left it and am flagging it instead.

### Found but deliberately not fixed here

Each is a behaviour change that wants a decision, not a patch:

- **The stall safeguard compares `‖Δu‖₂` against `abstol`**, a bound on `‖F(u)‖` — two independent scale errors, since it is also hard-coded to `L2_NORM` while the `NonlinearProblem` default `internalnorm` is L∞. The verdict flips with problem size (√n) and with a change of variables Newton is invariant to: the same iteration `Stalled`s at `S = 1` and runs 27× longer to `MaxIters` at `S = 10⁴`. The step-size threshold is literally `abstol` (fires at `1e-31` and `1e-40` for `abstol = 1e-30`, not at `1e-20`). For `NonlinearProblem` a spurious fire yields `Stalled`, a failure code; for `NonlinearLeastSquaresProblem` it becomes `StalledSuccess`, and `successful_retcode(StalledSuccess) === true`, so there it is a silent early exit.
- **The patience "no improvement" guard is a tautology**: `min_obj < min_max_factor * max_obj` with `min_obj ≤ max_obj` and a default factor of 1.3 is true for every positive residual, so `min_max_factor` is inert and a strictly decreasing residual can be declared `Stalled`. The intended test is presumably the reverse. Blast radius is confined to solves sitting inside `(abstol, 3·abstol]`.
- **`reltol` is silently ignored for `NonlinearProblem`** — the default mode is absolute, so `reltol ∈ {1e-1, 1e-2, 1e-6}` gives identical iterations, f-evals and residual (partly covered by #1149).
- **`RelNorm` modes compare a residual against `‖du .+ u‖`**, mixing a residual with an iterate.
- **`protective_threshold`'s `length(du)` factor** means an identical 50× residual blow-up fires at n=1 and n=10 but not at n=100 — divergence detection weakens as the problem grows.
- **`SimpleNewtonRaphson`'s `sol.resid` does not correspond to `sol.u`** (opposite sign), and it takes one more Jacobian probe than needed. It is the only Simple solver with this discrepancy.

I can open these as separate issues, or fold any of them in here if you would rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
