### PR TITLE
Drop @fastmath from L2_NORM/Linf_NORM so isfinite guards survive

### DIFF
--- a/lib/NonlinearSolveBase/src/common_defaults.jl
+++ b/lib/NonlinearSolveBase/src/common_defaults.jl
@@ -16,24 +16,29 @@ function NAN_CHECK(x::Union{AbstractVectorOfArray, ArrayPartition})
     return any(NAN_CHECK, Utils.get_internal_array(x))
 end
 
-L2_NORM(u::Union{AbstractFloat, Complex}) = @fastmath abs(u)
-L2_NORM(u::Number) = @fastmath sqrt(UNITLESS_ABS2(u))
+# `@fastmath` must not be used in these norms. Its `nnan`/`ninf` LLVM flags let the
+# optimizer constant-fold `isfinite`/`isnan` guards applied to the result away entirely
+# (`termination_conditions.jl`'s protective break compiled to `ret i8 0`), so a diverged
+# solve was reported as converged. `@simd` already supplies `reassoc`+`contract`, which is
+# what vectorizes the reduction, so dropping `@fastmath` keeps the vectorized loop.
+L2_NORM(u::Union{AbstractFloat, Complex}) = abs(u)
+L2_NORM(u::Number) = sqrt(UNITLESS_ABS2(u))
 function L2_NORM(u::Array{<:Union{AbstractFloat, Complex}})
     if Utils.fast_scalar_indexing(u)
         x = zero(eltype(u))
         @simd for i in eachindex(u)
-            @inbounds @fastmath x += abs2(u[i])
+            @inbounds x += abs2(u[i])
         end
-        return @fastmath sqrt(real(x))
+        return sqrt(real(x))
     end
-    return @fastmath sqrt(UNITLESS_ABS2(u))
+    return sqrt(UNITLESS_ABS2(u))
 end
 function L2_NORM(u::StaticArray{<:Union{AbstractFloat, Complex}})
-    return @fastmath sqrt(real(sum(abs2, u)))
+    return sqrt(real(sum(abs2, u)))
 end
 L2_NORM(u) = norm(u, 2)
 
-Linf_NORM(u::Union{AbstractFloat, Complex}) = @fastmath abs(u)
+Linf_NORM(u::Union{AbstractFloat, Complex}) = abs(u)
 Linf_NORM(u) = maximum(abs, u)
 
 get_tolerance(η, ::Type{T}) where {T} = Utils.convert_real(T, η)

--- a/lib/NonlinearSolveBase/test/nonfinite_objective.jl
+++ b/lib/NonlinearSolveBase/test/nonfinite_objective.jl
@@ -1,0 +1,26 @@
+using NonlinearSolveBase, SciMLBase, Test
+using LinearAlgebra: norm
+
+@testset "safe modes break on a non-finite objective" begin
+    prob = NonlinearProblem((u, p) -> u, [1.0, 1.0])
+    u = [1.0, 1.0]
+    modes = (
+        NonlinearSolveBase.AbsNormSafeTerminationMode,
+        NonlinearSolveBase.AbsNormSafeBestTerminationMode,
+        NonlinearSolveBase.RelNormSafeTerminationMode,
+        NonlinearSolveBase.RelNormSafeBestTerminationMode,
+    )
+    @testset "$M / $nrm / du = $du" for M in modes,
+            nrm in (Base.Fix2(norm, 2), Base.Fix1(maximum, abs)),
+            du in ([Inf, 1.0], [NaN, 1.0], [-Inf, Inf])
+
+        cache = SciMLBase.init(prob, M(nrm), copy(du), u)
+        @test cache(du, u, u, 1.0e-8, 1.0e-8)
+        @test cache.retcode == SciMLBase.ReturnCode.Unstable
+    end
+end
+
+@testset "complex norms do not overflow" begin
+    @test NonlinearSolveBase.L2_NORM(1.0e200 + 1.0e200im) ≈ sqrt(2) * 1.0e200
+    @test NonlinearSolveBase.Linf_NORM(1.0e200 + 1.0e200im) ≈ sqrt(2) * 1.0e200
+end

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -349,6 +349,9 @@ run_tests(;
             "dampen_jacobian.jl"
         )
         @safetestset "safe_similar hands out zeroed buffers" include("safe_similar.jl")
