### PR TITLE
docs: specify NonlinearSolveBase interface traits

### DIFF
--- a/docs/src/devdocs/internal_interfaces.md
+++ b/docs/src/devdocs/internal_interfaces.md
@@ -55,6 +55,9 @@ NonlinearSolveBase.AbstractDescentCache
 NonlinearSolveBase.supports_line_search
 NonlinearSolveBase.supports_trust_region
 NonlinearSolveBase.set_du!
+NonlinearSolveBase.last_step_accepted
+NonlinearSolveBase.preinverted_jacobian
+NonlinearSolveBase.normal_form
 ```
 
 ### Descent Results
@@ -72,6 +75,10 @@ NonlinearSolveBase.AbstractApproximateJacobianUpdateRule
 NonlinearSolveBase.AbstractApproximateJacobianUpdateRuleCache
 NonlinearSolveBase.reset_update_rule_state!
 NonlinearSolveBase.AbstractResetCondition
+NonlinearSolveBase.stores_full_jacobian
+NonlinearSolveBase.get_full_jacobian
+NonlinearSolveBase.jacobian_initialized_preinverted
+NonlinearSolveBase.store_inverse_jacobian
 ```
 
 ## Damping Algorithms
@@ -79,6 +86,9 @@ NonlinearSolveBase.AbstractResetCondition
 ```@docs
 NonlinearSolveBase.AbstractDampingFunction
 NonlinearSolveBase.AbstractDampingFunctionCache
+NonlinearSolveBase.requires_normal_form_jacobian
+NonlinearSolveBase.requires_normal_form_rhs
+NonlinearSolveBase.returns_norm_form_damping
 ```
 
 ## Trust Region

