### PR TITLE
Bump versions for release

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.45.0"
+version = "2.46.0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
Version bumps only -- no source changes.

Each package below has `src/` changes since its last registered version (verified by comparing the registry's recorded `git-tree-sha1` for that version against the current tree), but its `Project.toml` version still equals the registered one, so there is nothing to register.

Increment is minor, which is a valid standard increment under the General [sequential version number](https://juliaregistries.github.io/RegistryCI.jl/stable/guidelines/) guideline.

- NonlinearSolveBase 2.45.0 -> 2.46.0