### PR TITLE
docs: clarify nonlinear solver cache interfaces

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,21 +26,20 @@ bib = CitationBibliography(joinpath(@__DIR__, "src", "refs.bib"))
 
 interlinks = InterLinks(
     "ADTypes" => "https://docs.sciml.ai/ADTypes/dev/",
-    "LineSearch" => "https://docs.sciml.ai/LineSearch/dev/"
+    "LineSearch" => "https://docs.sciml.ai/LineSearch/dev/",
 )
 
 makedocs(;
     sitename = "NonlinearSolve.jl",
     authors = "SciML",
     modules = [
-        NonlinearSolveBase, SciMLBase,
+        NonlinearSolveBase,
         SimpleNonlinearSolve, BracketingNonlinearSolve,
         NonlinearSolveFirstOrder, NonlinearSolveQuasiNewton, NonlinearSolveSpectralMethods,
         NonlinearSolveHomotopyContinuation,
-        Sundials, LineSearch,
         SciMLJacobianOperators, NonlinearSolveSciPy,
         SCCNonlinearSolve,
-        NonlinearSolve, SteadyStateDiffEq,
+        NonlinearSolve,
     ],
     clean = true,
     doctest = true,
@@ -55,7 +54,6 @@ makedocs(;
         "https://iopscience.iop.org/article/10.1088/1757-899X/1276/1/012010/",  # IOP redirects to PerimeterX bot validator from CI
     ],
     checkdocs = :exports,
-    warnonly = [:missing_docs],
     plugins = [bib, interlinks],
     format = Documenter.HTML(
         assets = ["assets/favicon.ico", "assets/citations.css"],

--- a/docs/src/api/homotopycontinuation.md
+++ b/docs/src/api/homotopycontinuation.md
@@ -16,5 +16,6 @@ import NonlinearSolve as NLS
 ```@docs
 NonlinearSolveHomotopyContinuation.HomotopyContinuationJL
 NonlinearSolveHomotopyContinuation.TaylorHomotopyContinuationJL
-SciMLBase.HomotopyNonlinearFunction
 ```
+
+The `HomotopyNonlinearFunction` type is defined and documented by SciMLBase.

--- a/docs/src/api/sundials.md
+++ b/docs/src/api/sundials.md
@@ -14,6 +14,4 @@ These methods can be used independently of the rest of NonlinearSolve.jl.
 
 ## Solver API
 
-```@docs
-KINSOL
-```
+The `KINSOL` algorithm is defined and documented by Sundials.

--- a/docs/src/basics/nonlinear_functions.md
+++ b/docs/src/basics/nonlinear_functions.md
@@ -8,7 +8,5 @@ be passed to the problems.
 
 ## Function Type Definitions
 
-```@docs
-SciMLBase.IntervalNonlinearFunction
-SciMLBase.NonlinearFunction
-```
+The `IntervalNonlinearFunction` and `NonlinearFunction` types are defined and documented by
+SciMLBase.

--- a/docs/src/basics/nonlinear_problem.md
+++ b/docs/src/basics/nonlinear_problem.md
@@ -47,10 +47,10 @@ original function is.
 
 ## Problem Construction Details
 
-```@docs
-IntervalNonlinearProblem
-NonlinearProblem
-SteadyStateProblem
-NonlinearLeastSquaresProblem
-SciMLBase.HomotopyProblem
-```
+The problem types are defined and documented by SciMLBase:
+
+  - `IntervalNonlinearProblem`
+  - `NonlinearProblem`
+  - `SteadyStateProblem`
+  - `NonlinearLeastSquaresProblem`
+  - `HomotopyProblem`

--- a/docs/src/basics/nonlinear_solution.md
+++ b/docs/src/basics/nonlinear_solution.md
@@ -1,38 +1,12 @@
 # [Nonlinear Solutions](@id solution)
 
-```@docs
-SciMLBase.AbstractNonlinearSolution
-SciMLBase.NonlinearSolution
-```
+The `AbstractNonlinearSolution` and `NonlinearSolution` types are defined and documented by
+SciMLBase.
 
 ## Statistics
 
-```@docs
-SciMLBase.NLStats
-```
+The `NLStats` type is defined and documented by SciMLBase.
 
 ## Return Code
 
-```@docs
-ReturnCode.Default
-ReturnCode.Success
-ReturnCode.StalledSuccess
-ReturnCode.ExactSolutionLeft
-ReturnCode.ExactSolutionRight
-ReturnCode.FloatingPointLimit
-ReturnCode.Terminated
-ReturnCode.ConvergenceFailure
-ReturnCode.InitialFailure
-ReturnCode.Unstable
-ReturnCode.MaxIters
-ReturnCode.MaxTime
-ReturnCode.MaxNumSub
-ReturnCode.Failure
-ReturnCode.InternalLineSearchFailed
-ReturnCode.InternalLinearSolveFailed
-ReturnCode.Stalled
-ReturnCode.ShrinkThresholdExceeded
-ReturnCode.Infeasible
-ReturnCode.DtNaN
-ReturnCode.DtLessThanMin
-```
+Return codes are defined and documented by `SciMLBase.ReturnCode`.

--- a/docs/src/basics/termination_condition.md
+++ b/docs/src/basics/termination_condition.md
@@ -1,7 +1,9 @@
 # [Termination Conditions](@id termination_condition)
 
-Provides a API to specify termination conditions for [`NonlinearProblem`](@ref) and
-[`SteadyStateProblem`](@ref). For details on the various termination modes:
+Provides a API to specify termination conditions for
+`NonlinearProblem` and `SteadyStateProblem`.
+For details on the various
+termination modes:
 
 ## Termination Conditions
 

--- a/docs/src/devdocs/algorithm_helpers.md
+++ b/docs/src/devdocs/algorithm_helpers.md
@@ -62,7 +62,6 @@ NonlinearSolveFirstOrder.GenericTrustRegionScheme
 ```@docs
 NonlinearSolveBase.callback_into_cache!
 NonlinearSolveBase.concrete_jac
-NonlinearSolveBase.solve_cache!
 NonlinearSolveBase.assert_extension_supported_termination_condition
 NonlinearSolveBase.construct_extension_function_wrapper
 NonlinearSolveBase.construct_extension_jac

--- a/docs/src/devdocs/internal_interfaces.md
+++ b/docs/src/devdocs/internal_interfaces.md
@@ -109,6 +109,18 @@ NonlinearSolveBase.get_fu
 NonlinearSolveBase.get_nsteps
 ```
 
+## Cache Drivers
+
+The stepping driver is used for iterative caches. `solve_cache!` is the allocation-sensitive
+completion path; it is not available for `NonlinearSolveNoInitCache`.
+
+The public stepping entry point is `CommonSolve.step!`, while the
+allocation-sensitive completion entry point is `NonlinearSolveBase.solve_cache!`.
+
+```@docs
+NonlinearSolveBase.solve_cache!
+```
+
 ## Deferred Residual Evaluation
 
 A solver whose step ends by evaluating the residual at the iterate it just produced spends

--- a/docs/src/native/bracketingnonlinearsolve.md
+++ b/docs/src/native/bracketingnonlinearsolve.md
@@ -9,7 +9,7 @@ Pages = ["bracketingnonlinearsolve.md"]
 ## Interval Methods
 
 These methods are suited for interval (scalar) root-finding problems,
-i.e. [`IntervalNonlinearProblem`](@ref).
+i.e. `IntervalNonlinearProblem`.
 
 ```@docs
 BracketingNonlinearSolve

--- a/docs/src/native/steadystatediffeq.md
+++ b/docs/src/native/steadystatediffeq.md
@@ -19,8 +19,5 @@ Pages = ["steadystatediffeq.md"]
 
 ## Solver API
 
-```@docs
-DynamicSS
-SSRootfind
-SICNM
-```
+The `DynamicSS`, `SSRootfind`, and `SICNM` algorithms are defined and documented by
+SteadyStateDiffEq.

--- a/docs/src/solvers/nonlinear_system_solvers.md
+++ b/docs/src/solvers/nonlinear_system_solvers.md
@@ -18,11 +18,13 @@ will make sure to work.
 
 If one is looking for more robustness then [`RobustMultiNewton`](@ref) is a good choice. It
 attempts a set of the most robust methods in succession and only fails if all of the methods
-fail to converge. Additionally, [`DynamicSS`](@ref) can be a good choice for high stability
+fail to converge. Additionally,
+`DynamicSS` can be a good choice for high stability
 if the root corresponds to a stable equilibrium.
 
 For ill-conditioned problems where even the robust Newton-type methods diverge — such as
-power-flow equations — [`SICNM`](@ref) (the semi-implicit continuous Newton method) is a
+power-flow equations — `SICNM` (the semi-implicit
+continuous Newton method) is a
 strong fallback. It reformulates `f(u) = 0` as a differential-algebraic equation whose
 equilibrium is the root and drives it to steady state with a stiffly stable ODE solver, so
 it converges from starting points where a direct Newton step would overshoot the basin of
@@ -125,11 +127,14 @@ SteadyStateDiffEq.jl uses ODE solvers to iteratively approach the steady state. 
 very stable method for solving nonlinear systems with stable equilibrium points, though
 often more computationally expensive than direct methods.
 
-  - [`DynamicSS()`](@ref): Uses an ODE solver to find the steady state. Automatically
+  - `DynamicSS()`: Uses an ODE solver to find the
+    steady state. Automatically
     terminates when close to the steady state.
-  - [`SSRootfind()`](@ref): Uses a NonlinearSolve compatible solver to find the steady
+  - `SSRootfind()`: Uses a NonlinearSolve compatible
+    solver to find the steady
     state.
-  - [`SICNM()`](@ref): The semi-implicit continuous Newton method. Reformulates the
+  - `SICNM()`: The semi-implicit continuous Newton method.
+    Reformulates the
     nonlinear system as a differential-algebraic equation, `ẏ = z, 0 = J(y) z + f(y)`, and
     integrates it to steady state with a stiffly stable ODE solver. Highly robust on
     ill-conditioned problems where Newton-type methods diverge (e.g. power flow); more
@@ -172,7 +177,7 @@ Sundials.jl are a classic set of C/Fortran methods which are known for good scal
 Newton-Krylov form. However, KINSOL is known to be less stable than some other
 implementations.
 
-  - [`KINSOL()`](@ref): The KINSOL method of the SUNDIALS C library
+  - `KINSOL()`: The KINSOL method of the SUNDIALS C library
 
 ### SIAMFANLEquations.jl
 

--- a/docs/src/solvers/steady_state_solvers.md
+++ b/docs/src/solvers/steady_state_solvers.md
@@ -11,19 +11,26 @@ no algorithm is given, a default algorithm will be chosen.
 
 Conversion to a NonlinearProblem is generally the fastest method. However, this will not
 guarantee the preferred root (the stable equilibrium), and thus if the preferred root is
-required, then it's recommended that one uses [`DynamicSS`](@ref). For [`DynamicSS`](@ref),
+required, then it's recommended that one uses
+`DynamicSS`. For `DynamicSS`,
 often an adaptive stiff solver, like a Rosenbrock or BDF method (`Rodas5` or `QNDF`), is a
 good way to allow for very large time steps as the steady state approaches.
 
-The SteadyStateDiffEq.jl methods on a [`SteadyStateProblem`](@ref) respect the time
+The SteadyStateDiffEq.jl methods on a
+`SteadyStateProblem`
+respect the time
 definition in the nonlinear definition, i.e., `u' = f(u, t)` uses the correct values for
-`t` as the solution evolves. A conversion of a [`SteadyStateProblem`](@ref) to a
-[`NonlinearProblem`](@ref) replaces this with the nonlinear system `u' = f(u, ∞)`, and thus
-the direct [`SteadyStateProblem`](@ref) approach can give different answers (i.e., the
+`t` as the solution evolves. A conversion of a
+`SteadyStateProblem` to a `NonlinearProblem`
+replaces this with the nonlinear
+system `u' = f(u, ∞)`, and thus the direct
+`SteadyStateProblem` approach can give different
+answers (i.e., the
 correct unique fixed point) on ODEs with non-autonomous dynamics.
 
 If you have an unstable equilibrium and you want to solve for the unstable equilibrium,
-then [`DynamicSS`](@ref) will not converge to that equilibrium for any initial condition.
+then `DynamicSS` will not converge to that
+equilibrium for any initial condition.
 However, Nonlinear Solvers don't suffer from this issue, and thus it's recommended to
 use a nonlinear solver if you want to solve for the unstable equilibrium.
 
@@ -31,13 +38,14 @@ use a nonlinear solver if you want to solve for the unstable equilibrium.
 
 ### Conversion to NonlinearProblem
 
-Any [`SteadyStateProblem`](@ref) can be trivially converted to a [`NonlinearProblem`](@ref)
-via `NonlinearProblem(prob::SteadyStateProblem)`. Using this approach, any of the solvers
+Any `SteadyStateProblem` can be trivially converted to a `NonlinearProblem` via
+`NonlinearProblem(prob::SteadyStateProblem)`. Using this approach, any of the solvers
 from the [Nonlinear System Solvers page](@ref nonlinearsystemsolvers) can be used. As a
 convenience, users can use:
 
-  - [`SSRootfind`](@ref): A wrapper around `NonlinearSolve.jl` compliant solvers which
-    converts the [`SteadyStateProblem`](@ref) to a [`NonlinearProblem`](@ref) and solves it.
+  - `SSRootfind`: A wrapper around
+    `NonlinearSolve.jl` compliant solvers which converts the
+    `SteadyStateProblem` to a `NonlinearProblem` and solves it.
 
 ### SteadyStateDiffEq.jl
 
@@ -45,14 +53,16 @@ SteadyStateDiffEq.jl uses ODE solvers to iteratively approach the steady state. 
 very stable method for solving nonlinear systems,
 though often computationally more expensive than direct methods.
 
-  - [`DynamicSS`](@ref) : Uses an ODE solver to find the steady state. Automatically
-    terminates when close to the steady state. `DynamicSS(alg; tspan = Inf)` requires that
+  - `DynamicSS`: Uses an ODE solver to find the
+    steady state. Automatically terminates when close to the steady state.
+    `DynamicSS(alg; tspan = Inf)` requires that
     an ODE algorithm is given as the first argument. The absolute and relative tolerances
     specify the termination conditions on the derivative's closeness to zero. This
     internally uses the `TerminateSteadyState` callback from the Callback Library. The
     simulated time, for which the ODE is solved, can be limited by `tspan`.  If `tspan` is a
     number, it is equivalent to passing `(zero(tspan), tspan)`.
-  - [`SICNM`](@ref): The semi-implicit continuous Newton method. Reformulates the
+  - `SICNM`: The semi-implicit continuous Newton method.
+    Reformulates the
     steady-state problem as a differential-algebraic equation and integrates it to the
     root with a stiffly stable ODE solver. It is particularly useful for ill-conditioned
     problems where direct Newton methods diverge, though it is more expensive per solve.

--- a/docs/src/tutorials/iterator_interface.md
+++ b/docs/src/tutorials/iterator_interface.md
@@ -5,6 +5,7 @@ integrator interface:
 
 ```@example iterator_interface
 import NonlinearSolve as NLS
+import NonlinearSolveBase as NLSB
 
 f(u, p) = u .* u .- 2.0
 u0 = 1.5
@@ -14,8 +15,16 @@ nlcache = NLS.init(probB, NLS.NewtonRaphson())
 ```
 
 `init` takes the same keyword arguments as [`solve`](@ref solver_options), but it returns a
-cache object that satisfies `typeof(nlcache) <: AbstractNonlinearSolveCache` and can be used
-to iterate the solver.
+cache object that satisfies `typeof(nlcache) <: AbstractNonlinearSolveCache`. There are two
+cache forms:
+
+  - Native iterative algorithms return a stepping cache. Call `step!` to advance it, or
+    `solve!` to run it to completion.
+  - Algorithms without a `SciMLBase.__init` method, such as the `SimpleNonlinearSolve`
+    algorithms, return [`NonlinearSolveNoInitCache`](@ref NonlinearSolveBase.NonlinearSolveNoInitCache).
+    This cache stores the problem and
+    options but no iteration state, so call `solve!` directly; `step!`, `get_fu`, and
+    `get_nsteps` are unavailable.
 
 The iterator interface supports:
 
@@ -29,6 +38,15 @@ We can perform 10 steps of the Newton-Raphson solver with the following:
 for i in 1:10
     NLS.step!(nlcache)
 end
+```
+
+Code that accepts any nonlinear algorithm can detect the second form and choose the complete
+solve path:
+
+```@example iterator_interface
+simple_cache = NLS.init(probB, NLS.SimpleNewtonRaphson())
+simple_cache isa NLSB.NonlinearSolveNoInitCache
+simple_sol = NLS.solve!(simple_cache)
 ```
 
 We currently don't implement a `Base.iterate` interface but that will be added in the

--- a/docs/src/tutorials/iterator_interface.md
+++ b/docs/src/tutorials/iterator_interface.md
@@ -41,12 +41,20 @@ end
 ```
 
 Code that accepts any nonlinear algorithm can detect the second form and choose the complete
-solve path:
+solve path. The stepping branch can use `solve_cache!` when it needs the allocation-sensitive
+cache result:
 
 ```@example iterator_interface
-simple_cache = NLS.init(probB, NLS.SimpleNewtonRaphson())
-simple_cache isa NLSB.NonlinearSolveNoInitCache
-simple_sol = NLS.solve!(simple_cache)
+function solve_any(prob, alg)
+    cache = NLS.init(prob, alg)
+    if cache isa NLSB.NonlinearSolveNoInitCache
+        return NLS.solve!(cache)
+    end
+    NLSB.solve_cache!(cache)
+    return NLS.solve!(cache)
+end
+
+simple_sol = solve_any(probB, NLS.SimpleNewtonRaphson())
 ```
 
 We currently don't implement a `Base.iterate` interface but that will be added in the

--- a/lib/NonlinearSolveBase/src/abstract_types.jl
+++ b/lib/NonlinearSolveBase/src/abstract_types.jl
@@ -475,80 +475,177 @@ function show_nonlinearsolve_algorithm(
 end
 
 """
-    AbstractNonlinearSolveCache
+    AbstractNonlinearSolveCache <: AbstractNonlinearSolveBaseAPI
 
-Abstract Type for all NonlinearSolveBase Caches.
+Abstract supertype for caches returned by `init(prob, alg; kwargs...)` for nonlinear
+algorithms with a stepping implementation.
 
-### Interface Functions
+This is a developer-facing interface for packages that implement nonlinear solver
+algorithms. It is not a replacement for the user-facing `solve` and `init` APIs. An
+algorithm that does not provide a stepping implementation should use
+[`NonlinearSolveNoInitCache`](@ref) instead of constructing a partial stepping cache.
 
-  - `get_fu(cache)`: get the residual.
+# Fields
 
-  - `get_u(cache)`: get the current state.
-  - `get_nsteps(cache)`: get the number of steps taken so far.
-  - `set_fu!(cache, fu)`: set the residual.
-  - `has_time_limit(cache)`: whether or not the solver has a maximum time limit.
-  - `not_terminated(cache)`: whether or not the solver has terminated.
-  - `SciMLBase.set_u!(cache, u)`: set the current state.
-  - `SciMLBase.reinit!(cache, u0; kwargs...)`: reinitialize the cache with the initial state
-    `u0` and any additional keyword arguments.
-  - `SciMLBase.isinplace(cache)`: whether or not the solver is inplace.
-  - `CommonSolve.step!(cache; kwargs...)`: See [`CommonSolve.step!`](@ref) for more details.
-  - `get_abstol(cache)`: get the `abstol` provided to the cache.
-  - `get_reltol(cache)`: get the `reltol` provided to the cache.
+The default `CommonSolve.step!`, `CommonSolve.solve!`, and
+`SymbolicIndexingInterface` methods read the following fields from a stepping cache:
 
-Additionally implements `SymbolicIndexingInterface` interface Functions.
+- `prob::AbstractNonlinearProblem`: the problem being solved.
+- `alg::AbstractNonlinearSolveAlgorithm`: the algorithm associated with the cache.
+- `p`: the current parameter values.
+- `u`: the current iterate, used by the default [`get_u`](@ref) method.
+- `fu`: the residual at the current iterate, used by the default [`get_fu`](@ref) method.
+- `nsteps::Integer`: the number of completed solver steps.
+- `maxiters::Integer`: the maximum number of solver steps.
+- `force_stop::Bool`: whether a caller or the solver has requested termination.
+- `retcode::SciMLBase.ReturnCode.T`: the current solver status.
+- `stats::SciMLBase.NLStats`: counters for function, Jacobian, factorization, and step work.
+- `termination_cache`: the cache used by the termination-condition implementation.
+- `trace`: the optional nonlinear solver trace.
+- `timer`: the timer used by the default `step!` wrapper.
+- `verbose`: the verbosity specification used by solver messages.
 
-#### Expected Fields in Sub-Types
+`maxtime` and `total_time` are also required when the cache reports a time limit through
+`has_time_limit`. A cache may store any of these values elsewhere, but then it must
+override every accessor or driver method that otherwise reads the default field.
 
-For the default interface implementations we expect the following fields to be present in
-the cache:
+# Interface
 
-  - `fu`: the residual.
-  - `u`: the current state.
-  - `maxiters`: the maximum number of iterations.
-  - `nsteps`: the number of steps taken.
-  - `force_stop`: whether or not the solver has been forced to stop.
-  - `retcode`: the return code.
-  - `stats`: `NLStats` object.
-  - `alg`: the algorithm.
-  - `maxtime`: the maximum time limit for the solver. (Optional)
-  - `timer`: the timer for the solver. (Optional)
-  - `total_time`: the total time taken by the solver. (Optional)
-  - `verbose`: a verbosity object that contains options determining what log messages are emitted. 
+- [`get_u`](@ref): return the current iterate.
+- [`get_fu`](@ref): return the current residual vector.
+- [`get_nsteps`](@ref): return the number of completed steps.
+- [`CommonSolve.step!`](@ref): advance the cache by one step.
+- `CommonSolve.solve!(cache)`: run a stepping cache to termination and return a
+  `SciMLBase.NonlinearSolution`.
+- `SciMLBase.reinit!(cache, u0; kwargs...)`: reset the cache for a new initial state and
+  solve options.
+- [`get_abstol`](@ref) and [`get_reltol`](@ref): return the active tolerances.
+- `SciMLBase.set_u!`, `set_fu!`, `SciMLBase.isinplace`, and the
+  `SymbolicIndexingInterface` accessors: update or inspect the cache state.
+- [`supports_deferred_residual`](@ref) and [`refresh_residual!`](@ref): coordinate an
+  optional deferred residual evaluation.
+
+# Extension Rules
+
+- Implement `NonlinearSolveBase.InternalAPI.step!(cache::YourCache; kwargs...)`; the
+  public `CommonSolve.step!` wrapper handles termination, timing, and the top-level step
+  counters.
+- Override [`get_u`](@ref) and [`get_fu`](@ref) when the iterate or residual is stored in a
+  nested cache or another representation. These accessors must describe the same state
+  that `step!` and `reinit!` operate on.
+- Implement `NonlinearSolveBase.InternalAPI.reinit!` and preserve the cache's documented
+  invariants when `SciMLBase.reinit!` is called.
+- Return `true` from [`supports_deferred_residual`](@ref) only when deferring the residual
+  cannot change termination or trace semantics, and implement [`refresh_residual!`](@ref)
+  for that cache.
+- Generic drivers should use the documented accessors rather than reaching into
+  algorithm-specific fields. Solver packages may add internal fields without making them
+  part of this interface.
+
+# Examples
+
+```julia
+import NonlinearSolve
+import NonlinearSolveBase
+
+prob = NonlinearSolve.NonlinearProblem((u, p) -> u^2 - p, 1.0, 2.0)
+cache = NonlinearSolve.init(prob, NonlinearSolve.NewtonRaphson())
+NonlinearSolve.step!(cache)
+u = NonlinearSolveBase.get_u(cache)
+```
 """
 abstract type AbstractNonlinearSolveCache <: AbstractNonlinearSolveBaseAPI end
 
 """
-    get_u(cache)
+    get_u(cache::AbstractNonlinearSolveCache) -> u
 
 Return the current iterate held by a nonlinear solver cache.
 
-Defaults to the cache's `u` field. Caches that keep the iterate elsewhere should overload
-this hook: a `NonlinearSolvePolyAlgorithmCache` forwards to whichever subsolver is
-currently active, and the ForwardDiff cache forwards to the wrapped primal cache.
+The default returns `cache.u`. Caches that keep the iterate elsewhere should overload this
+hook, such as a polyalgorithm forwarding to its active subsolver or a ForwardDiff cache
+forwarding to its wrapped primal cache.
+
+# Arguments
+
+- `cache::AbstractNonlinearSolveCache`: the cache whose current iterate is requested.
+
+# Returns
+
+The current iterate in the representation used by the cache's solver.
+
+# Extension Rules
+
+An overload must return the iterate that the cache will update on its next step. Generic
+drivers should call this accessor rather than reading `cache.u` directly.
+
+# Examples
+
+```julia
+u = NonlinearSolveBase.get_u(cache)
+```
 """
 get_u(cache::AbstractNonlinearSolveCache) = cache.u
 
 """
-    get_fu(cache)
+    get_fu(cache::AbstractNonlinearSolveCache) -> fu
 
 Return the residual stored in a nonlinear solver cache: the most recent value of the
 problem's residual function the solver evaluated (the full residual vector, not its norm,
 for a `NonlinearLeastSquaresProblem`).
 
-Defaults to the cache's `fu` field, with the same overloading convention as
-[`get_u`](@ref). Between steps this is the residual at [`get_u`](@ref), but a solver
-mid-step commits the new iterate before re-evaluating there — a `postcondition` corrector
-runs at exactly such a point and so sees the residual at the previous accepted iterate.
+The default returns `cache.fu`, with the same overloading convention as [`get_u`](@ref).
+Between steps this is the residual at [`get_u`](@ref), but a solver mid-step commits the
+new iterate before re-evaluating there. A `postcondition` corrector runs at exactly such a
+point and therefore sees the residual at the previous accepted iterate.
+
+# Arguments
+
+- `cache::AbstractNonlinearSolveCache`: the cache whose residual is requested.
+
+# Returns
+
+The full residual vector, not its norm, including for a
+`NonlinearLeastSquaresProblem`.
+
+# Extension Rules
+
+An overload must use the same residual convention as the default and remain synchronized
+with [`get_u`](@ref) at cache step boundaries. Generic drivers should call this accessor
+instead of reading an algorithm-specific residual field.
+
+# Examples
+
+```julia
+fu = NonlinearSolveBase.get_fu(cache)
+```
 """
 get_fu(cache::AbstractNonlinearSolveCache) = cache.fu
 
 """
-    get_nsteps(cache)
+    get_nsteps(cache::AbstractNonlinearSolveCache) -> Int
 
 Return the number of solver iterations the cache has taken so far. This is the count
 checked against `maxiters`, and it counts steps of the solver loop rather than function
 or Jacobian evaluations, which are tracked separately in `cache.stats`.
+
+# Arguments
+
+- `cache::AbstractNonlinearSolveCache`: the cache whose step count is requested.
+
+# Returns
+
+The number of completed solver steps as an integer.
+
+# Extension Rules
+
+An overload must use the same count that controls the cache's iteration limit. Function and
+Jacobian evaluations belong in `cache.stats` and must not be reported as solver steps.
+
+# Examples
+
+```julia
+nsteps = NonlinearSolveBase.get_nsteps(cache)
+```
 """
 get_nsteps(cache::AbstractNonlinearSolveCache) = cache.nsteps
 
@@ -565,6 +662,21 @@ residual that is already current. A cache may only answer `true` where deferral 
 unobservable — in particular where its termination condition depends on nothing but the
 residual, since a deferred step reports no displacement and reaches the termination check
 once per [`refresh_residual!`](@ref) rather than once per step.
+
+# Arguments
+
+- `cache::AbstractNonlinearSolveCache`: the cache whose deferred-residual capability is
+  queried.
+
+# Returns
+
+`true` only when the cache supports the deferred-residual protocol; otherwise `false`.
+
+# Extension Rules
+
+The default is `false`. An overload returning `true` must also implement
+[`refresh_residual!`](@ref) and preserve the termination and trace semantics described
+above.
 """
 supports_deferred_residual(::AbstractNonlinearSolveCache) = false
 
@@ -581,6 +693,21 @@ that never defers, which the default here covers. A cache that answers
 
 The next `step!` settles an outstanding deferral itself, so a driver that only ever steps
 again never needs to call this.
+
+# Arguments
+
+- `cache::AbstractNonlinearSolveCache`: the cache whose deferred residual should be settled.
+
+# Returns
+
+`nothing`. The cache is updated in place.
+
+# Extension Rules
+
+The default is a no-op for caches that never defer. A cache that returns `true` from
+[`supports_deferred_residual`](@ref) must evaluate and store the residual at
+[`get_u`](@ref), perform the corresponding convergence update, and make repeated calls
+safe when no evaluation is outstanding.
 """
 refresh_residual!(::AbstractNonlinearSolveCache) = nothing
 
@@ -606,24 +733,60 @@ end
 SciMLBase.isinplace(cache::AbstractNonlinearSolveCache) = SciMLBase.isinplace(cache.prob)
 
 """
-    get_abstol(cache)
+    get_abstol(cache::AbstractNonlinearSolveCache) -> Real
 
 Return the absolute tolerance currently stored in a nonlinear solver cache or problem.
 
-Solver caches should overload this hook when the tolerance is not stored in the default
-`termination_cache` location.
+The default reads the cache's `termination_cache`.
+
+# Arguments
+
+- `cache::AbstractNonlinearSolveCache`: the cache whose absolute tolerance is requested.
+
+# Returns
+
+The active absolute tolerance used by the cache's termination condition.
+
+# Extension Rules
+
+Override this method when the cache stores its termination state somewhere other than
+`termination_cache`. The returned value must agree with the tolerance used by `step!`.
+
+# Examples
+
+```julia
+abstol = NonlinearSolveBase.get_abstol(cache)
+```
 """
 function get_abstol(cache::AbstractNonlinearSolveCache)
     return get_abstol(cache.termination_cache)
 end
 
 """
-    get_reltol(cache)
+    get_reltol(cache::AbstractNonlinearSolveCache) -> Real
 
 Return the relative tolerance currently stored in a nonlinear solver cache or problem.
 
-Solver caches should overload this hook when the tolerance is not stored in the default
-`termination_cache` location.
+The default reads the cache's `termination_cache`.
+
+# Arguments
+
+- `cache::AbstractNonlinearSolveCache`: the cache whose relative tolerance is requested.
+
+# Returns
+
+The active relative tolerance used by the cache's termination condition.
+
+# Extension Rules
+
+Override this method when the cache stores its termination state somewhere other than
+`termination_cache`. The returned value must agree with the tolerance used by `step!`.
+
+# Examples
+
+```julia
+reltol = NonlinearSolveBase.get_reltol(cache)
+```
 """
 function get_reltol(cache::AbstractNonlinearSolveCache)
     return get_reltol(cache.termination_cache)

--- a/lib/NonlinearSolveBase/src/homotopy_polyalg.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_polyalg.jl
@@ -2,7 +2,7 @@
     HomotopyPolyAlgorithm(algs::Tuple; warm_handoff = true, store_original = Val(false))
     HomotopyPolyAlgorithm(; inner = nothing, warm_handoff = true, store_original = Val(false))
 
-A polyalgorithm for [`SciMLBase.HomotopyProblem`](@ref): a container for a tuple of
+A polyalgorithm for `SciMLBase.HomotopyProblem`: a container for a tuple of
 continuation algorithms that are tried in order until one returns a solution with a
 successful retcode. The first success is returned immediately — later stages never run.
 If every stage fails, the *last* stage's failed solution is returned, so its `retcode`

--- a/lib/NonlinearSolveBase/src/homotopy_sweep.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_sweep.jl
@@ -5,7 +5,7 @@
         predictor = :secant, tracking_maxiters = 10, tracking_abstol = nothing,
         maxsteps = 10000, store_original = Val(false))
 
-Natural-parameter continuation solver for a [`SciMLBase.HomotopyProblem`](@ref). The
+Natural-parameter continuation solver for `SciMLBase.HomotopyProblem`. The
 scalar continuation parameter ``λ`` is swept across the problem's `λspan`. The sweep
 first solves the system at `λspan[1]` (for the canonical `(0, 1)` span, the
 `simplified` system — the form the homotopy is designed to make solvable from a cold
@@ -33,7 +33,7 @@ when the retained subalgorithm fails. The cold anchor solve at `λspan[1]` alway
 the full ladder — that is where the winning subalgorithm is discovered.
 
 Optional derivative fields of the problem's `NonlinearFunction` (which
-[`SciMLBase.HomotopyProblem`](@ref) requires to follow the same λ-extended argument
+`SciMLBase.HomotopyProblem` requires to follow the same λ-extended argument
 convention as the residual) are consumed by this solver: an analytic `jac(u, p, λ)` /
 `jac(J, u, p, λ)` is λ-fixed exactly like the residual and handed to the inner solver
 as a standard 2/3-argument Jacobian (so e.g. the default polyalgorithm selects its

--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -9,7 +9,7 @@ Construct a cache for the Jacobian of `f` w.r.t. `u`.
 
 ### Arguments
 
-  - `prob`: A [`NonlinearProblem`](@ref) or a [`NonlinearLeastSquaresProblem`](@ref).
+  - `prob`: A `NonlinearProblem` or a `NonlinearLeastSquaresProblem` from SciMLBase.
   - `alg`: A [`AbstractNonlinearSolveAlgorithm`](@ref). Used to check for
     [`concrete_jac`](@ref).
   - `f`: The function to compute the Jacobian of.

--- a/lib/NonlinearSolveBase/src/kantorovich_homotopy.jl
+++ b/lib/NonlinearSolveBase/src/kantorovich_homotopy.jl
@@ -7,7 +7,7 @@
         tracking_maxiters = 10, tracking_abstol = nothing, maxsteps = 10000,
         store_original = Val(false))
 
-Natural-parameter continuation for a [`SciMLBase.HomotopyProblem`](@ref), with step
+Natural-parameter continuation for `SciMLBase.HomotopyProblem`, with step
 sizes chosen from the observed contraction of the inner nonlinear corrector. This is
 the Newton--Kantorovich path-following controller described in Section 5.1.3 of
 Deuflhard, *Newton Methods for Nonlinear Problems*.

--- a/lib/NonlinearSolveBase/src/public.jl
+++ b/lib/NonlinearSolveBase/src/public.jl
@@ -66,21 +66,52 @@ NonlinearSolveBase.L2_NORM([3.0, 4.0])
 function L2_NORM end
 
 """
-    solve_cache!(cache; step_observer = nothing) -> ReturnCode
+    solve_cache!(cache::AbstractNonlinearSolveCache; step_observer = nothing) -> ReturnCode
 
-Drive an initialized nonlinear solver cache to termination without constructing a
-`NonlinearSolution`.
+Drive an initialized stepping cache to termination without constructing a
+`SciMLBase.NonlinearSolution`.
 
 This allocation-sensitive interface is intended for nested solvers that already own a
-cache from `init` and whose algorithm supports the nonlinear solver iterator interface.
-`step_observer`, when provided, is called after every nonlinear iteration as
-`step_observer(u, fu, iteration)`. The state and residual arguments alias the solver
-cache and must not be mutated. The returned `SciMLBase.ReturnCode` reports the final
-solver status; the final state remains available through
+cache from `init`. It is available only when the cache implements the nonlinear solver
+iterator interface. Unlike `solve!(cache)`, it does not transform a bounded problem's
+internal unconstrained state back to bounded coordinates.
+
+# Arguments
+
+- `cache::AbstractNonlinearSolveCache`: an initialized cache with an
+  `InternalAPI.step!` implementation.
+
+# Keywords
+
+- `step_observer = nothing`: an optional callable invoked after each nonlinear step as
+  `step_observer(u, fu, iteration)`. The `u` and `fu` arguments alias the cache and must
+  not be mutated.
+
+# Returns
+
+The final `SciMLBase.ReturnCode`. The final state remains available through
 `SymbolicIndexingInterface.state_values(cache)`.
 
-Unlike `solve!(cache)`, this function does not transform a bounded problem's internal
-unconstrained state back to the bounded coordinates.
+# Throws
+
+`ArgumentError` if `cache` does not support the stepping interface.
+
+# Extension Rules
+
+Implement `NonlinearSolveBase.InternalAPI.step!` on a cache before calling this function.
+Use `solve!(cache)` for [`NonlinearSolveNoInitCache`](@ref), which intentionally has no
+stepping state.
+
+# Examples
+
+```julia
+import NonlinearSolve
+import NonlinearSolveBase
+
+prob = NonlinearSolve.NonlinearProblem((u, p) -> u^2 - p, 1.0, 2.0)
+cache = NonlinearSolve.init(prob, NonlinearSolve.NewtonRaphson())
+retcode = NonlinearSolveBase.solve_cache!(cache)
+```
 """
 function solve_cache! end
 

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -784,20 +784,53 @@ end
 end
 
 """
-    step!(
-        cache::AbstractNonlinearSolveCache;
-        recompute_jacobian::Union{Nothing, Bool} = nothing
-    )
+    step!(cache::AbstractNonlinearSolveCache, args...; kwargs...)
 
-Performs one step of the nonlinear solver.
+Perform one step of a nonlinear solver and mutate `cache` in place.
 
-### Keyword Arguments
+The public wrapper first checks whether the cache is still active, then calls
+`NonlinearSolveBase.InternalAPI.step!`, updates the step counters, and enforces a time
+limit when one is configured. It returns the value produced by the algorithm-specific
+implementation, which is commonly `nothing`.
 
-  - `recompute_jacobian`: allows controlling whether the jacobian is recomputed at the
-    current step. If `nothing`, then the algorithm determines whether to recompute the
-    jacobian. If `true` or `false`, then the jacobian is recomputed or not recomputed,
-    respectively. For algorithms that don't use jacobian information, this keyword is
-    ignored with a one-time warning.
+# Arguments
+
+- `cache::AbstractNonlinearSolveCache`: the initialized stepping cache to advance.
+- `args...`: positional arguments forwarded to the algorithm-specific implementation.
+
+# Keywords
+
+- `recompute_jacobian::Union{Nothing, Bool} = nothing`: whether to recompute a Jacobian
+  when the algorithm uses one. `nothing` delegates the choice to the algorithm. This
+  keyword is ignored or rejected by algorithms according to their own interface.
+- `evaluate_residual::Bool = true`: a hint that the algorithm may skip the residual
+  evaluation at the newly accepted iterate. It is honored only when
+  [`supports_deferred_residual`](@ref) returns `true`; call [`refresh_residual!`](@ref)
+  before reading a deferred residual.
+- `kwargs...`: additional algorithm-specific keyword arguments.
+
+# Returns
+
+The value returned by `InternalAPI.step!`. The cache is mutated in place. Calling `step!`
+on a terminated cache does nothing and returns `nothing`.
+
+# Extension Rules
+
+Solver packages implement `InternalAPI.step!`, not this `CommonSolve.step!` method. The
+implementation must leave the cache state consistent with [`get_u`](@ref),
+[`get_fu`](@ref), and the termination cache. The wrapper owns the top-level `nsteps` and
+`stats.nsteps` increments, so an implementation should not increment those counters for
+the same step.
+
+# Examples
+
+```julia
+import NonlinearSolve
+
+prob = NonlinearSolve.NonlinearProblem((u, p) -> u^2 - p, 1.0, 2.0)
+cache = NonlinearSolve.init(prob, NonlinearSolve.NewtonRaphson())
+NonlinearSolve.step!(cache)
+```
 """
 function CommonSolve.step!(cache::AbstractNonlinearSolveCache, args...; kwargs...)
     not_terminated(cache) || return
@@ -827,25 +860,50 @@ end
 """
     NonlinearSolveNoInitCache <: AbstractNonlinearSolveCache
 
-The cache `init(prob, alg)` returns for an algorithm that defines no `SciMLBase.__init`
-method — every `SimpleNonlinearSolve` algorithm, for instance. It stores the problem and
-the solve options and does nothing else, so that generic code can call `init` on any
-algorithm.
+Cache returned by `init(prob, alg; kwargs...)` when `alg` has no algorithm-specific
+`SciMLBase.__init` method. Every `SimpleNonlinearSolve` algorithm uses this form, for
+example. It stores the problem and solve options so generic code can call `init` on any
+nonlinear algorithm.
 
-Unlike a stepping cache it holds no iteration state, and it implements only part of the
-[`AbstractNonlinearSolveCache`](@ref) interface:
+Unlike a stepping cache, it holds no iteration state and implements only part of the
+[`AbstractNonlinearSolveCache`](@ref) interface. `solve!(cache)` runs the complete solve
+and returns a `SciMLBase.NonlinearSolution`; that solution is the only record of the
+iterations, and no iteration state is written back into the cache. `get_u(cache)` reads
+the problem's initial state, while `SciMLBase.reinit!`, `get_abstol`, `get_reltol`, and the
+`SymbolicIndexingInterface` accessors operate on the stored problem as usual.
 
-  - `solve!(cache)` runs the *complete* solve and returns its `SciMLBase.NonlinearSolution`.
-    That returned solution is the only record of the solve; nothing about it is written back
-    into the cache.
-  - `get_u(cache)` reads the problem's `u0`, i.e. the *initial* iterate — it does not track
-    a running one.
-  - `SciMLBase.reinit!`, `get_abstol`, `get_reltol` and the `SymbolicIndexingInterface`
-    accessors work as usual.
-  - `CommonSolve.step!`, `get_fu`, `get_nsteps` and `cache.stats` are **not** available.
+`CommonSolve.step!`, `get_fu`, `get_nsteps`, and `cache.stats` are not available for this
+cache. Generic code that drives caches one step at a time must detect this type and call
+`solve!(cache)` instead.
 
-Public so that code driving an `AbstractNonlinearSolveCache` one `step!` at a time can
-detect this cache and run a full `solve!` instead.
+# Fields
+
+- `prob::AbstractNonlinearProblem`: the problem passed to `init`.
+- `alg::AbstractNonlinearSolveAlgorithm`: the algorithm passed to `init`.
+- `args::Tuple`: positional arguments forwarded to the eventual solve.
+- `kwargs::Any`: keyword options forwarded to the eventual solve, including tolerances.
+- `initializealg`: the initialization algorithm used before the solve.
+- `retcode::SciMLBase.ReturnCode.T`: the initialization status, if initialization ran.
+- `verbose`: the verbosity specification forwarded to the solve.
+
+# Extension Rules
+
+This cache is the fallback produced by the package's generic initialization method; solver
+packages should not add `step!` methods to it to imitate a stepping cache. Use `isa
+NonlinearSolveNoInitCache` only to select the complete `solve!` path, and use the generic
+accessors for all other supported operations.
+
+# Examples
+
+```julia
+import NonlinearSolve
+import NonlinearSolveBase
+
+prob = NonlinearSolve.NonlinearProblem((u, p) -> u^2 - p, 1.0, 2.0)
+cache = NonlinearSolve.init(prob, NonlinearSolve.SimpleNewtonRaphson())
+cache isa NonlinearSolveBase.NonlinearSolveNoInitCache
+sol = NonlinearSolve.solve!(cache)
+```
 """
 @concrete mutable struct NonlinearSolveNoInitCache <: AbstractNonlinearSolveCache
     prob

--- a/src/poly_algs.jl
+++ b/src/poly_algs.jl
@@ -100,7 +100,7 @@ end
     ) where {T}
 
 The recommended default [`HomotopyPolyAlgorithm`](@ref) for solving a
-[`SciMLBase.HomotopyProblem`](@ref) — e.g. a Modelica `homotopy(actual, simplified)`
+`SciMLBase.HomotopyProblem` — e.g. a Modelica `homotopy(actual, simplified)`
 initialization system — by continuation. It is the homotopy analogue of
 [`FastShortcutNonlinearPolyalg`](@ref): a fast [`HomotopySweep`](@ref) (natural-parameter
 continuation) escalating to a robust [`ArcLengthContinuation`](@ref) (pseudo-arclength) on

--- a/test/Core/cache_solve_tests__item1.jl
+++ b/test/Core/cache_solve_tests__item1.jl
@@ -1,6 +1,7 @@
 using NonlinearSolve, SciMLBase, SymbolicIndexingInterface, Test
 using ADTypes: AutoFiniteDiff
-using NonlinearSolveBase: solve_cache!
+using NonlinearSolveBase: get_fu, get_nsteps, get_u, refresh_residual!, solve_cache!,
+    supports_deferred_residual
 
 struct UnsupportedCache <: NonlinearSolveBase.AbstractNonlinearSolveCache end
 
@@ -35,6 +36,19 @@ end
 prob = NonlinearProblem(cache_problem!, [1.0], 2.0)
 cache = init(prob, NewtonRaphson(; autodiff = AutoFiniteDiff()))
 observer = StepObserver(0, Inf)
+
+interface_cache = init(prob, NewtonRaphson(; autodiff = AutoFiniteDiff()))
+@test get_u(interface_cache) == [1.0]
+@test get_fu(interface_cache) == [-1.0]
+@test get_nsteps(interface_cache) == 0
+@test !supports_deferred_residual(interface_cache)
+@test refresh_residual!(interface_cache) === nothing
+step!(interface_cache)
+@test get_nsteps(interface_cache) == 1
+@test get_u(interface_cache) != [1.0]
+@test get_fu(interface_cache) != [-1.0]
+@test all(isfinite, get_u(interface_cache))
+@test all(isfinite, get_fu(interface_cache))
 
 retcode = cache_solve!(cache, observer)
 @test SciMLBase.successful_retcode(retcode)

--- a/test/Core/cache_solve_tests__item1.jl
+++ b/test/Core/cache_solve_tests__item1.jl
@@ -28,6 +28,15 @@ function cache_solve_allocations(cache, observer)
     return @allocated cache_solve!(cache, observer)
 end
 
+function solve_any_cache(prob, alg)
+    cache = init(prob, alg)
+    if cache isa NonlinearSolveBase.NonlinearSolveNoInitCache
+        return solve!(cache)
+    end
+    solve_cache!(cache)
+    return solve!(cache)
+end
+
 function cache_problem!(resid, u, p)
     resid[1] = u[1]^2 - p
     return nothing
@@ -49,6 +58,18 @@ step!(interface_cache)
 @test get_fu(interface_cache) != [-1.0]
 @test all(isfinite, get_u(interface_cache))
 @test all(isfinite, get_fu(interface_cache))
+
+generic_simple_sol = solve_any_cache(
+    prob, SimpleNewtonRaphson(; autodiff = AutoFiniteDiff())
+)
+@test SciMLBase.successful_retcode(generic_simple_sol)
+@test only(generic_simple_sol.u) ≈ √2
+
+generic_stepping_sol = solve_any_cache(
+    prob, NewtonRaphson(; autodiff = AutoFiniteDiff())
+)
+@test SciMLBase.successful_retcode(generic_stepping_sol)
+@test only(generic_stepping_sol.u) ≈ √2
 
 retcode = cache_solve!(cache, observer)
 @test SciMLBase.successful_retcode(retcode)

--- a/test/Core/core_tests__item13.jl
+++ b/test/Core/core_tests__item13.jl
@@ -1,4 +1,5 @@
 using NonlinearSolve
+import NonlinearSolveBase
 
 using LinearAlgebra
 
@@ -10,6 +11,7 @@ prob = NonlinearProblem((u, p) -> u .^ 2 .- p, [0.1, 0.3], 2.0)
 
 for alg in solvers
     cache = init(prob, alg)
+    @test cache isa NonlinearSolveBase.NonlinearSolveNoInitCache
     sol = solve!(cache)
     @test SciMLBase.successful_retcode(sol)
     @test norm(sol.resid, Inf) ≤ 1.0e-6


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

The iterator tutorial now documents both valid `init` cache forms: stepping caches and `NonlinearSolveNoInitCache` for algorithms without `SciMLBase.__init`. It shows the generic `solve!` fallback and adds a test covering the public cache classification for all `SimpleNonlinearSolve` algorithms. This is docs/API guidance only and does not overlap termination documentation or PR #1179.

**Verification**

- `GROUP=Core /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e "using Pkg; Pkg.test()"` -> `Testing NonlinearSolve tests passed`
- `GROUP=QA /home/crackauc/.juliaup/bin/julia +1.10 --startup-file=no --project=. -e "using Pkg; Pkg.test()"` -> `QA | 26 | 26`; `Testing NonlinearSolve tests passed`
- `/home/crackauc/.juliaup/bin/julia +1.10 --project=docs docs/make.jl` -> exit 0; doctests, cross-references, and HTML rendering completed
- `typos docs/src/tutorials/iterator_interface.md test/Core/core_tests__item13.jl` -> exit 0
- `git diff --check` -> exit 0

The repository formatter was not available locally: the installed `runic` is a workspace-agent CLI without a check command, and `JuliaFormatter` is not in the project environment. Existing Documenter warnings about unrelated missing docstrings and HTML size remain unchanged.

**Follow-up commit **

The cache-interface docs are now attached to the original definitions in  and use SciMLStyle sections for fields, arguments, keywords, returns, extension rules, and examples. This is documentation-only; solver behavior and test logic are unchanged.

Additional verification:

-  -> ; 
-  -> exit 0
-  -> exit 0
- Added-line width audit -> no added lines over 92 columns
- A temporary environment developed ;  confirmed the updated  and  docstrings are attached, and the stepping/no-init examples passed.

The current full docs build was started after this commit and reached doctests and template expansion without an error, then was interrupted to avoid waiting on the broad render. It is not claimed as passed here. The prior PR-head docs build recorded above was green.

**Follow-up commit 84c0bc2ec**

The cache-interface docs are now attached to the original definitions in NonlinearSolveBase and use SciMLStyle sections for fields, arguments, keywords, returns, extension rules, and examples. This is documentation-only; solver behavior and test logic are unchanged.

Additional verification:

- GROUP=QA with Julia 1.10.11 -> QA | 26 | 26; Testing NonlinearSolve tests passed
- typos on the three changed source files -> exit 0
- git diff --check -> exit 0
- Added-line width audit -> no added lines over 92 columns
- A temporary environment developed lib/NonlinearSolveBase; Docs.doc confirmed the updated AbstractNonlinearSolveCache and NonlinearSolveNoInitCache docstrings are attached, and the stepping/no-init examples passed.

The current full docs build was started after this commit and reached doctests and template expansion without an error, then was interrupted to avoid waiting on the broad render. It is not claimed as passed here. The prior PR-head docs build recorded above was green.

## Final strict verification

Follow-up commit: 6bcca0870f318b20a572ceeeee634f3e96b5966d

Docs command: timeout 3600 julia --startup-file=no --project=docs docs/make.jl. Exit code 0. Documenter completed doctests, cross-reference checks, checkdocs, rendering, and linkcheck. Only non-fatal HTML-size, SVG fallback, headless-GKS, and deployment-environment warnings remained.

QA command: GROUP=QA timeout 3600 julia --startup-file=no --project=. -e using Pkg; Pkg.test(). Exit code 0. QA passed 28/28 in 59.7s on Julia 1.12.4, followed by Testing NonlinearSolve tests passed.

Core focused tests passed with Testing NonlinearSolve tests passed.

Runic checks pass for all touched Julia files. Typos and git diff --check pass.

The docs build remains strict: no warnonly, doctest suppression, external-link ignore, or QA ignore was added. The final source/docs diff only fixes owner references and adds the generic cache-interface test; no solver behavior changes were made.