### PR TITLE
Require all components to stall before resetting Broyden

### DIFF
--- a/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
+++ b/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
@@ -92,7 +92,6 @@ include("homotopy_sweep.jl")
 include("arclength.jl")
 include("homotopy_polyalg.jl")
 
-
 include("descent/common.jl")
 include("descent/newton.jl")
 include("descent/steepest.jl")

--- a/lib/NonlinearSolveQuasiNewton/Project.toml
+++ b/lib/NonlinearSolveQuasiNewton/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveQuasiNewton"
 uuid = "9a2c21bd-3a47-402d-9113-8faf9a0ee114"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.15.1"
+version = "1.15.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/NonlinearSolveQuasiNewton/src/reset_conditions.jl
+++ b/lib/NonlinearSolveQuasiNewton/src/reset_conditions.jl
@@ -55,7 +55,7 @@ end
 function InternalAPI.solve!(cache::NoChangeInStateResetCache, J, fu, u, du; kwargs...)
     cond = ≤(cache.reset_tolerance) ∘ abs
     if cache.condition.check_du
-        if any(cond, du)
+        if all(cond, du)
             cache.steps_since_change_du += 1
             if cache.steps_since_change_du ≥ cache.condition.nsteps
                 cache.steps_since_change_du = 0
@@ -69,7 +69,7 @@ function InternalAPI.solve!(cache::NoChangeInStateResetCache, J, fu, u, du; kwar
     end
     if cache.condition.check_dfu
         @bb @. cache.dfu = fu - cache.dfu
-        if any(cond, cache.dfu)
+        if all(cond, cache.dfu)
             cache.steps_since_change_dfu += 1
             if cache.steps_since_change_dfu ≥ cache.condition.nsteps
                 cache.steps_since_change_dfu = 0

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests.jl
@@ -10,3 +10,4 @@
 @safetestset "Postcondition iterate correction" include("core_tests__item10.jl")
 @safetestset "LimitedMemoryBroyden: continuation from a nearby root" include("core_tests__item11.jl")
 @safetestset "reinit! resets the update rule state" include("core_tests__item12.jl")
+@safetestset "No-change reset requires every component to stall" include("core_tests__item13.jl")

--- a/lib/NonlinearSolveQuasiNewton/test/core_tests__item13.jl
+++ b/lib/NonlinearSolveQuasiNewton/test/core_tests__item13.jl
@@ -1,0 +1,10 @@
+using NonlinearSolveQuasiNewton
+using SciMLBase
+
+f(u, p) = [u[1]^3 - 2, u[2]]
+prob = NonlinearProblem(f, [1.0, 0.0])
+cache = init(prob, Broyden(; max_resets = 1); abstol = 1.0e-12)
+sol = solve!(cache)
+
+@test SciMLBase.successful_retcode(sol)
+@test maximum(abs, f(sol.u, nothing)) ≤ 1.0e-12

--- a/test/Core/23_test_problems_tests__item7.jl
+++ b/test/Core/23_test_problems_tests__item7.jl
@@ -26,7 +26,7 @@ skip_tests[alg_ops[2]] = [4, 8]
 skip_tests[alg_ops[4]] = [1, 8]
 if Sys.isapple()
     broken_tests[alg_ops[1]] = [1, 5, 11]
-    broken_tests[alg_ops[3]] = [1, 5, 6, 9, 11]
+    broken_tests[alg_ops[3]] = [1, 6, 9, 11]
     if VERSION ≥ v"1.12"
         # Test #4 (Wood function) passes on v1.12+
         broken_tests[alg_ops[5]] = [1, 5, 11]
@@ -37,7 +37,7 @@ if Sys.isapple()
     end
 else
     broken_tests[alg_ops[1]] = [1, 5, 11]
-    broken_tests[alg_ops[3]] = [1, 5, 6, 9, 11]
+    broken_tests[alg_ops[3]] = [1, 6, 9, 11]
     broken_tests[alg_ops[5]] = [1, 5, 11]
 end
 


### PR DESCRIPTION
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed

`NoChangeInStateReset` now resets Broyden only when every component of the state step or residual change has stalled. The previous `any` reduction treated one unchanged component as evidence that the entire iteration had stalled, which could consume every reset and fail an otherwise convergent solve.

The regression test uses only public APIs. The existing Helical problem contract is also tightened by removing problem 5 from the alg-3 broken list, and `NonlinearSolveQuasiNewton` receives a patch version bump to 1.15.2.

A behavior-neutral blank-line removal in `NonlinearSolveBase.jl` is included deliberately so that this PR triggers the repository's complete source-dependent CI matrix.

## Failing before / passing after

The same new test was run against an unfixed clean worktree and this branch:

```sh
julia +1.12 --project=lib/NonlinearSolveQuasiNewton -e 'using Test; include("lib/NonlinearSolveQuasiNewton/test/core_tests__item13.jl")'
```

Unfixed:

```text
Test Failed at core_tests__item13.jl:9
Expression: SciMLBase.successful_retcode(sol)
retcode = ConvergenceFailure
nresets = 1
maximum residual = 0.040265031294151266
```

Fixed:

```text
Test Summary:                                      | Pass  Total
No-change reset requires every component to stall |    2      2
retcode = Success
nresets = 0
maximum residual = 5.329070518200751e-15
```

The existing Helical problem 5 with Broyden alg 3 discriminates the same failure mechanism:

```text
unfixed: ConvergenceFailure, 301 evaluations, 100 resets, residual 3.9563
fixed:   Success,             18 evaluations,   1 reset,  residual 2.2373e-16
```

## Local verification

```sh
GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
```

```text
23 Test Problems: Broyden | 95 pass, 20 existing broken, 115 total
Testing NonlinearSolve tests passed
```

From `lib/NonlinearSolveQuasiNewton`:

```sh
GROUP=Core julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
```

```text
Broyden | 594/594
Klement | 216/216
LimitedMemoryBroyden | 99/99
No-change reset requires every component to stall | 2/2
Testing NonlinearSolveQuasiNewton tests passed
QA | 20/20
```

From the repository root:

```sh
GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
julia +1.12 --project=@runic -e 'using Runic; exit(Runic.main(["--check", "."]))'
typos <changed files>
git diff --check
```

```text
QA | 28/28
Runic: exit 0
typos: exit 0
git diff --check: exit 0
```

## Not verified locally

The original Wood failure occurs on macOS after LinearSolve 5.6.0 → 5.7.0. On Linux, Wood succeeds both before and after this patch with zero resets, so local testing does not prove that this fix repairs that architecture-specific trajectory. The deliberate NonlinearSolveBase source touch is present so macOS and the complete downstream matrix can decide that directly.

No GPU tests were run locally. This PR does not change public API or documentation.

## Links

- Tracking issue: https://github.com/SciML/NonlinearSolve.jl/issues/1158
- Original failing macOS CI: https://github.com/SciML/NonlinearSolve.jl/actions/runs/32118981711
- LinearSolve trajectory boundary: https://github.com/SciML/LinearSolve.jl/commit/6bbb233daa4bd647fa289b96b4a3d9ff6fe0b7e0