### PR TITLE
Stabilize Broyden inverse-Jacobian initialization

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.46.0"
+version = "2.46.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseLinearSolveExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseLinearSolveExt.jl
@@ -7,11 +7,16 @@ using LinearSolve: LinearSolve, QRFactorization, SciMLLinearSolveAlgorithm
 using SciMLBase: SciMLBase, ReturnCode, LinearProblem, LinearAliasSpecifier
 using SciMLLogging: @SciMLMessage
 
-using LinearAlgebra: ColumnNorm, Symmetric
+using LinearAlgebra: BlasFloat, ColumnNorm, Symmetric
 
 using NonlinearSolveBase: NonlinearSolveBase, LinearSolveJLCache, LinearSolveResult, Utils, NonlinearVerbosity, InternalAPI, LinearSolveParameters
 
 Utils.is_extension_loaded(::Val{:LinearSolve}) = true
+Utils.inverse_jacobian_linsolve(::StridedMatrix{<:BlasFloat}) = LinearSolve.LUFactorization()
+function Utils.inverse_jacobian_linsolve_failure(A::StridedMatrix{<:BlasFloat}, rhs)
+    prob = LinearProblem(A, rhs)
+    return CommonSolve.solve(prob, LinearSolve.QRFactorization(ColumnNorm())).u
+end
 
 function (cache::LinearSolveJLCache)(;
         A = nothing, b = nothing, linu = nothing,

--- a/lib/NonlinearSolveBase/src/utils.jl
+++ b/lib/NonlinearSolveBase/src/utils.jl
@@ -235,6 +235,8 @@ condition_number(::Any) = -1
 linsolve_workspace(A) = nothing, A
 linsolve_workspace(A::Diagonal) = nothing, A
 linsolve_workspace(A::SMatrix) = nothing, A
+inverse_jacobian_linsolve(A) = nothing
+inverse_jacobian_linsolve_failure(A, rhs) = pinv(A)
 function linsolve_workspace(A::AbstractMatrix)
     LinearAlgebra.checksquare(A)
     # Backends without fast scalar indexing may not implement factorization solves with
@@ -248,14 +250,13 @@ function linsolve_workspace(A::AbstractMatrix)
     copyto!(A_buf, A)
     rhs = make_identity!!(similar(A_buf, T), true)
     u = similar(A_buf, T)
-    # One factorization + a multi-RHS solve against an identity RHS gives X = A⁻¹, and the
-    # default algorithm's singular-LU → pivoted-QR rescue handles rank-deficient input.
+    # One factorization + a multi-RHS solve against an identity RHS gives X = A⁻¹.
     # All buffers are workspace-owned, so aliasing is opted into to let the LU
     # refactorize A_buf in place instead of copying it on every call. Requires LinearSolve
     # to be loaded (as does any use of `construct_linear_solver` without a native fast
     # path).
     lincache = NonlinearSolveBase.construct_linear_solver(
-        nothing, nothing, A_buf, rhs, u, nothing;
+        nothing, inverse_jacobian_linsolve(A), A_buf, rhs, u, nothing;
         stats = SciMLBase.NLStats(0, 0, 0, 0, 0),
         alias = SciMLBase.LinearAliasSpecifier(alias_A = true, alias_b = true)
     )
@@ -298,10 +299,11 @@ function linsolve_identity!!(workspace, A::AbstractMatrix)
     # the previous solve may have consumed the RHS buffer, so refill it with I. The
     # lincache call copies A into its internal buffer before overwriting the solution
     # buffer, so A is never mutated and passing the previously returned inverse as A is
-    # safe. On singular A the default algorithm's pivoted-QR rescue returns a finite
-    # least-squares generalized inverse (not the SVD `pinv`).
+    # safe. A failed solve is handled by the backend-specific rescue below.
     make_identity!!(workspace.rhs, true)
-    return workspace.lincache(; A, b = workspace.rhs).u
+    linres = workspace.lincache(; A, b = workspace.rhs)
+    linres.success && return linres.u
+    return inverse_jacobian_linsolve_failure(A, workspace.rhs)
 end
 
 function initial_jacobian_scaling_alpha(α, u, fu, ::Any)

--- a/lib/NonlinearSolveBase/test/linsolve_workspace.jl
+++ b/lib/NonlinearSolveBase/test/linsolve_workspace.jl
@@ -39,6 +39,20 @@ ArrayInterface.fast_scalar_indexing(::Type{<:NoFastScalarMatrix}) = false
     end
 end
 
+@testset "BLAS matrices use explicit LU factorization" begin
+    A = [
+        5601.0 600.0 0.0 0.0
+        1200.0 220.2 0.0 19.8
+        0.0 0.0 5041.0 540.0
+        0.0 19.8 1080.0 200.2
+    ]
+    rhs = Matrix{Float64}(I, 4, 4)
+    workspace, _ = Utils.linsolve_workspace(A)
+    X = Utils.linsolve_identity!!(workspace, A)
+    X_lu = solve(LinearProblem(A, rhs), LUFactorization()).u
+    @test X == X_lu
+end
+
 @testset "arrays without fast scalar indexing use pinv" begin
     A = NoFastScalarMatrix(rand(5, 5))
     workspace, A_ret = Utils.linsolve_workspace(A)
@@ -47,8 +61,8 @@ end
 end
 
 @testset "singular input takes the pivoted-QR rescue" begin
-    # The result is the LinearSolve default algorithm's least-squares generalized
-    # inverse from its singular-LU → pivoted-QR rescue, NOT the SVD `pinv` (an
+    # The result is LinearSolve's least-squares generalized inverse from a pivoted-QR
+    # rescue, NOT the SVD `pinv` (an
     # intentional semantics change: same fitness for quasi-Newton initialization,
     # different finite matrix).
     n = 20


### PR DESCRIPTION
## What changed and why

Use `LinearSolve.LUFactorization()` explicitly when inverse-Jacobian initialization solves `A * X = I` for strided BLAS matrices. The LinearSolve 5.7 GenericLU kernel changed the floating-point trajectory of true-Jacobian Broyden and made the Wood problem fail deterministically on macOS aarch64; selecting the public LAPACK-backed LU algorithm restores a stable solver choice instead of inheriting changes in LinearSolve's default heuristic.

If LU reports a singular factorization, the LinearSolve extension explicitly performs the existing pivoted-QR least-squares rescue, preserving finite generalized-inverse behavior. NonlinearSolveBase is bumped from 2.46.0 to 2.46.1.

Ignore this PR until reviewed by @ChrisRackauckas.

Tracking issue: https://github.com/SciML/NonlinearSolve.jl/issues/1158

## Failing before

The new assertion is part of the existing `NonlinearSolveBase` Core workspace test. On unfixed current master with LinearSolve 5.12.0, the default GenericLU result differs from explicit LU for the Wood Jacobian:

```text
BLAS matrices use explicit LU factorization: Test Failed
Expression: X == X_lu
Evaluated: [GenericLU inverse] == [LUFactorization inverse]

linsolve_identity!! workspace (#1020) | 52 pass, 1 fail, 53 total
Testing NonlinearSolveBase tests failed
```

The maximum entrywise difference is approximately `1.7e-18`, which is enough to change the long Broyden trajectory. The dependency boundary is LinearSolve 5.6.0 → 5.7.0, specifically https://github.com/SciML/LinearSolve.jl/commit/6bbb233daa4bd647fa289b96b4a3d9ff6fe0b7e0.

## Passing after

The identical test passes with the explicit selection:

```text
linsolve_identity!! workspace (#1020) | 53 pass, 53 total
Testing NonlinearSolveBase tests passed
```

A focused Linux run of the public Wood problem with the patch returns:

```text
retcode = Success
evaluations = 1012
residual_inf = 2.5757174171303632e-14
```

The singular-matrix path remains finite and satisfies the generalized-inverse identity:

```text
all(isfinite, X) = true
norm(A * X * A - A) = 4.7e-16
```

## Local verification

```text
NonlinearSolveBase GROUP=Core
  linsolve workspace 53/53; routing 12/12; allocations 14/14
  Testing NonlinearSolveBase tests passed

NonlinearSolveBase GROUP=QA
  QA 20/20

NonlinearSolve GROUP=Core
  23 Test Problems: Broyden | 94 pass, 21 existing broken, 115 total
  Testing NonlinearSolve tests passed

NonlinearSolve GROUP=QA
  QA 28/28
```

Runic over all changed Julia files, typos over the diff, and `git diff --check` passed.

## macOS verification boundary

Linux does not reproduce the failing Wood endpoint: both the GenericLU and explicit-LU trajectories converge there. The three source-triggered macOS aarch64 Core jobs are the decisive validation and currently fail on unfixed/default initialization:

- Julia 1: https://github.com/SciML/NonlinearSolve.jl/actions/runs/32368371779/job/96432457092
- Julia LTS: https://github.com/SciML/NonlinearSolve.jl/actions/runs/32368371779/job/96432457316
- Julia pre: https://github.com/SciML/NonlinearSolve.jl/actions/runs/32368371779/job/96432457356

I am not claiming the macOS regression fixed until this PR's corresponding jobs pass.

## Not verified locally

macOS aarch64, GPU groups, downstream packages, and the Julia version matrix were not run locally. No docs build was run because this changes no public API, docstring, or documentation.