--- a/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
+++ b/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
@@ -126,6 +126,15 @@ include("forward_diff.jl")
 @compat(
     public,
     (
+        last_step_accepted, preinverted_jacobian, normal_form,
+        requires_normal_form_jacobian, requires_normal_form_rhs, returns_norm_form_damping,
+        stores_full_jacobian, get_full_jacobian, jacobian_initialized_preinverted,
+        store_inverse_jacobian,
+    )
+)
+@compat(
+    public,
+    (
         needs_conditioning, transform_conditioned_problem, apply_postcondition!!,
         get_precondition, get_postcondition, supports_postcondition,
     )

--- a/lib/NonlinearSolveBase/src/abstract_types.jl
+++ b/lib/NonlinearSolveBase/src/abstract_types.jl
@@ -227,7 +227,12 @@ acceptance is stored outside that field.
 
 # Arguments
 
-- `cache`: A descent or trust-region cache.
+- `cache::AbstractDescentCache`: A descent or trust-region cache. If the cache does not
+  have a `last_step_accepted` field, the default method assumes that the step was accepted.
+
+# Returns
+
+`true` when the most recent step was accepted and `false` when it was rejected.
 
 # Examples
 
@@ -253,6 +258,25 @@ Return whether the cache stores an inverse Jacobian rather than the Jacobian its
 
 The default reads the cache's `preinverted_jacobian` field and treats `missing` as `false`.
 Descent cache implementations should provide that field or overload this hook.
+
+# Arguments
+
+- `cache::AbstractDescentCache`: A descent cache whose `preinverted_jacobian` field is a
+  `Bool` or `Val{Bool}`, or a cache with a specialized method.
+
+# Returns
+
+`true` when the cache stores an inverse Jacobian and `false` when it stores the Jacobian.
+
+# Examples
+
+```julia
+struct InvertedCache <: NonlinearSolveBase.AbstractDescentCache
+    preinverted_jacobian::Val{true}
+end
+
+NonlinearSolveBase.preinverted_jacobian(InvertedCache(Val(true))) # true
+```
 """
 function preinverted_jacobian(cache::AbstractDescentCache)
     res = Utils.unwrap_val(Utils.safe_getproperty(cache, Val(:preinverted_jacobian)))
@@ -267,6 +291,25 @@ Return whether the cache's linear solve uses normal-form equations.
 
 The default reads the cache's `normal_form` field and treats `missing` as `false`.
 Descent cache implementations should provide that field or overload this hook.
+
+# Arguments
+
+- `cache::AbstractDescentCache`: A descent cache whose `normal_form` field is a `Bool` or
+  `Val{Bool}`, or a cache with a specialized method.
+
+# Returns
+
+`true` when the cache uses normal-form equations ``JᵀJ δu = Jᵀfu`` and `false` otherwise.
+
+# Examples
+
+```julia
+struct NormalFormCache <: NonlinearSolveBase.AbstractDescentCache
+    normal_form::Val{true}
+end
+
+NonlinearSolveBase.normal_form(NormalFormCache(Val(true))) # true
+```
 """
 function normal_form(cache::AbstractDescentCache)
     res = Utils.unwrap_val(Utils.safe_getproperty(cache, Val(:normal_form)))
@@ -328,7 +371,17 @@ abstract type AbstractDampingFunctionCache <: AbstractNonlinearAlgorithm end
 Return whether a damping function requires the Jacobian in normal form, ``JᵀJ``.
 
 Every concrete [`AbstractDampingFunction`](@ref) must define this trait. It is queried
-before the damping cache is initialized, so it must not depend on cache state.
+before the damping cache is initialized, so it must not depend on cache state. A damping
+cache that is passed to this trait by `InternalAPI.solve!` must implement the same contract.
+
+# Arguments
+
+- `alg`: A damping function, or its cache when the solver queries the cache during a solve.
+
+# Returns
+
+`true` when the Jacobian must be supplied as ``JᵀJ`` and `false` when the ordinary Jacobian
+is sufficient.
 """
 function requires_normal_form_jacobian end
 
@@ -338,7 +391,17 @@ function requires_normal_form_jacobian end
 Return whether a damping function requires the residual in normal form, ``Jᵀfu``.
 
 Every concrete [`AbstractDampingFunction`](@ref) must define this trait. It is queried
-before the damping cache is initialized, so it must not depend on cache state.
+before the damping cache is initialized, so it must not depend on cache state. A damping
+cache that is passed to this trait by `InternalAPI.solve!` must implement the same contract.
+
+# Arguments
+
+- `alg`: A damping function, or its cache when the solver queries the cache during a solve.
+
+# Returns
+
+`true` when the residual must be supplied as ``Jᵀfu`` and `false` when the ordinary residual
+is sufficient.
 """
 function requires_normal_form_rhs end
 
@@ -350,6 +413,14 @@ Return whether the damping function returns a normal-form damping factor.
 The default is `requires_normal_form_jacobian(alg) || requires_normal_form_rhs(alg)`. A
 concrete damping function may overload this when its returned factor uses a different
 representation.
+
+# Arguments
+
+- `alg`: A damping function or damping cache implementing the normal-form traits.
+
+# Returns
+
+`true` when the returned damping factor is in normal form and `false` otherwise.
 
 # Examples
 
@@ -642,6 +713,22 @@ Return whether an approximate-Jacobian structure retains the full Jacobian.
 
 The default is `false`. A structure that retains a full Jacobian must overload this trait
 and provide the corresponding [`get_full_jacobian`](@ref) behavior.
+
+# Arguments
+
+- `alg::AbstractApproximateJacobianStructure`: The approximate-Jacobian structure.
+
+# Returns
+
+`true` when the structure retains a full Jacobian and `false` otherwise.
+
+# Examples
+
+```julia
+struct LowRankStructure <: NonlinearSolveBase.AbstractApproximateJacobianStructure end
+
+NonlinearSolveBase.stores_full_jacobian(LowRankStructure()) # false
+```
 """
 stores_full_jacobian(::AbstractApproximateJacobianStructure) = false
 
@@ -652,6 +739,28 @@ Return the full Jacobian represented by an approximate-Jacobian cache.
 
 The default returns `J` when [`stores_full_jacobian`](@ref) is true and throws otherwise.
 Implementations that store the full Jacobian in a separate buffer should overload this hook.
+
+# Arguments
+
+- `cache`: The approximate-Jacobian cache, when the implementation stores the full matrix
+  separately.
+- `alg::AbstractApproximateJacobianStructure`: The structure describing the cache.
+- `J`: The current Jacobian representation.
+
+# Returns
+
+The full Jacobian represented by the cache. The default returns `J` only when
+[`stores_full_jacobian`](@ref) is `true`.
+
+# Examples
+
+```julia
+struct FullStructure <: NonlinearSolveBase.AbstractApproximateJacobianStructure end
+NonlinearSolveBase.stores_full_jacobian(::FullStructure) = true
+
+J = [1.0 0.0; 0.0 1.0]
+NonlinearSolveBase.get_full_jacobian(nothing, FullStructure(), J) == J
+```
 """
 function get_full_jacobian(cache, alg::AbstractApproximateJacobianStructure, J)
     stores_full_jacobian(alg) && return J
@@ -692,6 +801,22 @@ Return whether a Jacobian initialization algorithm produces an inverse Jacobian.
 
 The default is `false`; an initialization algorithm that constructs an inverse directly must
 overload this trait so the enclosing solver interprets the cache correctly.
+
+# Arguments
+
+- `alg::AbstractJacobianInitialization`: The Jacobian initialization algorithm.
+
+# Returns
+
+`true` when the initialization algorithm returns an inverse Jacobian and `false` when it
+returns an ordinary Jacobian.
+
+# Examples
+
+```julia
+struct DirectInverse <: NonlinearSolveBase.AbstractJacobianInitialization end
+NonlinearSolveBase.jacobian_initialized_preinverted(DirectInverse()) # false by default
+```
 """
 jacobian_initialized_preinverted(::AbstractJacobianInitialization) = false
 
@@ -722,6 +847,26 @@ Return whether an approximate-Jacobian update rule stores an inverse Jacobian.
 
 The default for a concrete rule reads its `store_inverse_jacobian` field. Update-rule cache
 implementations delegate to the rule, so the same contract applies to both forms.
+
+# Arguments
+
+- `rule::AbstractApproximateJacobianUpdateRule`: The update rule whose stored Jacobian
+  representation is being queried.
+
+# Returns
+
+`true` when the rule stores an inverse Jacobian and `false` when it stores an ordinary
+Jacobian.
+
+# Examples
+
+```julia
+struct DirectUpdate <: NonlinearSolveBase.AbstractApproximateJacobianUpdateRule
+    store_inverse_jacobian::Bool
+end
+
+NonlinearSolveBase.store_inverse_jacobian(DirectUpdate(true)) # true
+```
 """
 function store_inverse_jacobian(rule::AbstractApproximateJacobianUpdateRule)
     return rule.store_inverse_jacobian

--- a/lib/NonlinearSolveBase/src/abstract_types.jl
+++ b/lib/NonlinearSolveBase/src/abstract_types.jl
@@ -216,17 +216,62 @@ set_du!(cache::AbstractDescentCache, δu) = (cache.δu = δu)
 set_du!(cache::AbstractDescentCache, δu, ::Val{1}) = set_du!(cache, δu)
 set_du!(cache::AbstractDescentCache, δu, ::Val{N}) where {N} = (cache.δus[N - 1] = δu)
 
+"""
+    last_step_accepted(cache::AbstractDescentCache) -> Bool
+
+Return whether the most recent descent step was accepted.
+
+The default reads `cache.last_step_accepted` when that field exists and returns `true`
+otherwise. Trust-region and damping cache implementations should overload this hook when
+acceptance is stored outside that field.
+
+# Arguments
+
+- `cache`: A descent or trust-region cache.
+
+# Examples
+
+```julia
+mutable struct MyDescentCache <: NonlinearSolveBase.AbstractDescentCache
+    δu::Vector{Float64}
+    last_step_accepted::Bool
+end
+
+cache = MyDescentCache([1.0], false)
+NonlinearSolveBase.last_step_accepted(cache) # false
+```
+"""
 function last_step_accepted(cache::AbstractDescentCache)
     hasfield(typeof(cache), :last_step_accepted) && return cache.last_step_accepted
     return true
 end
 
-for fname in (:preinverted_jacobian, :normal_form)
-    @eval function $(fname)(alg::AbstractDescentCache)
-        res = Utils.unwrap_val(Utils.safe_getproperty(alg, Val($(QuoteNode(fname)))))
-        res === missing && return false
-        return res
-    end
+"""
+    preinverted_jacobian(cache::AbstractDescentCache) -> Bool
+
+Return whether the cache stores an inverse Jacobian rather than the Jacobian itself.
+
+The default reads the cache's `preinverted_jacobian` field and treats `missing` as `false`.
+Descent cache implementations should provide that field or overload this hook.
+"""
+function preinverted_jacobian(cache::AbstractDescentCache)
+    res = Utils.unwrap_val(Utils.safe_getproperty(cache, Val(:preinverted_jacobian)))
+    res === missing && return false
+    return res
+end
+
+"""
+    normal_form(cache::AbstractDescentCache) -> Bool
+
+Return whether the cache's linear solve uses normal-form equations.
+
+The default reads the cache's `normal_form` field and treats `missing` as `false`.
+Descent cache implementations should provide that field or overload this hook.
+"""
+function normal_form(cache::AbstractDescentCache)
+    res = Utils.unwrap_val(Utils.safe_getproperty(cache, Val(:normal_form)))
+    res === missing && return false
+    return res
 end
 
 """
@@ -277,8 +322,45 @@ Returns the damping factor.
 """
 abstract type AbstractDampingFunctionCache <: AbstractNonlinearAlgorithm end
 
+"""
+    requires_normal_form_jacobian(alg) -> Bool
+
+Return whether a damping function requires the Jacobian in normal form, ``JᵀJ``.
+
+Every concrete [`AbstractDampingFunction`](@ref) must define this trait. It is queried
+before the damping cache is initialized, so it must not depend on cache state.
+"""
 function requires_normal_form_jacobian end
+
+"""
+    requires_normal_form_rhs(alg) -> Bool
+
+Return whether a damping function requires the residual in normal form, ``Jᵀfu``.
+
+Every concrete [`AbstractDampingFunction`](@ref) must define this trait. It is queried
+before the damping cache is initialized, so it must not depend on cache state.
+"""
 function requires_normal_form_rhs end
+
+"""
+    returns_norm_form_damping(alg) -> Bool
+
+Return whether the damping function returns a normal-form damping factor.
+
+The default is `requires_normal_form_jacobian(alg) || requires_normal_form_rhs(alg)`. A
+concrete damping function may overload this when its returned factor uses a different
+representation.
+
+# Examples
+
+```julia
+struct MyDamping <: NonlinearSolveBase.AbstractDampingFunction end
+NonlinearSolveBase.requires_normal_form_jacobian(::MyDamping) = true
+NonlinearSolveBase.requires_normal_form_rhs(::MyDamping) = false
+
+NonlinearSolveBase.returns_norm_form_damping(MyDamping()) # true
+```
+"""
 function returns_norm_form_damping(f::F) where {F}
     return requires_normal_form_jacobian(f) || requires_normal_form_rhs(f)
 end
@@ -553,7 +635,24 @@ Abstract Type for all Approximate Jacobian Structures used in NonlinearSolve.jl.
 """
 abstract type AbstractApproximateJacobianStructure <: AbstractNonlinearSolveBaseAPI end
 
+"""
+    stores_full_jacobian(alg::AbstractApproximateJacobianStructure) -> Bool
+
+Return whether an approximate-Jacobian structure retains the full Jacobian.
+
+The default is `false`. A structure that retains a full Jacobian must overload this trait
+and provide the corresponding [`get_full_jacobian`](@ref) behavior.
+"""
 stores_full_jacobian(::AbstractApproximateJacobianStructure) = false
+
+"""
+    get_full_jacobian(cache, alg::AbstractApproximateJacobianStructure, J)
+
+Return the full Jacobian represented by an approximate-Jacobian cache.
+
+The default returns `J` when [`stores_full_jacobian`](@ref) is true and throws otherwise.
+Implementations that store the full Jacobian in a separate buffer should overload this hook.
+"""
 function get_full_jacobian(cache, alg::AbstractApproximateJacobianStructure, J)
     stores_full_jacobian(alg) && return J
     error("This algorithm does not store the full Jacobian. Define `get_full_jacobian` for \
@@ -586,6 +685,14 @@ All subtypes need to define
 """
 abstract type AbstractJacobianInitialization <: AbstractNonlinearSolveBaseAPI end
 
+"""
+    jacobian_initialized_preinverted(alg::AbstractJacobianInitialization) -> Bool
+
+Return whether a Jacobian initialization algorithm produces an inverse Jacobian.
+
+The default is `false`; an initialization algorithm that constructs an inverse directly must
+overload this trait so the enclosing solver interprets the cache correctly.
+"""
 jacobian_initialized_preinverted(::AbstractJacobianInitialization) = false
 
 """
@@ -608,6 +715,14 @@ InternalAPI.init(
 """
 abstract type AbstractApproximateJacobianUpdateRule <: AbstractNonlinearSolveBaseAPI end
 
+"""
+    store_inverse_jacobian(rule) -> Bool
+
+Return whether an approximate-Jacobian update rule stores an inverse Jacobian.
+
+The default for a concrete rule reads its `store_inverse_jacobian` field. Update-rule cache
+implementations delegate to the rule, so the same contract applies to both forms.
+"""
 function store_inverse_jacobian(rule::AbstractApproximateJacobianUpdateRule)
     return rule.store_inverse_jacobian
 end

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -147,6 +147,7 @@ run_tests(;
             end
 
             struct TraitStructure <: NonlinearSolveBase.AbstractApproximateJacobianStructure end
+            struct TraitFullStructure <: NonlinearSolveBase.AbstractApproximateJacobianStructure end
             struct TraitInitialization <: NonlinearSolveBase.AbstractJacobianInitialization end
             struct TraitUpdateRule <: NonlinearSolveBase.AbstractApproximateJacobianUpdateRule
                 store_inverse_jacobian::Bool
@@ -158,6 +159,7 @@ run_tests(;
 
             NonlinearSolveBase.requires_normal_form_jacobian(::TraitDamping) = true
             NonlinearSolveBase.requires_normal_form_rhs(::TraitDamping) = false
+            NonlinearSolveBase.stores_full_jacobian(::TraitFullStructure) = true
 
             cache = TraitDescentCache(
                 [1.0], [[1.0], [2.0]], Val(false), Val(false), false
@@ -166,10 +168,18 @@ run_tests(;
             @test NonlinearSolveBase.preinverted_jacobian(cache) === false
             @test NonlinearSolveBase.normal_form(cache) === false
 
+            @test NonlinearSolveBase.last_step_accepted(
+                TraitDescentCache([1.0], [[1.0]], Val(false), Val(false), true)
+            )
+
             @test NonlinearSolveBase.stores_full_jacobian(TraitStructure()) === false
             @test_throws ErrorException NonlinearSolveBase.get_full_jacobian(
                 nothing, TraitStructure(), [1.0]
             )
+            J = [1.0 0.0; 0.0 1.0]
+            @test NonlinearSolveBase.get_full_jacobian(
+                nothing, TraitFullStructure(), J
+            ) === J
             @test NonlinearSolveBase.jacobian_initialized_preinverted(TraitInitialization()) ===
                 false
 

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -135,6 +135,61 @@ run_tests(;
             end
         end
 
+        @safetestset "Abstract interface trait contracts" begin
+            using NonlinearSolveBase, Test
+
+            mutable struct TraitDescentCache <: NonlinearSolveBase.AbstractDescentCache
+                δu::Vector{Float64}
+                δus::Vector{Vector{Float64}}
+                preinverted_jacobian::Val{false}
+                normal_form::Val{false}
+                last_step_accepted::Bool
+            end
+
+            struct TraitStructure <: NonlinearSolveBase.AbstractApproximateJacobianStructure end
+            struct TraitInitialization <: NonlinearSolveBase.AbstractJacobianInitialization end
+            struct TraitUpdateRule <: NonlinearSolveBase.AbstractApproximateJacobianUpdateRule
+                store_inverse_jacobian::Bool
+            end
+            struct TraitUpdateCache <: NonlinearSolveBase.AbstractApproximateJacobianUpdateRuleCache
+                rule::TraitUpdateRule
+            end
+            struct TraitDamping <: NonlinearSolveBase.AbstractDampingFunction end
+
+            NonlinearSolveBase.requires_normal_form_jacobian(::TraitDamping) = true
+            NonlinearSolveBase.requires_normal_form_rhs(::TraitDamping) = false
+
+            cache = TraitDescentCache(
+                [1.0], [[1.0], [2.0]], Val(false), Val(false), false
+            )
+            @test NonlinearSolveBase.last_step_accepted(cache) === false
+            @test NonlinearSolveBase.preinverted_jacobian(cache) === false
+            @test NonlinearSolveBase.normal_form(cache) === false
+
+            @test NonlinearSolveBase.stores_full_jacobian(TraitStructure()) === false
+            @test_throws ErrorException NonlinearSolveBase.get_full_jacobian(
+                nothing, TraitStructure(), [1.0]
+            )
+            @test NonlinearSolveBase.jacobian_initialized_preinverted(TraitInitialization()) ===
+                false
+
+            rule = TraitUpdateRule(true)
+            @test NonlinearSolveBase.store_inverse_jacobian(rule) === true
+            @test NonlinearSolveBase.store_inverse_jacobian(TraitUpdateCache(rule)) === true
+            @test NonlinearSolveBase.returns_norm_form_damping(TraitDamping()) === true
+
+            @static if VERSION ≥ v"1.11"
+                for name in (
+                        :last_step_accepted, :preinverted_jacobian, :normal_form,
+                        :requires_normal_form_jacobian, :requires_normal_form_rhs,
+                        :returns_norm_form_damping, :stores_full_jacobian, :get_full_jacobian,
+                        :jacobian_initialized_preinverted, :store_inverse_jacobian,
+                    )
+                    @test Base.ispublic(NonlinearSolveBase, name)
+                end
+            end
+        end
+
         @safetestset "standardize_forwarddiff_tag leaves unwrapped problems alone (#3381)" begin
             # Regression for SciML/OrdinaryDiffEq.jl#3381: under FullSpecialize (or
             # any path where the user function was not wrapped via AutoSpecialize),


### PR DESCRIPTION
## Summary

Document the NonlinearSolveBase abstract interface traits at their original definitions and expose the developer-facing contracts through the developer API page. The PR adds concise usage examples, extension rules, and generic contract tests for the traits; it does not change solver behavior.

This is developer public API for packages implementing NonlinearSolve interfaces. It is intentionally separate from user-facing solver API.

## Verification

- `GROUP=Core timeout 3600 julia --startup-file=no --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test()'`: passed, including `Abstract interface trait contracts | 19 19`.
- `GROUP=QA timeout 3600 julia --startup-file=no --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test()'`: passed, `QA | 20 20`.
- `timeout 3600 julia --startup-file=no --project=docs docs/make.jl`: exit 0. Documenter emitted the existing 211-docstring coverage warning set and ordinary HTML/deployment warnings; no build errors.
- Runic source check: passed.
- `typos --diff`: passed.
- `git diff --check`: passed.

GPU and downstream suites were not run locally.

Ignore this draft until reviewed by @ChrisRackauckas.