### PR TITLE
Skip machine-dependent Wood test for true-Jacobian Broyden

### DIFF
--- a/test/Core/23_test_problems_tests__item7.jl
+++ b/test/Core/23_test_problems_tests__item7.jl
@@ -19,10 +19,10 @@ broken_tests[alg_ops[4]] = [5, 6, 11]
 # BLAS/CPU dependent. Skip rather than mark broken, since an unexpected pass would also
 # error — both have failed in both directions across runners. See
 # SciML/NonlinearSolve.jl#1083 and SciML/NonlinearSolve.jl#1096. Problem #8 with plain
-# true_jacobian Broyden (alg #2) sits on the same knife-edge: as of LinearSolve 5.6 it
-# converges on some runners (Unexpected Pass) and not on others.
+# true_jacobian Broyden (alg #2) sits on the same knife-edge for problems #4 (Wood) and
+# #8: dependency-level factorization changes make them converge on different runners.
 skip_tests = Dict(alg => Int[] for alg in alg_ops)
-skip_tests[alg_ops[2]] = [8]
+skip_tests[alg_ops[2]] = [4, 8]
 skip_tests[alg_ops[4]] = [1, 8]
 if Sys.isapple()
     broken_tests[alg_ops[1]] = [1, 5, 11]


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Exclude problem 4 (Wood) for `Broyden(init_jacobian = Val(:true_jacobian))` in the existing machine-dependent Broyden skip table. The algorithm/problem pair converges on Linux but fails on macOS aarch64 after an ulp-level inverse-Jacobian trajectory change, so it is not a portable solver contract.

This follows the maintainer direction on the broader, now-closed solver-policy proposal https://github.com/SciML/NonlinearSolve.jl/pull/1185. This is test-only and does not change package behavior or versions.

## Failing before

A NonlinearSolveBase source touch ran the otherwise-hidden full Core matrix. All three macOS aarch64 lanes fail the same existing test on unfixed master:

```text
23 Test Problems: Broyden | 94 pass | 1 fail | 20 broken
4: Wood function | alg #2: failed
```

- Julia 1: https://github.com/SciML/NonlinearSolve.jl/actions/runs/32368371779/job/96432457092
- Julia LTS: https://github.com/SciML/NonlinearSolve.jl/actions/runs/32368371779/job/96432457316
- Julia prerelease: https://github.com/SciML/NonlinearSolve.jl/actions/runs/32368371779/job/96432457356

The dependency boundary is LinearSolve 5.6.0 → 5.7.0, specifically https://github.com/SciML/LinearSolve.jl/commit/6bbb233daa4bd647fa289b96b4a3d9ff6fe0b7e0. Linux does not reproduce the endpoint failure: unfixed master converges in 323 evaluations with residual `1.99e-13`. This platform split is why the portable expectation is removed instead of changing NonlinearSolve's linear-solver policy.

## Passing after

The affected local Core suite now reports:

```text
23 Test Problems: Broyden | 93 pass | 22 broken | 115 total
```

The full owning gates complete successfully:

```text
GROUP=Core
Testing NonlinearSolve tests passed

GROUP=QA
QA | 28 pass | 28 total
Testing NonlinearSolve tests passed
```

Runic on the changed test file, typos over the diff, and `git diff --check` pass.

## Verification boundary

The exact pass-after discrimination requires macOS aarch64 and is delegated to this draft's three Core lanes. I am not claiming that platform result until those jobs complete. No docs build was run because this changes only an internal test list; GPU and downstream groups were not run locally.