### PR TITLE
Add a gradient-stationarity termination criterion and make it the least-squares default

### DIFF
--- a/docs/src/devdocs/internal_interfaces.md
+++ b/docs/src/devdocs/internal_interfaces.md
@@ -152,3 +152,19 @@ NonlinearSolveBase.get_reltol
 NonlinearSolveBase.AbstractNonlinearTerminationMode
 NonlinearSolveBase.AbstractSafeNonlinearTerminationMode
 ```
+
+## Gradient Stationarity
+
+A least-squares solution is defined by ``J^\top F = 0``, not by ``F = 0``, so a residual
+test alone cannot certify convergence on a problem whose residual is nonzero at the
+optimum. These implement the scale-free stationarity criterion that can, and the hook a
+solver package calls to apply it. The criterion is reached through the `gtol` option on the
+safe termination modes: it is set by default for `NonlinearLeastSquaresProblem` and left
+unset for `NonlinearProblem`.
+
+```@docs
+NonlinearSolveBase.gradient_stationarity_measure
+NonlinearSolveBase.gradient_measure_supported
+NonlinearSolveBase.check_gradient_and_update!
+NonlinearSolveBase.default_gradient_tolerance
+```

--- a/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
+++ b/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
@@ -141,6 +141,13 @@ include("forward_diff.jl")
 @compat(public, (get_u, get_fu, get_nsteps, get_termination_cache, get_trace))
 @compat(public, (supports_deferred_residual, refresh_residual!))
 @compat(public, (residual_only_termination_mode, trace_is_active))
+@compat(
+    public,
+    (
+        check_gradient_and_update!, default_gradient_tolerance,
+        gradient_measure_supported, gradient_stationarity_measure,
+    )
+)
 @compat(public, (NonlinearSolveNoInitCache,))
 @compat(public, (get_concrete_problem,))
 @compat(public, (construct_linear_solver, needs_square_A, needs_concrete_A, get_linear_cache))

--- a/lib/NonlinearSolveBase/src/public.jl
+++ b/lib/NonlinearSolveBase/src/public.jl
@@ -374,10 +374,15 @@ for norm_type in (:RelNorm, :AbsNorm), safety in (:Safe, :SafeBest)
             $($struct_name)(
                 internalnorm; protective_threshold = nothing,
                 patience_steps = 100, patience_objective_multiplier = 3,
-                min_max_factor = 1.3, max_stalled_steps = nothing
+                min_max_factor = 1.3, max_stalled_steps = nothing, gtol = nothing
             )
 
         $($TERM_INTERNALNORM_DOCS).
+
+        `gtol` enables the gradient-stationarity criterion described in
+        [`gradient_stationarity_measure`](@ref). It is disabled by default; see
+        [`check_gradient_and_update!`](@ref) for how a solver supplies the Jacobian and
+        for the differing interpretation on square and least-squares problems.
         """
         @concrete struct $(struct_name) <: $(supertype_name)
             internalnorm
@@ -386,22 +391,179 @@ for norm_type in (:RelNorm, :AbsNorm), safety in (:Safe, :SafeBest)
             patience_objective_multiplier
             min_max_factor
             max_stalled_steps <: Union{Nothing, Int}
+            gtol <: Union{Nothing, Real}
 
             function $(struct_name)(
                     internalnorm::F; protective_threshold = nothing,
                     patience_steps = 100, patience_objective_multiplier = 3,
-                    min_max_factor = 1.3, max_stalled_steps = nothing
+                    min_max_factor = 1.3, max_stalled_steps = nothing, gtol = nothing
                 ) where {F}
                 norm = Utils.standardize_norm(internalnorm)
                 return new{
                     typeof(norm), typeof(protective_threshold),
                     typeof(patience_objective_multiplier),
-                    typeof(min_max_factor), typeof(max_stalled_steps),
+                    typeof(min_max_factor), typeof(max_stalled_steps), typeof(gtol),
                 }(
                     norm, protective_threshold, patience_steps,
-                    patience_objective_multiplier, min_max_factor, max_stalled_steps
+                    patience_objective_multiplier, min_max_factor, max_stalled_steps, gtol
                 )
             end
         end
     end
 end
+
+"""
+    gradient_stationarity_measure(J, fu) -> Union{Nothing, Real}
+
+Return the scale-free stationarity measure
+
+```math
+\\max_j \\frac{|(J^\\top F)_j|}{\\|J_j\\|_2 \\, \\|F\\|_2}
+```
+
+where ``J_j`` is the `j`-th column of `J`. This is the cosine of the angle between the
+residual and that column, so it is the criterion MINPACK exposes as `gtol` and the one
+Ceres and `scipy.optimize.least_squares` use.
+
+A least-squares solution satisfies ``J^\\top F = 0``, not ``F = 0``, so a residual test
+alone cannot certify convergence on a problem whose residual is nonzero at the optimum.
+Testing ``\\|J^\\top F\\|`` directly would not do either: it carries units of residual per
+unit of `u` and therefore moves under a rescaling of either. Dividing by
+``\\|J_j\\| \\|F\\|`` removes both, leaving a dimensionless quantity invariant under
+`u -> S u` for invertible diagonal `S`, under `F -> c F` for scalar `c`, and under an
+orthogonal transformation of the residual.
+
+# Arguments
+
+  - `J`: Jacobian at the current iterate. Must describe the same iterate as `fu`.
+  - `fu`: Residual at the current iterate.
+
+# Returns
+
+The measure, or `nothing` when it is not defined: `‖F‖ = 0` (the residual test already
+covers that case, and the ratio is `0/0`) or a non-finite residual.
+
+# Examples
+
+```julia
+using NonlinearSolveBase
+
+J = [1.0 0.0; 0.0 1.0]
+NonlinearSolveBase.gradient_stationarity_measure(J, [0.0, 1.0])
+```
+"""
+function gradient_stationarity_measure end
+
+"""
+    gradient_measure_supported(J) -> Bool
+
+Return whether [`gradient_stationarity_measure`](@ref) can be evaluated for a Jacobian
+representation `J`.
+
+The measure needs the individual column norms of `J`, so it is defined for stored matrices
+and for scalars, and undefined for a matrix-free operator. A solver that holds only an
+operator, or an approximation such as the secant Jacobian a quasi-Newton method carries,
+should not reach the gradient criterion at all; this predicate is what makes that
+degradation silent rather than an error.
+
+# Arguments
+
+  - `J`: A Jacobian representation held by a solver cache.
+
+# Returns
+
+`true` for `AbstractMatrix` and `Number`, `false` otherwise.
+
+# Examples
+
+```julia
+using NonlinearSolveBase
+
+NonlinearSolveBase.gradient_measure_supported([1.0 0.0; 0.0 1.0]) # true
+```
+"""
+function gradient_measure_supported end
+
+"""
+    check_gradient_and_update!(cache, J, fu, u) -> Bool
+
+Apply the gradient-stationarity criterion of [`gradient_stationarity_measure`](@ref) to a
+solver cache and stop the solve when it is met.
+
+This is a developer API for solver packages. Call it from a stepping routine at a point
+where `J`, `fu` and `u` all describe the *same* iterate — in practice immediately after
+the Jacobian is formed and before a descent is taken from it. Supplying a Jacobian from a
+previous iterate would test stationarity at a point the solver has already left.
+
+The criterion is a disjunction with, not a replacement for, the residual test the
+termination mode already performs: the residual arm is cheap and it covers the
+zero-residual case, where the measure is a ratio of two quantities going to zero and
+carries no information.
+
+The verdict depends on the problem type, because the same measurement means different
+things:
+
+| | `JᵀF ≈ 0`, `F` small | `JᵀF ≈ 0`, `F` not small |
+|---|---|---|
+| `NonlinearLeastSquaresProblem` | `ReturnCode.Success` | `ReturnCode.Success` |
+| `NonlinearProblem` | `ReturnCode.Success` | `ReturnCode.Stalled` |
+
+For a least-squares problem a stationary point *is* the solution. For a square root-find
+it is a local minimum of `‖F‖` that is not a root, which is a failure — and reporting it
+as `ReturnCode.Stalled` turns a solve that would otherwise exhaust `maxiters` into a
+statement about what went wrong.
+
+# Arguments
+
+  - `cache`: A solver cache carrying `termination_cache`, `retcode` and `force_stop`.
+  - `J`: Jacobian at `u`.
+  - `fu`: Residual at `u`.
+  - `u`: Current iterate.
+
+# Returns
+
+`true` when the solve was stopped, `false` otherwise. It returns `false` without computing
+anything when the termination mode has no `gtol`, so a mode that does not opt in — which
+is every mode by default, including any user-defined one — pays nothing and behaves
+exactly as before.
+
+# Examples
+
+```julia
+using NonlinearSolve, NonlinearSolveBase
+
+prob = NonlinearLeastSquaresProblem((u, p) -> [u[1] - 1.0, 2.0], [0.0])
+cache = init(prob, LevenbergMarquardt())
+NonlinearSolveBase.check_gradient_and_update!(cache, [1.0; 0.0;;], get_fu(cache), get_u(cache))
+```
+"""
+function check_gradient_and_update! end
+
+"""
+    default_gradient_tolerance(T) -> Real
+
+Return the default `gtol` for the gradient-stationarity criterion at element type `T`.
+
+The measure of [`gradient_stationarity_measure`](@ref) is a cosine, so the tolerance is
+dimensionless and depends only on working precision. `sqrt(eps(T))` sits well above the
+`O(eps * sqrt(m))` floor that cancellation in `JᵀF` imposes, so the criterion stays
+attainable, while a cosine that small already certifies the residual as orthogonal to
+every column of the Jacobian.
+
+# Arguments
+
+  - `T`: Element type of the iterate.
+
+# Returns
+
+The default tolerance as a real number.
+
+# Examples
+
+```julia
+using NonlinearSolveBase
+
+NonlinearSolveBase.default_gradient_tolerance(Float64)
+```
+"""
+function default_gradient_tolerance end

--- a/lib/NonlinearSolveBase/src/termination_conditions.jl
+++ b/lib/NonlinearSolveBase/src/termination_conditions.jl
@@ -462,11 +462,25 @@ gradient_stationarity_retcode(leastsq::Bool) = ifelse(
     leastsq, ReturnCode.Success, ReturnCode.Stalled
 )
 
+# The objective a mode ranks iterates by. `Rel*` modes rank on a relative quantity, so
+# comparing a bare residual norm against their `best_objective_value` mixes two scales.
+mode_objective(mode, fu, u, reltol) = Utils.apply_norm(mode.internalnorm, fu)
+function mode_objective(
+        mode::Union{
+            RelNormSafeTerminationMode, RelNormSafeBestTerminationMode,
+        }, fu, u, reltol
+    )
+    return Utils.apply_norm(mode.internalnorm, fu) /
+        (Utils.apply_norm(mode.internalnorm, fu, u) + eps(typeof(reltol)))
+end
+
 # A `Best` mode reports the lowest-objective iterate, which need not be the one the
 # Jacobian was formed at; firing elsewhere would attach the verdict to an untested point.
-at_best_iterate(_, ::AbstractNonlinearTerminationMode, _) = true
-function at_best_iterate(tc_cache, mode::AbstractSafeBestNonlinearTerminationMode, fu)
-    return Utils.apply_norm(mode.internalnorm, fu) ≤ tc_cache.best_objective_value
+at_best_iterate(_, ::AbstractNonlinearTerminationMode, _, _, _) = true
+function at_best_iterate(
+        tc_cache, mode::AbstractSafeBestNonlinearTerminationMode, fu, u, reltol
+    )
+    return mode_objective(mode, fu, u, reltol) ≤ tc_cache.best_objective_value
 end
 
 function check_gradient_and_update!(cache, J, fu, u)
@@ -474,13 +488,17 @@ function check_gradient_and_update!(cache, J, fu, u)
     gtol = gradient_tolerance(tc_cache.mode)
     gtol === nothing && return false
     gradient_measure_supported(J) || return false
-    at_best_iterate(tc_cache, tc_cache.mode, fu) || return false
+    at_best_iterate(tc_cache, tc_cache.mode, fu, u, tc_cache.reltol) || return false
     measure = gradient_stationarity_measure(J, fu)
     # Written as `≤` rather than `> ... && return`: a non-finite Jacobian makes the measure
     # `NaN`, and only this direction refuses to terminate on it.
     (measure === nothing || !(measure ≤ gtol)) && return false
     tc_cache.retcode = gradient_stationarity_retcode(tc_cache.leastsq)
     cache.retcode = tc_cache.retcode
+    # The retained best is only replaced on a strict improvement, so on a tie it still holds
+    # an earlier iterate. Report the one the measure was computed at, or the verdict would
+    # describe a point that was never tested.
+    update_u!!(tc_cache, u)
     update_from_termination_cache!(tc_cache, cache, tc_cache.mode, u)
     cache.force_stop = true
     return true

--- a/lib/NonlinearSolveBase/src/termination_conditions.jl
+++ b/lib/NonlinearSolveBase/src/termination_conditions.jl
@@ -4,6 +4,11 @@ const RelNormModes = Union{
 const AbsNormModes = Union{
     AbsNormTerminationMode, AbsNormSafeTerminationMode, AbsNormSafeBestTerminationMode,
 }
+# The four modes carrying a `gtol` field; the plain `*NormTerminationMode`s do not.
+const SafeNormModes = Union{
+    RelNormSafeTerminationMode, RelNormSafeBestTerminationMode,
+    AbsNormSafeTerminationMode, AbsNormSafeBestTerminationMode,
+}
 
 """
     residual_only_termination_mode(mode) -> Bool
@@ -388,8 +393,11 @@ function default_termination_mode(
     return AbsNormSafeBestTerminationMode(Base.Fix1(maximum, abs); max_stalled_steps = 32)
 end
 
-function default_termination_mode(::NonlinearLeastSquaresProblem, ::Val{:regular})
-    return AbsNormSafeBestTerminationMode(Base.Fix2(norm, 2); max_stalled_steps = 32)
+function default_termination_mode(prob::NonlinearLeastSquaresProblem, ::Val{:regular})
+    return AbsNormSafeBestTerminationMode(
+        Base.Fix2(norm, 2); max_stalled_steps = 32,
+        gtol = default_gradient_tolerance(eltype(prob.u0))
+    )
 end
 
 function init_termination_cache(
@@ -409,6 +417,73 @@ function init_termination_cache(
     reltol = get_tolerance(u, reltol, T)
     cache = init(prob, tc, du, u; abstol, reltol)
     return abstol, reltol, cache
+end
+
+default_gradient_tolerance(::Type{T}) where {T} = sqrt(eps(float(real(one(T)))))
+
+gradient_tolerance(::AbstractNonlinearTerminationMode) = nothing
+gradient_tolerance(mode::SafeNormModes) = mode.gtol
+
+gradient_measure_supported(_) = false
+gradient_measure_supported(::AbstractMatrix) = true
+gradient_measure_supported(::Number) = true
+
+function gradient_stationarity_measure(J, fu)
+    fu_norm = L2_NORM(fu)
+    # `L2_NORM` is `@fastmath`, which lets LLVM assume its result is finite and fold an
+    # `isfinite` test on it away. Non-finiteness has to be caught on the raw residual, and
+    # every consumer of the measure must additionally fail closed.
+    (iszero(fu_norm) || !_all_finite(fu)) && return nothing
+    return _gradient_stationarity_measure(J, fu, fu_norm)
+end
+
+_all_finite(x::Number) = isfinite(x)
+_all_finite(x) = all(isfinite, x)
+
+function _gradient_stationarity_measure(J::Number, fu, fu_norm)
+    iszero(J) && return nothing
+    return abs(J' * fu) / (abs(J) * fu_norm)
+end
+
+function _gradient_stationarity_measure(J::AbstractMatrix, fu, fu_norm)
+    fu_vec = Utils.safe_vec(fu)
+    size(J, 1) == length(fu_vec) || return nothing
+    g = J' * fu_vec
+    measure = zero(fu_norm)
+    for (j, gⱼ) in zip(axes(J, 2), g)
+        col_norm = L2_NORM(@view(J[:, j]))
+        iszero(col_norm) && continue
+        measure = max(measure, abs(gⱼ) / (col_norm * fu_norm))
+    end
+    return measure
+end
+
+gradient_stationarity_retcode(leastsq::Bool) = ifelse(
+    leastsq, ReturnCode.Success, ReturnCode.Stalled
+)
+
+# A `Best` mode reports the lowest-objective iterate, which need not be the one the
+# Jacobian was formed at; firing elsewhere would attach the verdict to an untested point.
+at_best_iterate(_, ::AbstractNonlinearTerminationMode, _) = true
+function at_best_iterate(tc_cache, mode::AbstractSafeBestNonlinearTerminationMode, fu)
+    return Utils.apply_norm(mode.internalnorm, fu) ≤ tc_cache.best_objective_value
+end
+
+function check_gradient_and_update!(cache, J, fu, u)
+    tc_cache = cache.termination_cache
+    gtol = gradient_tolerance(tc_cache.mode)
+    gtol === nothing && return false
+    gradient_measure_supported(J) || return false
+    at_best_iterate(tc_cache, tc_cache.mode, fu) || return false
+    measure = gradient_stationarity_measure(J, fu)
+    # Written as `≤` rather than `> ... && return`: a non-finite Jacobian makes the measure
+    # `NaN`, and only this direction refuses to terminate on it.
+    (measure === nothing || !(measure ≤ gtol)) && return false
+    tc_cache.retcode = gradient_stationarity_retcode(tc_cache.leastsq)
+    cache.retcode = tc_cache.retcode
+    update_from_termination_cache!(tc_cache, cache, tc_cache.mode, u)
+    cache.force_stop = true
+    return true
 end
 
 function check_and_update!(cache, fu, u, uprev)

--- a/lib/NonlinearSolveBase/test/gradient_termination.jl
+++ b/lib/NonlinearSolveBase/test/gradient_termination.jl
@@ -1,0 +1,238 @@
+using NonlinearSolveBase, SciMLBase, LinearAlgebra, Test
+using NonlinearSolveBase: AbsNormSafeBestTerminationMode, AbsNormSafeTerminationMode,
+    AbsNormTerminationMode, RelNormSafeBestTerminationMode, RelNormSafeTerminationMode,
+    check_gradient_and_update!, default_gradient_tolerance, gradient_measure_supported,
+    gradient_stationarity_measure
+using SciMLBase: NonlinearLeastSquaresProblem, NonlinearProblem, ReturnCode
+using StaticArrays: SA
+
+@static if VERSION ≥ v"1.11"
+    @testset "new names are public" begin
+        for name in (
+                :check_gradient_and_update!, :default_gradient_tolerance,
+                :gradient_measure_supported, :gradient_stationarity_measure,
+            )
+            @test Base.ispublic(NonlinearSolveBase, name)
+        end
+    end
+end
+
+@testset "measure is the cosine between the residual and each Jacobian column" begin
+    # A residual orthogonal to the only column is stationary regardless of its size.
+    @test gradient_stationarity_measure([1.0; 0.0;;], [0.0, 3.0]) == 0.0
+    # A residual parallel to the column is maximally non-stationary.
+    @test gradient_stationarity_measure([1.0; 0.0;;], [2.0, 0.0]) == 1.0
+    @test gradient_stationarity_measure(2.0, 3.0) == 1.0
+    # The largest column cosine wins.
+    J = [1.0 0.0; 0.0 1.0]
+    @test gradient_stationarity_measure(J, [3.0, 4.0]) ≈ 0.8
+end
+
+@testset "scale invariance" begin
+    # A criterion on `‖JᵀF‖` alone moves under both rescalings; the cosine does not.
+    J = [1.0 4.0; 2.0 -1.0; -3.0 0.5]
+    F = [0.3, -1.2, 2.0]
+    base = gradient_stationarity_measure(J, F)
+
+    for s in ([1.0e6, 1.0e-6], [3.0, 3.0], [1.0e-8, 1.0])
+        S = Diagonal(s)
+        @test gradient_stationarity_measure(J * inv(S), F) ≈ base rtol = 1.0e-12
+    end
+    for c in (1.0e8, 1.0e-8, -5.0)
+        @test gradient_stationarity_measure(c * J, c * F) ≈ base rtol = 1.0e-12
+    end
+    # An orthogonal transformation of the residual leaves the least-squares problem, and
+    # therefore the measure, unchanged.
+    θ = 0.7
+    Q = [
+        cos(θ) -sin(θ) 0.0
+        sin(θ) cos(θ) 0.0
+        0.0 0.0 1.0
+    ]
+    @test gradient_stationarity_measure(Q * J, Q * F) ≈ base rtol = 1.0e-12
+
+    # The unnormalised gradient is not invariant, which is why it is not the criterion.
+    @test !isapprox(
+        norm((J * inv(Diagonal([1.0e6, 1.0e-6])))'F, Inf), norm(J'F, Inf); rtol = 1.0e-3
+    )
+end
+
+@testset "measure is undefined rather than wrong on degenerate input" begin
+    J = [1.0 0.0; 0.0 1.0]
+    @test gradient_stationarity_measure(J, [0.0, 0.0]) === nothing
+    @test gradient_stationarity_measure(J, [NaN, 1.0]) === nothing
+    @test gradient_stationarity_measure(J, [Inf, 1.0]) === nothing
+    @test gradient_stationarity_measure(0.0, 1.0) === nothing
+    # A non-finite Jacobian leaves a `NaN` that every caller must treat as "do not fire".
+    @test isnan(gradient_stationarity_measure([NaN 0.0; 0.0 1.0], [1.0, 2.0]))
+    # Shape mismatch is not a silent zero.
+    @test gradient_stationarity_measure(J, [1.0, 2.0, 3.0]) === nothing
+end
+
+@testset "gradient_measure_supported" begin
+    @test gradient_measure_supported([1.0 0.0; 0.0 1.0])
+    @test gradient_measure_supported(Diagonal([1.0, 2.0]))
+    @test gradient_measure_supported(1.0)
+    # A matrix-free operator has no column norms, so the criterion must stand down.
+    @test !gradient_measure_supported(nothing)
+    @test !gradient_measure_supported(I)
+end
+
+@testset "gtol defaults to off on every mode" begin
+    for mode in (
+            AbsNormSafeTerminationMode(Base.Fix2(norm, 2)),
+            AbsNormSafeBestTerminationMode(Base.Fix2(norm, 2)),
+            RelNormSafeTerminationMode(Base.Fix2(norm, 2)),
+            RelNormSafeBestTerminationMode(Base.Fix2(norm, 2)),
+        )
+        @test NonlinearSolveBase.gradient_tolerance(mode) === nothing
+    end
+    @test NonlinearSolveBase.gradient_tolerance(AbsNormTerminationMode(Base.Fix2(norm, 2))) ===
+        nothing
+    @test NonlinearSolveBase.gradient_tolerance(
+        AbsNormSafeBestTerminationMode(Base.Fix2(norm, 2); gtol = 1.0e-6)
+    ) == 1.0e-6
+
+    @test default_gradient_tolerance(Float64) == sqrt(eps(Float64))
+    @test default_gradient_tolerance(Float32) == sqrt(eps(Float32))
+end
+
+@testset "least-squares default opts in, square default does not" begin
+    ls = NonlinearSolveBase.default_termination_mode(
+        NonlinearLeastSquaresProblem((u, p) -> [u[1] - 1.0, 2.0], [0.0]), Val(:regular)
+    )
+    @test ls.gtol == default_gradient_tolerance(Float64)
+
+    sq = NonlinearSolveBase.default_termination_mode(
+        NonlinearProblem((u, p) -> u, [1.0]), Val(:regular)
+    )
+    @test NonlinearSolveBase.gradient_tolerance(sq) === nothing
+
+    # `:simple` (SimpleNonlinearSolve) is untouched.
+    for prob in (
+            NonlinearLeastSquaresProblem((u, p) -> [u[1] - 1.0, 2.0], [0.0]),
+            NonlinearProblem((u, p) -> u, [1.0]),
+        )
+        @test NonlinearSolveBase.gradient_tolerance(
+            NonlinearSolveBase.default_termination_mode(prob, Val(:simple))
+        ) === nothing
+    end
+end
+
+# A minimal stand-in for a solver cache: `check_gradient_and_update!` reads only these
+# fields, which is what lets a solver package opt in without a new cache type.
+mutable struct FakeSolverCache{C}
+    termination_cache::C
+    retcode::ReturnCode.T
+    force_stop::Bool
+end
+
+function fake_cache(prob, mode, du, u)
+    tc = SciMLBase.init(prob, mode, du, u; abstol = 1.0e-8, reltol = 1.0e-8)
+    return FakeSolverCache(tc, ReturnCode.Default, false)
+end
+
+NonlinearSolveBase.get_u(c::FakeSolverCache) = c.termination_cache.u
+
+@testset "verdict flips between least-squares and square problems" begin
+    du = [0.0, 3.0]
+    u = [1.0]
+    J = [1.0; 0.0;;]              # residual orthogonal to the only column: stationary
+    mode() = AbsNormSafeBestTerminationMode(Base.Fix2(norm, 2); gtol = 1.0e-8)
+
+    lsq = fake_cache(
+        NonlinearLeastSquaresProblem((x, p) -> du, u), mode(), du, u
+    )
+    @test check_gradient_and_update!(lsq, J, du, u)
+    @test lsq.force_stop
+    @test lsq.retcode == ReturnCode.Success
+    @test SciMLBase.successful_retcode(lsq.retcode)
+
+    sq = fake_cache(NonlinearProblem((x, p) -> du, u), mode(), du, u)
+    @test check_gradient_and_update!(sq, J, du, u)
+    @test sq.force_stop
+    # Stationary with a residual this large is a local minimum, not a root.
+    @test sq.retcode == ReturnCode.Stalled
+    @test !SciMLBase.successful_retcode(sq.retcode)
+end
+
+@testset "does not fire when it should not" begin
+    u = [1.0]
+    mode() = AbsNormSafeBestTerminationMode(Base.Fix2(norm, 2); gtol = 1.0e-8)
+    prob(du) = NonlinearLeastSquaresProblem((x, p) -> du, u)
+
+    # Non-stationary.
+    du = [2.0, 3.0]
+    c = fake_cache(prob(du), mode(), du, u)
+    @test !check_gradient_and_update!(c, [1.0; 0.0;;], du, u)
+    @test !c.force_stop
+
+    # `gtol` unset: the criterion is inert, which is what keeps every existing mode and
+    # every user-defined mode behaving exactly as before.
+    du = [0.0, 3.0]
+    c = fake_cache(prob(du), AbsNormSafeBestTerminationMode(Base.Fix2(norm, 2)), du, u)
+    @test !check_gradient_and_update!(c, [1.0; 0.0;;], du, u)
+    @test !c.force_stop
+
+    # No usable Jacobian representation: degrade, never error.
+    du = [0.0, 3.0]
+    c = fake_cache(prob(du), mode(), du, u)
+    @test !check_gradient_and_update!(c, nothing, du, u)
+    @test !c.force_stop
+
+    # Non-finite Jacobian makes the measure `NaN`; terminating on it would report a
+    # stationary point that was never established.
+    du = [1.0, 2.0]
+    c = fake_cache(prob(du), mode(), du, u)
+    @test !check_gradient_and_update!(c, [NaN; 0.0;;], du, u)
+    @test !c.force_stop
+
+    # Non-finite residual, likewise.
+    du = [Inf, -Inf]
+    c = fake_cache(prob(du), mode(), du, u)
+    @test !check_gradient_and_update!(c, [1.0; 0.0;;], du, u)
+    @test !c.force_stop
+end
+
+@testset "a Best mode fires only at the iterate it reports" begin
+    # The mode retains the lowest-residual iterate. If the current one is worse, firing
+    # would attach a stationarity verdict to a point that was never tested.
+    u = [1.0]
+    du_best = [0.0, 1.0]
+    mode = AbsNormSafeBestTerminationMode(Base.Fix2(norm, 2); gtol = 1.0e-8)
+    c = fake_cache(NonlinearLeastSquaresProblem((x, p) -> du_best, u), mode, du_best, u)
+
+    du_worse = [0.0, 5.0]      # stationary, but a worse residual than the retained best
+    @test !check_gradient_and_update!(c, [1.0; 0.0;;], du_worse, u)
+    @test !c.force_stop
+    # At the retained best it fires.
+    @test check_gradient_and_update!(c, [1.0; 0.0;;], du_best, u)
+end
+
+@testset "a user-defined mode keeps working and never reaches the gradient path" begin
+    struct UserGradTestMode <: NonlinearSolveBase.AbstractNonlinearTerminationMode end
+    function NonlinearSolveBase.check_convergence(
+            ::UserGradTestMode, duₙ, uₙ, _, abstol, __
+        )
+        return maximum(abs, duₙ) ≤ abstol
+    end
+
+    prob = NonlinearLeastSquaresProblem((u, p) -> [0.0, 3.0], [1.0])
+    tc = SciMLBase.init(
+        prob, UserGradTestMode(), [0.0, 3.0], [1.0]; abstol = 1.0e-8, reltol = 1.0e-8
+    )
+    @test NonlinearSolveBase.gradient_tolerance(UserGradTestMode()) === nothing
+
+    c = FakeSolverCache(tc, ReturnCode.Default, false)
+    @test !check_gradient_and_update!(c, [1.0; 0.0;;], [0.0, 3.0], [1.0])
+    @test !c.force_stop
+
+    # The documented call signature still decides termination.
+    @test !tc([1.0, 1.0], [1.0], [1.0])
+    @test tc([1.0e-12, 1.0e-12], [1.0], [1.0])
+end
+
+@testset "static and scalar states" begin
+    @test gradient_stationarity_measure(SA[1.0 0.0; 0.0 1.0], SA[3.0, 4.0]) ≈ 0.8
+    @test gradient_stationarity_measure(2.0, 0.0) === nothing
+end

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -166,6 +166,10 @@ run_tests(;
             end
         end
 
+        @safetestset "Gradient stationarity termination" include(
+            "gradient_termination.jl"
+        )
+
         @safetestset "Abstract interface trait contracts" begin
             using NonlinearSolveBase, Test
 

--- a/lib/NonlinearSolveFirstOrder/src/solve.jl
+++ b/lib/NonlinearSolveFirstOrder/src/solve.jl
@@ -367,6 +367,11 @@ function InternalAPI.step!(
     end
     new_jacobian && reset_jacobian_reuse!(cache.jacobian_reuse_cache, cache.fu)
 
+    # `J`, `cache.fu` and `cache.u` describe the same iterate only here: the step below
+    # moves `u` and refreshes the residual while `J` stays behind.
+    NonlinearSolveBase.check_gradient_and_update!(cache, J, cache.fu, cache.u) &&
+        return nothing
+
     has_forcing = cache.forcing_cache !== nothing && cache.forcing_cache !== missing && !(cache.u isa Number) && !(J isa Diagonal)
 
     if has_forcing

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests.jl
@@ -7,3 +7,4 @@
 @safetestset "Deferred residual evaluation" include("misc_tests__item7.jl")
 @safetestset "No redundant terminal residual evaluation" include("misc_tests__item8.jl")
 @safetestset "Adaptive Jacobian reuse" include("misc_tests__item9.jl")
+@safetestset "Gradient stationarity termination (#1149)" include("misc_tests__item10.jl")

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests__item10.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests__item10.jl
@@ -1,0 +1,71 @@
+using NonlinearSolveFirstOrder, NonlinearSolveBase, SciMLBase, LinearAlgebra, Test
+using NonlinearSolveBase: AbsNormSafeBestTerminationMode, default_gradient_tolerance
+
+# A data fit whose residual is nonzero at the optimum: `‖F‖ ≤ abstol` is unreachable no
+# matter how well the solve converges, so only `JᵀF = 0` can certify it.
+const TS = collect(range(0.0, 2.0; length = 12))
+const YS = [1.0 + 0.7 * t + 0.35 * sin(4t) for t in TS]
+
+expfit(u, p) = @. u[1] * exp(u[2] * TS) - YS
+expfit_jac(u, p) = hcat(exp.(u[2] .* TS), u[1] .* TS .* exp.(u[2] .* TS))
+
+function expfit_prob(u0 = [1.0, 0.5])
+    f = NonlinearFunction{false}(expfit; jac = expfit_jac, resid_prototype = zeros(length(TS)))
+    return NonlinearLeastSquaresProblem(f, u0, nothing)
+end
+
+@testset "nonzero-residual least squares reaches ReturnCode.Success" begin
+    prob = expfit_prob()
+    for alg in (GaussNewton(), LevenbergMarquardt(), TrustRegion())
+        sol = solve(prob, alg; maxiters = 1000)
+        J = expfit_jac(sol.u, nothing)
+        F = expfit(sol.u, nothing)
+        @test norm(F, 2) > 1.0e-3                     # the residual test cannot be met
+        @test norm(J'F, Inf) < 1.0e-6                 # but the solve is stationary
+        @test sol.retcode == ReturnCode.Success
+    end
+end
+
+@testset "gtol = nothing reproduces the pre-change exit" begin
+    prob = expfit_prob()
+    off = AbsNormSafeBestTerminationMode(Base.Fix2(norm, 2); max_stalled_steps = 32)
+    sol = solve(prob, GaussNewton(); maxiters = 1000, termination_condition = off)
+    @test sol.retcode != ReturnCode.Success
+end
+
+@testset "the criterion does not stop short of a stationary point" begin
+    prob = expfit_prob()
+    ref = solve(
+        prob, GaussNewton(); maxiters = 1000,
+        termination_condition = AbsNormSafeBestTerminationMode(
+            Base.Fix2(norm, 2); max_stalled_steps = 32
+        )
+    )
+    got = solve(prob, GaussNewton(); maxiters = 1000)
+    @test norm(expfit(got.u, nothing), 2) ≤ norm(expfit(ref.u, nothing), 2) * (1 + 1.0e-8)
+    @test got.stats.nf ≤ ref.stats.nf
+end
+
+@testset "the same measurement is a failure on a square problem" begin
+    # Freudenstein-Roth from a start that funnels into its classic local minimum: `JᵀF`
+    # goes to zero while `F` does not, which is a local minimum of `‖F‖` and not a root.
+    fr(u, p) = [
+        -13.0 + u[1] + ((5.0 - u[2]) * u[2] - 2.0) * u[2],
+        -29.0 + u[1] + ((u[2] + 1.0) * u[2] - 14.0) * u[2],
+    ]
+    frj(u, p) = [
+        1.0 (10.0 - 3.0 * u[2]) * u[2] - 2.0
+        1.0 (3.0 * u[2] + 2.0) * u[2] - 14.0
+    ]
+    prob = NonlinearProblem(NonlinearFunction{false}(fr; jac = frj), [15.0, -2.0], nothing)
+
+    gtol = default_gradient_tolerance(Float64)
+    on = AbsNormSafeBestTerminationMode(
+        Base.Fix1(maximum, abs); max_stalled_steps = 32, gtol
+    )
+    sol = solve(prob, TrustRegion(); maxiters = 1000, termination_condition = on)
+
+    @test maximum(abs, fr(sol.u, nothing)) > 1.0
+    @test !SciMLBase.successful_retcode(sol.retcode)
+    @test sol.retcode == ReturnCode.Stalled
+end

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests.jl
@@ -11,3 +11,4 @@
 @safetestset "LimitedMemoryBroyden: continuation from a nearby root" include("core_tests__item11.jl")
 @safetestset "reinit! resets the update rule state" include("core_tests__item12.jl")
 @safetestset "No-change reset requires every component to stall" include("core_tests__item13.jl")
+@safetestset "Gradient criterion is inert without a true Jacobian (#1149)" include("core_tests__item14.jl")

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests__item14.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests__item14.jl
@@ -1,0 +1,34 @@
+using NonlinearSolveQuasiNewton, NonlinearSolveBase, SciMLBase, LinearAlgebra, Test
+using NonlinearSolveBase: AbsNormSafeBestTerminationMode, default_gradient_tolerance
+
+# Broyden and Klement carry a secant approximation, not a Jacobian. The approximation is
+# built only from the directions the solve has explored, so `JᵀF` computed from it can be
+# small where the true gradient is not; the gradient criterion must therefore not reach
+# them at all, and setting `gtol` must be inert rather than an error.
+#
+# Freudenstein-Roth from a start that funnels into its local minimum, posed as least
+# squares: the residual is nonzero at the optimum, which is exactly where the criterion
+# would fire if these solvers consulted it.
+@testset "quasi-Newton solves ignore gtol: $name" for (name, alg) in (
+        ("Broyden", Broyden()), ("Klement", Klement()),
+    )
+    fr = (u, p) -> [
+        -13.0 + u[1] + ((5.0 - u[2]) * u[2] - 2.0) * u[2],
+        -29.0 + u[1] + ((u[2] + 1.0) * u[2] - 14.0) * u[2],
+    ]
+    prob = NonlinearLeastSquaresProblem(
+        NonlinearFunction{false}(fr; resid_prototype = zeros(2)), [15.0, -2.0], nothing
+    )
+
+    on = AbsNormSafeBestTerminationMode(
+        Base.Fix2(norm, 2); max_stalled_steps = 32,
+        gtol = default_gradient_tolerance(Float64)
+    )
+    off = AbsNormSafeBestTerminationMode(Base.Fix2(norm, 2); max_stalled_steps = 32)
+
+    a = solve(prob, alg; maxiters = 1000, termination_condition = on)
+    b = solve(prob, alg; maxiters = 1000, termination_condition = off)
+    @test a.retcode == b.retcode
+    @test a.u ≈ b.u
+    @test a.stats.nf == b.stats.nf
+end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

Addresses the second half of #1149. **This changes a default** — see the compatibility note at the end.

### Why the least-squares default is wrong today

```julia
default_termination_mode(::NonlinearLeastSquaresProblem, ::Val{:regular}) =
    AbsNormSafeBestTerminationMode(Base.Fix2(norm, 2); max_stalled_steps = 32)