+        @safetestset "Non-finite objective protective break" include(
+            "nonfinite_objective.jl"
+        )
 
         return @safetestset "Dense LU refactorization allocations" include(
             "lu_refactorization_allocs.jl"

--- a/lib/NonlinearSolveFirstOrder/test/least_squares_tests.jl
+++ b/lib/NonlinearSolveFirstOrder/test/least_squares_tests.jl
@@ -1,3 +1,6 @@
 @safetestset "General NLLS Solvers" include("least_squares_tests__item1.jl")
 @safetestset "Overdetermined NLLS with StaticArrays" include("least_squares_tests__item2.jl")
 @safetestset "Underdetermined NLLS" include("least_squares_tests__item3.jl")
+@safetestset "NLLS with a non-finite residual does not report success" include(
+    "least_squares_tests__item4.jl"
+)

--- a/lib/NonlinearSolveFirstOrder/test/least_squares_tests__item4.jl
+++ b/lib/NonlinearSolveFirstOrder/test/least_squares_tests__item4.jl
@@ -1,0 +1,22 @@
+using NonlinearSolveFirstOrder, SciMLBase, Test
+
+function nan_residual!(du, u, p)
+    du[1] = exp(u[1]) - exp(2 * u[1]) + 1.0
+    du[2] = u[2] - 1.0
+    return nothing
+end
+
+@testset "non-finite NLLS residual" begin
+    @testset "$name" for (name, solver) in (
+            ("TrustRegion", TrustRegion()),
+            ("LevenbergMarquardt", LevenbergMarquardt()),
+            ("GaussNewton", GaussNewton()),
+        )
+        prob = NonlinearLeastSquaresProblem(
+            NonlinearFunction(nan_residual!; resid_prototype = zeros(2)), [1000.0, 0.0]
+        )
+        sol = solve(prob, solver; maxiters = 100)
+        @test isnan(sol.resid[1])
+        @test !SciMLBase.successful_retcode(sol)
+    end
+end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

**Released NonlinearSolve can return a successful retcode on a diverged solve.** Reproduced against the registry, not this branch — `NonlinearSolve v4.27.0` / `NonlinearSolveBase v2.46.0`:

```julia
using NonlinearSolve, SciMLBase
function nanres!(du, u, p)          # Inf - Inf = NaN, e.g. an Arrhenius overflow
    du[1] = exp(u[1]) - exp(2*u[1]) + 1.0
    du[2] = u[2] - 1.0
end
prob = NonlinearLeastSquaresProblem(
    NonlinearFunction(nanres!; resid_prototype = zeros(2)), [1000.0, 0.0])
sol = solve(prob, TrustRegion(); maxiters = 100)

sol.retcode                       # ReturnCode.StalledSuccess
SciMLBase.successful_retcode(sol) # true
sol.resid                         # [NaN, -1.0]
```

### Cause

`L2_NORM` and `Linf_NORM` are defined with `@fastmath` (`lib/NonlinearSolveBase/src/common_defaults.jl`, the only `@fastmath` in the repo). `@fastmath sqrt` emits `call fast double @llvm.sqrt.f64`, and `fast` implies `nnan ninf`, so LLVM proves any `isfinite` on the result is true and deletes it. With the released code,

```julia
g(du::Vector{Float64}) = !isfinite(NonlinearSolveBase.L2_NORM(du))
```

compiles to, in full:

```llvm
define i8 @julia_g(ptr noundef nonnull align 8 dereferenceable(24) %"du::Array") #0 {
top:
  ret i8 0
}
```

The safe-mode protective break is written exactly that way (`termination_conditions.jl:256`, `if !isfinite(objective)`), and the **least-squares default** `internalnorm` is `Base.Fix2(norm, 2)`, which `standardize_norm`s to `L2_NORM`. So for least-squares the guard is dead. Square `NonlinearProblem` defaults to `Base.Fix1(maximum, abs)` → `Linf_NORM` (`maximum(abs, u)`, no `@fastmath` on the reduction) and is unaffected.

From there: the guard misses → TrustRegion rejects every step (`ρ = NaN`, so `NaN > threshold` is `false`) → `u == uprev` exactly → `L2_NORM(u - uprev) = 0 ≤ abstol` → the stall branch fires with `leastsq == true` → `StalledSuccess`, which `successful_retcode` reports as `true`.

Causal isolation — same mode, same input, only the norm differs:

| `internalnorm` | `du = [NaN, 1.0]` | `[-Inf, Inf]` |
|---|---|---|
| `Base.Fix2(norm, 2)` → `L2_NORM` | `Failure` | `Failure` |
| `Base.Fix1(maximum, abs)` → `Linf_NORM` | `Unstable` | `Unstable` |
| the same `L2_NORM` behind `@noinline` | `Unstable` | `Unstable` |

The `@noinline` row rules out an ordinary logic bug: the guard's *input* is correct (`L2_NORM([NaN, 1.0])` is `NaN` at top level), and only inlining-plus-fold explains the miss. `code_typed` still contains the check; it is an LLVM fold, and it happens at `-O1` and above on every Julia version tested (1.10, 1.11, 1.12, 1.13-rc2).

### It is broader than NaN, and broader than `isfinite`

- **A fully finite residual is enough.** `L2_NORM` computes an unscaled `sum(abs2)`, so any `‖F‖ ≳ 1.34e154` overflows to `Inf` internally. Starting from `u0 = [200.0, 0.0]` with `r(u0) = [-5.22e173, -1.0]` — every entry finite — master returns `StalledSuccess`/successful; this branch returns `Unstable`.
- **`isnan` is folded too**, though `isinf` is not.
- **`max`/`min` swallow NaN**, because Julia builds them on an internal `isnan` test which is also folded: on master `max(L2_NORM([NaN,1.0]), 1.0) == 1.0`. That launders NaN into the initial trust radius (`trust_region.jl:336`), `utils.jl:313`, `homotopy_sweep.jl:839` and two `SimpleNonlinearSolve` sites. Removing the taint at source fixes all of them — verified `NaN` after the change.

Ordered comparisons (`fcmp ole/ogt`) are *not* affected and survive verbatim; every accept/reject site consuming a tainted norm was checked and behaves identically before and after, always in the reject direction.

### Fix

Drop `@fastmath` from the two norms rather than rewriting the guards. Magnitude comparisons do not work here — `NaN > 1e300` is `false`, so they catch `Inf` but not `NaN` — and `!(x <= c)` formulations are themselves fast-math-dependent. Screening the raw residual costs an extra O(n) pass per iteration.

**The cost is nil, and the reason is that `@fastmath` was not doing the work.** `@simd` already supplies the `reassoc`+`contract` that vectorizes the reduction. Codegen for `L2_NORM(::Vector{Float64})`, counted in-process so the shared machine cannot distort it:

| | before | after |
|---|---|---|
| `<4 x double>` / `fmul` / `fadd` | 20 / 5 / 9 | **20 / 5 / 9** |
| `vfmadd` / `vaddpd` (native) | 5 / 4 | **5 / 4** |
| reduction flags | `fast` | `reassoc`, `contract` |
| allocations, n = 8…65536 | 0 B | **0 B** |

Identical vector width, identical flops, identical allocations. The only added work is `sqrt`'s negative-domain check. Interleaved wall clock is +1.0% at n=8, +0.7% at n=65536 — and the norm is O(n) against an O(n²)–O(n³) linear solve per iteration.

### Effect

42 (problem × algorithm) cells: successful retcode on a non-finite objective **2 → 0**. Both were `TrustRegion` on least-squares. Separately, the same dead guard was turning `Unstable` into `MaxIters` for NewtonRaphson, GaussNewton, PseudoTransient, Broyden, Klement and the default polyalgorithm on least-squares — 7 algorithms × 4 problems now report `Unstable` instead of burning 100 iterations.

Also fixed: `Base.FastMath.abs_fast(::Complex)` skips `hypot` scaling, so `L2_NORM(1e200 + 1e200im)` returned `Inf` instead of `1.414e200`.

### Tests

Testing this is awkward, because the fold depends on the optimizer. A naive `@test !isfinite(L2_NORM(x))` **passes on unfixed master** — the assertion is itself folded. The tests therefore assert observable behaviour (`cache.retcode == Unstable`, `!successful_retcode(sol)`), never the predicate.

Negative control, `src/common_defaults.jl` alone reverted, full `GROUP=Core`:

```
NonlinearSolveBase       Non-finite objective protective break | 36 pass 14 fail 50
                         failures are exactly the Base.Fix2(norm,2) rows,
                         Evaluated: ReturnCode.Failure == ReturnCode.Unstable
NonlinearSolveFirstOrder exactly 1 failure in the whole Core suite:
                         TrustRegion: !(successful_retcode(sol))
```

Rebased-branch verification:

- `GROUP=Core julia --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test()'`: passed; the new protective-break test passed 50/50.
- `GROUP=Core julia --project=lib/NonlinearSolveFirstOrder -e 'using Pkg; Pkg.test()'`: passed; the new NLLS regression test passed 6/6 and TrustRegion passed 1176/1176.
- `GROUP=QA julia --project=lib/NonlinearSolveFirstOrder -e 'using Pkg; Pkg.test()'`: passed 20/20.
- `GROUP=QA julia --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test()'`: 19/20 because `get_termination_cache` and `get_trace` are not rendered in the docs. The identical failure reproduces on clean `master` at `7a9c9044b`; the focused fix is https://github.com/SciML/NonlinearSolve.jl/pull/1196.
- `julia -m Runic --check <changed Julia files>`, `typos <changed files>`, and `git diff --check origin/master...HEAD`: clean.

**Known limitation, stated plainly:** the test only bites when the optimizer folds. At `-O0`, or if LLVM changes, it would pass on unfixed code. It can never false-*pass* on fixed code, which is the property that matters, but nothing here locks in "no `@fastmath` in these norms" at source level. A lint or a `@code_llvm` assertion would be a stronger guarantee if you want one.

### Related, not fixed here

`DiffEqBase.ODE_DEFAULT_NORM` has the same hazard — `isnan(ODE_DEFAULT_NORM(u, t))` also compiles to `ret i8 0`. It appears latent today (the `initdt` path still reports `Unstable` by another route), but it is the same trap. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01NB3oFTNzGW79UtDt8AyjsM