### PR TITLE
Document that the termination modes receive the residual, not the increment

### DIFF
--- a/docs/src/basics/termination_condition.md
+++ b/docs/src/basics/termination_condition.md
@@ -16,6 +16,18 @@ cache = init(du, u, AbsNormSafeBestTerminationMode(); abstol = 1e-9, reltol = 1e
 If `abstol` and `reltol` are not supplied, then we choose a default based on the element
 types of `du` and `u`.
 
+!!! note
+
+    The first argument (written `du` here and ``\Delta u`` in the mode docstrings) is the
+    **residual** `f(u)`, not the Newton increment — every solver in this package passes the
+    residual. The naming is inherited from the step-based use of the same machinery in
+    DifferentialEquations.jl.
+
+    A consequence worth knowing: the default termination mode for a `NonlinearProblem` is an
+    *absolute* one, so `reltol` has no effect on it. Solving the same problem with
+    `reltol = 1e-1` and `reltol = 1e-8` gives an identical iteration count, f-evaluation count
+    and residual; only `abstol` moves them.
+
 To test for termination simply call the `cache`:
 
 ```julia

--- a/docs/src/basics/termination_condition.md
+++ b/docs/src/basics/termination_condition.md
@@ -10,7 +10,9 @@ termination modes:
 The termination condition is constructed as:
 
 ```julia
-cache = init(du, u, AbsNormSafeBestTerminationMode(); abstol = 1e-9, reltol = 1e-9)
+prob = NonlinearProblem((u, p) -> [u[1]^2 - 2], [1.0])
+mode = AbsNormSafeBestTerminationMode(Base.Fix1(maximum, abs))
+cache = init(prob, mode, [1.0], [1.0]; abstol = 1.0e-9, reltol = 1.0e-9)
 ```
 
 If `abstol` and `reltol` are not supplied, then we choose a default based on the element
@@ -18,15 +20,14 @@ types of `du` and `u`.
 
 !!! note
 
-    The first argument (written `du` here and ``\Delta u`` in the mode docstrings) is the
-    **residual** `f(u)`, not the Newton increment — every solver in this package passes the
-    residual. The naming is inherited from the step-based use of the same machinery in
-    DifferentialEquations.jl.
+    The first state argument (written `du` here and `r` in the mode docstrings) is the
+    **residual** `f(u)`, not the Newton increment. The name `du` is inherited from the
+    step-based use of the same machinery in DifferentialEquations.jl.
 
     A consequence worth knowing: the default termination mode for a `NonlinearProblem` is an
-    *absolute* one, so `reltol` has no effect on it. Solving the same problem with
-    `reltol = 1e-1` and `reltol = 1e-8` gives an identical iteration count, f-evaluation count
-    and residual; only `abstol` moves them.
+    *absolute* one, so `reltol` has no effect on it. To use a relative criterion, pass a
+    `RelTerminationMode` or `RelNormTerminationMode` explicitly through
+    `termination_condition`.
 
 To test for termination simply call the `cache`:
 

--- a/lib/NonlinearSolveBase/src/public.jl
+++ b/lib/NonlinearSolveBase/src/public.jl
@@ -316,7 +316,10 @@ for name in (:Rel, :Abs)
 
         Terminates if $($doctring).
 
-        ``\\Delta u`` denotes the increment computed by the nonlinear solver and ``u`` denotes the solution.
+        ``\\Delta u`` is the quantity the caller passes as the first argument. Every solver in
+        this package passes the **residual** ``f(u)`` there, not the Newton increment, so these
+        criteria are residual tests. The name is inherited from the step-based use of the same
+        machinery in DifferentialEquations.jl. ``u`` denotes the current iterate.
         """
         struct $(struct_name) <: AbstractNonlinearTerminationMode end
     end
@@ -332,7 +335,20 @@ for name in (:Norm, :RelNorm, :AbsNorm)
 
         Terminates if $($doctring).
 
-        ``\\Delta u`` denotes the increment computed by the inner nonlinear solver.
+        ``\\Delta u`` is the quantity the caller passes as the first argument. Every solver in
+        this package passes the **residual** ``f(u)`` there, not the Newton increment, so these
+        criteria are residual tests. The name is inherited from the step-based use of the same
+        machinery in DifferentialEquations.jl.
+
+        !!! warning
+
+            The relative criteria therefore compare a residual against ``\\|f(u) + u\\|``, which
+            adds a residual to an iterate. That is not a meaningful relative measure: it is
+            satisfied whenever ``\\|u\\|`` happens to be large, it is *not* satisfied for a
+            converged solve with a small ``\\|u\\|``, and it diverges when ``u \\approx -f(u)``
+            makes the denominator cancel. See
+            [#1149](https://github.com/SciML/NonlinearSolve.jl/issues/1149). Prefer the
+            absolute modes until this is resolved.
 
         ## Constructor
 

--- a/lib/NonlinearSolveBase/src/public.jl
+++ b/lib/NonlinearSolveBase/src/public.jl
@@ -252,7 +252,7 @@ It applies the cache's termination policy without exposing cache storage. Safe-b
 return their recorded best state and saved marker when one is available; other modes
 return `fallback_u` and `fallback_t`.
 
-# Termination Arguments
+# Arguments
 
   - `cache`: A cache returned by `SciMLBase.init` for a public nonlinear termination mode.
   - `fallback_u`: Final state produced by the enclosing solver.
@@ -349,7 +349,7 @@ sol = solve(prob, NewtonRaphson(); termination_condition = MODE)
 """
 
 const TERM_NORM_ARGS = """
-# Arguments
+# Constructor Arguments
 
 - `internalnorm`: Callable used to reduce the residual and the residual-plus-iterate pair to
   scalar objectives. It may be `norm`, `norm(_, 2)`, `norm(_, Inf)`, `maximum(abs, _)`, or a

--- a/lib/NonlinearSolveBase/src/public.jl
+++ b/lib/NonlinearSolveBase/src/public.jl
@@ -252,7 +252,7 @@ It applies the cache's termination policy without exposing cache storage. Safe-b
 return their recorded best state and saved marker when one is available; other modes
 return `fallback_u` and `fallback_t`.
 
-# Arguments
+# Termination Arguments
 
   - `cache`: A cache returned by `SciMLBase.init` for a public nonlinear termination mode.
   - `fallback_u`: Final state produced by the enclosing solver.
@@ -294,21 +294,101 @@ AbstractSafeNonlinearTerminationMode end
 
 #! format: off
 const TERM_DOCS = Dict(
-    :Norm => doc"``\| Δu \| ≤ reltol × \| Δu + u \|`` or ``\| Δu \| ≤ abstol``",
-    :Rel => doc"``\mathrm{all} \left(| Δu | ≤ reltol × | Δu + u | \right)``",
-    :RelNorm => doc"``\| Δu \| ≤ reltol × \| Δu + u \|``",
-    :Abs => doc"``\mathrm{all} \left( | Δu | ≤ abstol \right)``",
-    :AbsNorm => doc"``\| Δu \| ≤ abstol``"
+    :Norm => doc"``\| r \| ≤ reltol × \| r + u \|`` or ``\| r \| ≤ abstol``",
+    :Rel => doc"``\mathrm{all} \left(| r_i | ≤ reltol × | r_i + u_i | \right)``",
+    :RelNorm => doc"``\| r \| ≤ reltol × \| r + u \|``",
+    :Abs => doc"``\mathrm{all} \left( | r_i | ≤ abstol \right)``",
+    :AbsNorm => doc"``\| r \| ≤ abstol``"
 )
 
 const TERM_INTERNALNORM_DOCS = """
-where `internalnorm` is the norm to use for the termination condition. Special handling is
-done for `norm(_, 2)`, `norm`, `norm(_, Inf)`, and `maximum(abs, _)`"""
+where `internalnorm` is a callable norm to use for the termination condition. Special handling
+is done for `norm(_, 2)`, `norm`, `norm(_, Inf)`, and `maximum(abs, _)`."""
+
+const TERM_INTERFACE_DOCS = """
+The nonlinear solver evaluates this mode through a termination cache. The cache is called as
+`cache(du, u, uprev)`, where `du` is the current residual `f(u)`, `u` is the current iterate,
+and `uprev` is the previous accepted iterate. The solver supplies `abstol` and `reltol` when
+the cache is initialized. The name `du` is retained for compatibility with the step-based
+termination interface in DifferentialEquations.jl; it is not a Newton increment here.
+
+# Arguments
+
+- `du`: Current residual `f(u)`.
+- `u`: Current iterate.
+- `uprev`: Previous accepted iterate. Plain modes ignore it; safe modes use it only when
+  `max_stalled_steps` is enabled.
+
+# Returns
+
+- `Bool`: `true` when the mode's convergence or safety criterion requests termination, and
+  `false` when the solver should continue. The solver records `ReturnCode.Success` for a
+  tolerance-based termination. Safe modes can instead record `ReturnCode.Unstable`,
+  `ReturnCode.Stalled`, or `ReturnCode.StalledSuccess` when a safety criterion fires.
+"""
+
+const TERM_RELATIVE_WARNING = """
+!!! warning
+
+    The relative criterion compares the residual with `r + u`, rather than with a step and the
+    next iterate. This is the behavior currently implemented by NonlinearSolve. It can produce
+    a misleading relative measure when the residual and iterate have very different scales.
+    Prefer an absolute mode when this behavior is not appropriate. See
+    [#1149](https://github.com/SciML/NonlinearSolve.jl/issues/1149).
+"""
+
+const TERM_EXAMPLE = """
+# Examples
+
+```julia
+using NonlinearSolve, NonlinearSolveBase
+
+prob = NonlinearProblem((u, p) -> [u[1]^2 - 2], [1.0])
+sol = solve(prob, NewtonRaphson(); termination_condition = MODE)
+```
+"""
+
+const TERM_NORM_ARGS = """
+# Arguments
+
+- `internalnorm`: Callable used to reduce the residual and the residual-plus-iterate pair to
+  scalar objectives. It may be `norm`, `norm(_, 2)`, `norm(_, Inf)`, `maximum(abs, _)`, or a
+  custom callable with the corresponding inputs.
+"""
+
+const TERM_SAFE_KEYWORDS = """
+# Keywords
+
+- `protective_threshold`: Optional multiplier for the initial objective. When set, a current
+  objective larger than `protective_threshold * initial_objective * length(du)` returns
+  `ReturnCode.Unstable`. Defaults to `nothing`, which disables this check.
+- `patience_steps::Int`: Number of objective evaluations retained for the no-improvement check.
+  Defaults to `100`.
+- `patience_objective_multiplier`: Enables the no-improvement check only while the current
+  objective is at most this multiple of the requested tolerance. Defaults to `3`.
+- `min_max_factor`: Declares the objective stalled when the minimum objective in the retained
+  history is less than this factor times the maximum. Defaults to `1.3`.
+- `max_stalled_steps`: Optional number of steps after which a step-size stall is checked.
+  `nothing` disables this additional check. Defaults to `nothing`.
+"""
+
+const TERM_SAFE_SEMANTICS = """
+# Termination semantics
+
+In addition to the base tolerance criterion, safe modes terminate when the objective is not
+improving under the configured patience settings, when the objective is nonfinite, or when an
+enabled protective or step-stall check fires. A non-least-squares problem receives
+`ReturnCode.Stalled` for an objective or step stall; a least-squares problem receives
+`ReturnCode.StalledSuccess`. A `SafeBest` mode retains the iterate with the best objective seen
+so far and returns that iterate when the termination cache is used to build the solution.
+"""
 #! format: on
 
 for name in (:Rel, :Abs)
     struct_name = Symbol(name, :TerminationMode)
     doctring = TERM_DOCS[name]
+    criterion = name == :Rel ? TERM_RELATIVE_WARNING : ""
+    example = replace(TERM_EXAMPLE, "MODE" => "$(struct_name)()")
 
     @eval begin
         """
@@ -316,10 +396,20 @@ for name in (:Rel, :Abs)
 
         Terminates if $($doctring).
 
-        ``\\Delta u`` is the quantity the caller passes as the first argument. Every solver in
-        this package passes the **residual** ``f(u)`` there, not the Newton increment, so these
-        criteria are residual tests. The name is inherited from the step-based use of the same
-        machinery in DifferentialEquations.jl. ``u`` denotes the current iterate.
+        Here `r` denotes the residual `f(u)` supplied by the nonlinear solver and `u` denotes
+        the current iterate. This is a residual criterion, not a Newton-step criterion.
+
+        $($TERM_INTERFACE_DOCS)
+
+        # Constructor
+
+            $($struct_name)()
+
+        This constructor takes no arguments.
+
+        $($criterion)
+
+        $($example)
         """
         struct $(struct_name) <: AbstractNonlinearTerminationMode end
     end
@@ -328,6 +418,11 @@ end
 for name in (:Norm, :RelNorm, :AbsNorm)
     struct_name = Symbol(name, :TerminationMode)
     doctring = TERM_DOCS[name]
+    criterion = name == :RelNorm ? TERM_RELATIVE_WARNING : ""
+    example = replace(
+        TERM_EXAMPLE,
+        "MODE" => "$(struct_name)(Base.Fix1(maximum, abs))"
+    )
 
     @eval begin
         """
@@ -335,26 +430,22 @@ for name in (:Norm, :RelNorm, :AbsNorm)
 
         Terminates if $($doctring).
 
-        ``\\Delta u`` is the quantity the caller passes as the first argument. Every solver in
-        this package passes the **residual** ``f(u)`` there, not the Newton increment, so these
-        criteria are residual tests. The name is inherited from the step-based use of the same
-        machinery in DifferentialEquations.jl.
+        Here `r` denotes the residual `f(u)` supplied by the nonlinear solver and `u` denotes
+        the current iterate. This is a residual criterion, not a Newton-step criterion.
 
-        !!! warning
-
-            The relative criteria therefore compare a residual against ``\\|f(u) + u\\|``, which
-            adds a residual to an iterate. That is not a meaningful relative measure: it is
-            satisfied whenever ``\\|u\\|`` happens to be large, it is *not* satisfied for a
-            converged solve with a small ``\\|u\\|``, and it diverges when ``u \\approx -f(u)``
-            makes the denominator cancel. See
-            [#1149](https://github.com/SciML/NonlinearSolve.jl/issues/1149). Prefer the
-            absolute modes until this is resolved.
+        $($TERM_INTERFACE_DOCS)
 
         ## Constructor
 
-            $($struct_name)(internalnorm = nothing)
+            $($struct_name)(internalnorm)
 
-        $($TERM_INTERNALNORM_DOCS).
+        $($TERM_INTERNALNORM_DOCS)
+
+        $($TERM_NORM_ARGS)
+
+        $($criterion)
+
+        $($example)
         """
         struct $(struct_name){F} <: AbstractNonlinearTerminationMode
             internalnorm::F
@@ -371,6 +462,13 @@ for norm_type in (:RelNorm, :AbsNorm), safety in (:Safe, :SafeBest)
 
     struct_name = Symbol(norm_type, safety, :TerminationMode)
     supertype_name = Symbol(:Abstract, safety, :NonlinearTerminationMode)
+    criterion = norm_type == :AbsNorm ?
+        "The base criterion is ``\\|r\\| ≤ abstol``." :
+        "The base criterion is ``\\|r\\| / (\\|r + u\\| + \\epsilon(reltol)) ≤ reltol``."
+    example = replace(
+        TERM_EXAMPLE,
+        "MODE" => "$(struct_name)(Base.Fix1(maximum, abs); max_stalled_steps = 10)"
+    )
 
     doctring = safety == :Safe ?
         "Essentially [`$(norm_type)TerminationMode`](@ref) + terminate if there \
@@ -385,6 +483,10 @@ for norm_type in (:RelNorm, :AbsNorm), safety in (:Safe, :SafeBest)
 
         $($doctring)
 
+        $($criterion)
+
+        $($TERM_INTERFACE_DOCS)
+
         ## Constructor
 
             $($struct_name)(
@@ -393,7 +495,15 @@ for norm_type in (:RelNorm, :AbsNorm), safety in (:Safe, :SafeBest)
                 min_max_factor = 1.3, max_stalled_steps = nothing
             )
 
-        $($TERM_INTERNALNORM_DOCS).
+        $($TERM_INTERNALNORM_DOCS)
+
+        $($TERM_NORM_ARGS)
+
+        $($TERM_SAFE_KEYWORDS)
+
+        $($TERM_SAFE_SEMANTICS)
+
+        $($example)
         """
         @concrete struct $(struct_name) <: $(supertype_name)
             internalnorm


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Follow-up to #1149, which was closed after #1176 merged — but this half did not make it in. It was pushed to the same branch shortly after the merge, so master still carries the incorrect claim in two places.

The mode docstrings say ``\Delta u`` is "the increment computed by the nonlinear solver". It is not: every solver in this package passes `cache.fu`, the residual. The naming is inherited from the step-based use of the same machinery in DifferentialEquations.jl.

The distinction is what #1149 was reported over. `‖Δu‖ ≤ reltol·‖Δu + u‖` is the textbook relative-*step* test when `Δu` is the increment, because `Δu + u` is then the next iterate — the formula was never wrong, it is being handed the wrong vector. Fed the residual it compares `‖f(u)‖` against `‖f(u) + u‖`:

| case | ‖F‖ | ‖u‖ | objective |
|---|---|---|---|
| residual small, `u` large | 1e-6 | 1e+3 | 1.0e-9 — fires, but only because `‖u‖` is large |
| residual small, `u` tiny | 1e-6 | 1e-9 | **0.999** — converged, will not fire |
| `u ≈ -F` | 1e0 | 1e0 | **6.0e+23** — denominator cancels |

So this documents the modes accurately and adds a warning pointing at #1149, rather than changing the semantics — that is a behaviour change for every user of those modes and wants a decision. The issue reporter has endorsed redefining them as a relative-residual test (`‖F(u)‖ ≤ reltol·‖F(u₀)‖`) and additionally suggests a gradient-based criterion (`‖Jᵀ F‖`) for least-squares, which is the Nocedal & Wright convention and does not degenerate when the residual is nonzero at the solution. Neither is in this PR.

Also documents that `reltol` has no effect on a `NonlinearProblem`, whose default mode is absolute — verified: `reltol ∈ {1e-1, 1e-3, 1e-8}` gives identical iterations (5), f-evaluations (5) and residual (4.75e-14); only `abstol` moves them.

Docs only, no behaviour change. Runic clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Follow-up: SciMLStyle contract documentation

Commit `35e11e99` expands the generated termination-mode docstrings without changing solver code or termination behavior. The docs now use `r = f(u)` in the criteria, document the cache arguments and Boolean result separately from solver return codes, list `internalnorm` and every safe-mode keyword/default, describe `Success`/`Unstable`/`Stalled`/`StalledSuccess`, and provide examples for all nine modes. It also corrects the norm constructor signature and the termination-guide `init` example.

Focused verification:
- all nine modes constructed and solved a nonlinear problem with `ReturnCode.Success`;
- generated-doc inspection found `# Returns` and `# Examples` on all nine modes, `# Arguments` on norm constructors, and `# Keywords` on safe modes;
- `Runic.format_string` check: pass;
- `typos lib/NonlinearSolveBase/src/public.jl docs/src/basics/termination_condition.md`: pass;
- `git diff --check`: pass;
- isolated `NonlinearSolveBase` QA: `20/20` passed;
- focused Documenter build of the termination page: doctests and rendering passed. The repository-wide docs build was not used as a gate because it remained in the unrelated full-site doctest/render pass.