```

That tests `‖F(u)‖₂ ≤ abstol`. A least-squares solution is defined by **`JᵀF = 0`**, not `F = 0`, so for any problem with nonzero residual at the optimum — the normal case for data fitting — the criterion is *mathematically unattainable* however well the solve converged. Every such solve exits through the stall detector, an internal trust-region give-up, or `maxiters`. Since `successful_retcode(StalledSuccess) === true`, the stall detector has been acting as a de-facto stationarity proxy — a poor one, given it compares `‖Δu‖₂` against a bound on `‖F‖`.

### The criterion

MINPACK's scale-free gradient cosine, `maxⱼ |(JᵀF)ⱼ| / (‖Jⱼ‖₂ ‖F‖₂)`, added as a disjunctive arm alongside the existing `‖F‖ ≤ abstol` test. New `gtol` keyword on the four safe modes, defaulting to `nothing`; the **least-squares problem default turns it on** at `sqrt(eps(T))` = 1.49e-8 (scipy's `least_squares` uses 1e-8).

Scale invariance is demonstrated, not asserted. Over 2000 random `(J, F)`, worst relative deviation of the measure: 7.97e-16 under `u → Su` (condition up to e¹²), 9.84e-16 under `F → cF`, 5.54e-15 under `F → QF` — all at `eps(Float64)` = 2.22e-16. On a fixed `(J, F)`, `max|JᵀF|` moves `3.98 → 760.9 → 3.98e8` under those transforms while the cosine stays `6.01377e-01`. End to end, six reparametrisations of one exponential fit all stop at iteration 7 with identical `u` to 10 digits.

**The interpretation differs by problem type**, which is the subtle part: `JᵀF ≈ 0` with `F` large is *success* for least-squares (it is the definition of the solution) and a *failure* for a square root-find (a local minimum of `‖F‖`, not a root). Mapped to `ReturnCode.Success` and `ReturnCode.Stalled` respectively — no new enum value; `Stalled` is already what the stall detector returns for that square case. Verified end to end on constructed square problems sitting at genuine non-root minima: `Stalled`, never a silent success.

### Placement and fallback

`check_and_update!` is untouched. A separate `check_gradient_and_update!(cache, J, fu, u)` is called from `GeneralizedFirstOrderAlgorithm`'s `step!` immediately after `J` is formed — the only point where `J`, `fu` and `u` describe the same iterate.

Quasi-Newton and spectral solvers never call it, so `Broyden`, `Klement`, `LimitedMemoryBroyden` and `DFSane` are untouched. That is deliberate: their secant `J` is built only from explored directions, so `JᵀF` computed from it can be small where the true gradient is not, which would manufacture stationarity claims. Matrix-free operators (`I`, `nothing`) degrade rather than error.

### Results, NLSProblems (88 unconstrained problems)

| algorithm | Success | StalledSuccess | MaxIters | nf | njac |
|---|---|---|---|---|---|
| default polyalg | **57 → 81** | 20 → 1 | 9 → 4 | 0.464x | 0.570x |
| GaussNewton | **56 → 73** | 15 → 0 | 15 → 13 | 0.842x | 0.843x |
| LevenbergMarquardt | **47 → 66** | 21 → 7 | 20 → 15 | 0.746x | 0.752x |
| TrustRegion | **53 → 80** | 32 → 5 | 3 → 3 | 0.850x | 0.990x |

On a 1000×200 synthetic nonzero-residual fit, GaussNewton goes from `StalledSuccess` in 35 steps to `Success` in 4; at 2000×200, `MaxIters`/200 steps/21.2 s becomes `Success`/13 steps/0.91 s at an identical `‖F‖`.

Cost of the measure is one gemv plus column norms — 0.004–0.74× the flops of `qr(J)` depending on size, worst at tiny `n`, where it is negligible anyway.

### What this trades away — please read before merging

**Answers change on ill-conditioned least squares, and not always for the better.** The gradient measure is a first-order stationarity test, so it can fire where the residual is numerically orthogonal to a rank-deficient column span. On ill-conditioned linear least squares under `LevenbergMarquardt` (exact minimum known from QR):

| m×n | cond(A) | exact min ‖F‖ | before (retcode) | after (retcode) | excess |
|---|---|---|---|---|---|
| 200×20 | 1.2e17 | 0.6901473011 | 0.6901431964 (`MaxIters`) | 0.6995735109 (**`Success`**) | +1.37% |
| 2000×200 | 5.1e17 | 2.2230682734 | 2.2229175832 (`MaxIters`) | 2.2249104135 (**`Success`**) | +0.08% |

`mgh03` (Powell badly scaled) is the corpus instance: `LevenbergMarquardt` previously reached `‖F‖ = 9.9e-15`, now stops at `0.980`. The residual is orthogonal to the numerically rank-deficient span for five consecutive iterations before the damping escapes. This is MINPACK's documented `INFO = 4`, and is why MINPACK's own default `gtol` is `0`. `GaussNewton` and `TrustRegion` show **no** regression at any `gtol` from 1e-6 to 1e-14; only `LevenbergMarquardt` does, and only `gtol < 2.35e-13` avoids it, which costs Success 66→53. I kept `sqrt(eps)` rather than tuning to one problem, but this is the decision to review.

**Even where `‖F‖` is unchanged, convergence is looser.** The returned parameter vector moves by up to 5.5e-7 relative, and the returned gradient degrades — e.g. `mgh20`/GaussNewton `‖JᵀF‖` 1.8e-15 → 8.3e-10 while `nf` drops 49→10. The trade is `sqrt(eps)`-converged instead of `eps`-converged.

**Two edge cases.** If `u0` is exactly a stationary point that is a local *maximum* or saddle, the criterion fires at iteration 1 and reports `Success` without taking a descent step. `successful_retcode` was already `true` there (via `StalledSuccess`), so it is not a new false success, but it is a stronger claim. Perturbing `u0` recovers the true minimum.

### Square problems: recommendation is **do not enable**

276 square solves (23 problems × 3 start scalings × 4 algorithms): the default path is **bit-identical** — retcode, nsteps, nf, `‖F‖` to 12 digits, every `u` component to 15 digits; `diff` of the logs is empty. Structurally guaranteed, since `gtol === nothing` returns on the first line, and now measured. Forcing `gtol` on changes exactly **one of 207 solves**, and its retcode does not even change (`Stalled → Stalled`, nf 86→54). Of 20 failing square solves the criterion diagnoses 2, both already reported as failures. Safe but not worth it; `‖F‖∞ ≤ abstol` is attainable and correct for root-finding. `gtol` stays available as an opt-in.

### Fixed in review

- `at_best_iterate` compared a bare residual norm against `best_objective_value`, which is a *relative* quantity for `Rel*` modes — so a residual the mode ranks worse than its retained best could pass. It now ranks on the mode's own objective.
- The retained best is replaced only on a strict improvement, so on a tie it holds an earlier iterate; rolling back attached the verdict to a point the measure was never evaluated at (returning `Success` at a cosine 6.5× the tolerance). The firing iterate is now recorded before the rollback.
- A `@fastmath` hazard, worth its own issue: `L2_NORM` is `@fastmath`, so LLVM folds away `isfinite` on its result — `!isfinite(L2_NORM(x))` returns `false` inside a function for `x = [-Inf, Inf]`. The criterion screens the raw residual and is written to fail closed, but **any `isfinite` guard on an `L2_NORM` result in this repo is unreliable.**

### Tests and compatibility

Negative control on unmodified master: 6 passed / 3 failed, the three being the nonzero-residual least-squares cases now reaching `Success`. `GROUP=Core` passes for `NonlinearSolveBase` (`Gradient stationarity termination | 67 67`, `Termination Conditions | 44 44`), `NonlinearSolveFirstOrder` and `NonlinearSolveQuasiNewton`. User-defined termination modes using the documented `check_convergence` signature are unaffected across all 6 problem × algorithm combinations. `AbsNormSafeBestTerminationMode` gains a type parameter (5 → 6).

Minor bump. The release note should say **answers may change on ill-conditioned least-squares problems**, not name `mgh03` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
