### PR TITLE
Avoid a binding invalidation in the polyalgorithm generators

### DIFF
--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -577,7 +577,7 @@ end
     end
     push!(
         calls, quote
-            fus = tuple($(Tuple(resids)...))
+            fus = Base.tuple($(Tuple(resids)...))
             # Use findmin_resids directly since fus already contains residual vectors from get_fu
             minfu, idx = findmin_resids(cache.prob, fus)
         end
@@ -752,7 +752,7 @@ end
 
     push!(
         calls, quote
-            resids = tuple($(Tuple(resids)...))
+            resids = Base.tuple($(Tuple(resids)...))
             minfu, idx = findmin_resids(prob, resids)
         end
     )


### PR DESCRIPTION
Both `solve!(::NonlinearSolvePolyAlgorithmCache)` and `__generated_polysolve` build their bodies with `tuple($(...))` inside a `quote`. The bare symbol lowers to `GlobalRef(NonlinearSolveBase, :tuple)`, and since `tuple` is never called anywhere else in the package, that implicit-`Base`-import binding is still unresolved after precompilation:

    Core.Binding(:(NonlinearSolveBase.tuple), #undef, #undef, #undef, 0x08)

Inference records a backedge to it, and resolving the binding at load time counts as a rebinding, invalidating the cached `solve!` specializations.

Fixes this *absolute* unit of an invalidation seen when loading CurveFit that I can't be bothered to format nicely:
```julia
 rebinding Core.Binding(:(NonlinearSolveBase.tuple), #undef, #undef, #undef, 0x08) invalidated:                                                                                                                                                                                                                                                                                                                                                                                                
   mt_backedges: 1: signature NonlinearSolveBase.tuple triggered MethodInstance for CommonSolve.solve!(::NonlinearSolveBase.NonlinearSolvePolyAlgorithmCache{Val{6}, __T_prob, __T_caches, NonlinearSolveBase.NonlinearSolvePolyAlgorithm{Val{6}, Tuple{NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarq
uardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{LineSearch.BackTracking{Nothing
, Float64, Float64, Float64, Val{3}, Float64, Bool}, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Fan, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.Generaliz
edFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}}, Val{false}}, _A, _B, Nothing, typeof(NonlinearSolveBase.L2_NORM), _C, _D, NonlinearSolveBase.NonlinearSolveDefaultInit} where {__T_prob<:SciMLBase.AbstractNonlinearProblem, __T_caches<:Tuple{Union{NonlinearSolveBase.NonlinearSolveForwardDiffCache{_A, __T_prob, NonlinearSolveFirstOrder.Gene
ralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, __T_p, _B, __T_partials_p} where {_A, __T_prob<:SciMLBase.AbstractNonlinearProblem, __T_p<:(Union{ForwardDiff.Dual{T, V, P}, AbstractArray{<:ForwardDiff.Dual{T, V, P}}} where {T, V, P}), _B, __T_partials_p<:ForwardDiff.Partials}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{__T_fu, __T_u, __T_u_cache, __T_p, __T_alg, __T_prob, __T_globalization, __T_jac_cache, __T_descent_cache, __T_forcing_cache, __T_linesearch_cache, __T_trustregion_cache, Nothing, Nothing, __T_termination_cache,
 __T_trace, __T_kwargs, SciMLBase.NoInit} where {__T_fu, __T_u, __T_u_cache, __T_p, __T_alg<:NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm, __T_prob<:SciMLBase.AbstractNonlinearProblem, __T_globalization<:Union{Val{:LineSearch}, Val{:TrustRegion}, Val{:None}}, __T_jac_cache, __T_descent_cache, __T_forcing_cache, __T_linesearch_cache, __T_trustregion_cache, __T_termination_cache, __T_trace, __T_kwargs}}, Union{NonlinearSolveBase.NonlinearSolveForwardDiffCache{_A, __T_prob, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.Dam
pedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}, __T_p, _B, __T_partials_p} where {_A, __T_prob<:SciMLBase.AbstractNonlinearProblem, __T_p<:(Union{ForwardDiff.Dual{T, V, P}, AbstractArray{<:ForwardDiff.Dual{T, V, P}}} where {T, V, P}), _B, __T_partials_p<:ForwardDiff.Partials}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{__T_fu, __T_u, __T_u_cache, __T_p, __T_alg, __T_prob, __T_globalization, __T_jac_cache, __T_descent_cache, __T_forcing_cache, __T_linesearch_cache, __T_trustregion_cache, Nothin
g, Nothing, __T_termination_cache, __T_trace, __T_kwargs, SciMLBase.NoInit} where {__T_fu, __T_u, __T_u_cache, __T_p, __T_alg<:NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm, __T_prob<:SciMLBase.AbstractNonlinearProblem, __T_globalization<:Union{Val{:LineSearch}, Val{:TrustRegion}, Val{:None}}, __T_jac_cache, __T_descent_cache, __T_forcing_cache, __T_linesearch_cache, __T_trustregion_cache, __T_termination_cache, __T_trace, __T_kwargs}}, Union{NonlinearSolveBase.NonlinearSolveForwardDiffCache{_A, __T_prob, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{Non
linearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, __T_p, _B, __T_partials_p} where {_A, __T_prob<:SciMLBase.AbstractNonlinearProblem, __T_p<:(Union{ForwardDiff.Dual{T, V, P}, AbstractArray{<:ForwardDiff.Dual{T, V, P}}} where {T, V, P}), _B, __T_partials_p<:ForwardDiff.Partials}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{__T_fu, __T_
u, __T_u_cache, __T_p, __T_alg, __T_prob, __T_globalization, __T_jac_cache, __T_descent_cache, __T_forcing_cache, __T_linesearch_cache, __T_trustregion_cache, Nothing, Nothing, __T_termination_cache, __T_trace, __T_kwargs, SciMLBase.NoInit} where {__T_fu, __T_u, __T_u_cache, __T_p, __T_alg<:NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm, __T_prob<:SciMLBase.AbstractNonlinearProblem, __T_globalization<:Union{Val{:LineSearch}, Val{:TrustRegion}, Val{:None}}, __T_jac_cache, __T_descent_cache, __T_forcing_cache, __T_linesearch_cache, __T_trustregion_cache, __T_termination_cache, __T_trace, __T_kwargs}}, Union{NonlinearSolveBas
e.NonlinearSolveForwardDiffCache{_A, __T_prob, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{LineSearch.BackTracking{Nothing, Float64, Float64, Float64, Val{3}, Float64, Bool}, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, __T_p, _B, __T_partials_p} where {_A, __T_prob<:SciMLBase.AbstractNonlinearProblem, __T_p<:(Union{ForwardDiff.Dual{T, V, P}, AbstractArray{<:ForwardDiff.Dual{T, V, P}}} where {T, V, P}), _B, __T_partials_p<:ForwardDiff.Partials}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{__T_fu, __T_u, __T_u_cache, __T_p, __T_alg, __T_prob, __T_gl
obalization, __T_jac_cache, __T_descent_cache, __T_forcing_cache, __T_linesearch_cache, __T_trustregion_cache, Nothing, Nothing, __T_termination_cache, __T_trace, __T_kwargs, SciMLBase.NoInit} where {__T_fu, __T_u, __T_u_cache, __T_p, __T_alg<:NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm, __T_prob<:SciMLBase.AbstractNonlinearProblem, __T_globalization<:Union{Val{:LineSearch}, Val{:TrustRegion}, Val{:None}}, __T_jac_cache, __T_descent_cache, __T_forcing_cache, __T_linesearch_cache, __T_trustregion_cache, __T_termination_cache, __T_trace, __T_kwargs}}, Union{NonlinearSolveBase.NonlinearSolveForwardDiffCache{_A, __T_prob, N
onlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Fan, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, __T_p, _B, __T_partials_p} where {_A, __T_prob<:SciMLBase.AbstractNonlinearProblem, __T_p<:(Union{ForwardDiff.Dual{T, V, P}, AbstractArray{<:ForwardDiff.Dual{T, V, P}}} where {T, V, P}), _B
, __T_partials_p<:ForwardDiff.Partials}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{__T_fu, __T_u, __T_u_cache, __T_p, __T_alg, __T_prob, __T_globalization, __T_jac_cache, __T_descent_cache, __T_forcing_cache, __T_linesearch_cache, __T_trustregion_cache, Nothing, Nothing, __T_termination_cache, __T_trace, __T_kwargs, SciMLBase.NoInit} where {__T_fu, __T_u, __T_u_cache, __T_p, __T_alg<:NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm, __T_prob<:SciMLBase.AbstractNonlinearProblem, __T_globalization<:Union{Val{:LineSearch}, Val{:TrustRegion}, Val{:None}}, __T_jac_cache, __T_descent_cache, __T_forcing_cache, __
T_linesearch_cache, __T_trustregion_cache, __T_termination_cache, __T_trace, __T_kwargs}}, Union{NonlinearSolveBase.NonlinearSolveForwardDiffCache{_A, __T_prob, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}, __T_p, _B, __T_partials_p} where {_A, __T_prob<:SciMLBase.AbstractNonlinearProblem, __T_p<:(Unio
n{ForwardDiff.Dual{T, V, P}, AbstractArray{<:ForwardDiff.Dual{T, V, P}}} where {T, V, P}), _B, __T_partials_p<:ForwardDiff.Partials}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{__T_fu, __T_u, __T_u_cache, __T_p, __T_alg, __T_prob, __T_globalization, __T_jac_cache, __T_descent_cache, __T_forcing_cache, __T_linesearch_cache, __T_trustregion_cache, Nothing, Nothing, __T_termination_cache, __T_trace, __T_kwargs, SciMLBase.NoInit} where {__T_fu, __T_u, __T_u_cache, __T_p, __T_alg<:NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm, __T_prob<:SciMLBase.AbstractNonlinearProblem, __T_globalization<:Union{Val{:LineSea
rch}, Val{:TrustRegion}, Val{:None}}, __T_jac_cache, __T_descent_cache, __T_forcing_cache, __T_linesearch_cache, __T_trustregion_cache, __T_termination_cache, __T_trace, __T_kwargs}}}, _A, _B, _C, _D}) (0 children)                                                                                                                                                                                                                                                                         
                 2: signature NonlinearSolveBase.tuple triggered MethodInstance for CommonSolve.solve!(::NonlinearSolveBase.NonlinearSolvePolyAlgorithmCache{Val{6}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Vector{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Base.Pairs{Symbol, Union{
}, Nothing, @NamedTuple{}}, Nothing, Nothing}, Tuple{NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, ADTypes.AutoForwardDiff{nothing, Nothing}, ADTypes.AutoFiniteDiff{Val{:forward}, Val{:forward}, Val{:hcentral}, Nothing, Nothing, Bool}, ADTypes.AutoForwardDiff{nothing, Nothing}, Val{false}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Vector{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecializ
e, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, Nothing, Nothing}, Val{:None}, NonlinearSolveBase.JacobianCache{Matrix{Float64}, NonlinearSolveBase.FixedShapeJacobianDestination{Float64, Matrix{Float64}}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64},
 Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Vector{Float64}, Vector{Float64}, ADTypes.AutoForwardDiff{nothing, Nothing}, DifferentiationInterfaceForwardDiffExt.ForwardDiffOneArgJacobianPrep{Nothing, ForwardDiff.JacobianConfig{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, 
Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Float64}, Float64, 3, Vector{ForwardDiff.Dual{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Float64}, Float64, 3}}}, Tupl
e{Nothing}}}, NonlinearSolveBase.NewtonDescentCache{Vector{Float64}, Nothing, NonlinearSolveBase.LinearSolveJLCache{LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, NonlinearSolveBase.LinearSolveParameters{Vector{Float64}, Vector{Float64}}, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, LinearSolve._GenericLUFactorizationCache{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Vector{Int64}, Vecto
r{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Vector{Int64}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearSolve.AppleAccelerateLUCache{Matrix{Float64}, Vector{Int32}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Base.RefValue{Int64}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Matrix{Float64}, Vector
{Float64}, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{false}, Bool, LinearSolve.LinearSolveAdjoint{Missing, Missing, Missing}, Nothing}, Nothing}, Nothing, Nothing, Nothing, Val{false}, Val{false}}, Nothing, Nothing, Nothing, Nothing, Nothing, NonlinearSolveBase.NonlinearTerminationModeCache{Vector{Float64}, Float64, NonlinearSolveBase.AbsNormSafeBestTerminationMode{typeof(NonlinearSolveBase.L2_NORM), Nothing, Int64, Float64, Int64}, Float64, Vector{Float64}, Nothing, Nothing, Vector{Float64}, Int64, Vector{Float64}}, NonlinearSolveBase.NonlinearSolveTrace{Val{fa
lse}, Val{false}, Nothing, NonlinearSolveBase.NonlinearSolveTracing{Val{:minimal}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Vector{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, Nothing, Nothing}}, Base.Pairs{Symbol, Union{}, Nothi
ng, @NamedTuple{}}, SciMLBase.NoInit, NonlinearSolveBase.NonlinearVerbosity{true, SciMLLogging.None}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, ADTypes.AutoForwardDiff{nothing, Nothing}, ADTypes.AutoFiniteDiff{Val{:forward}, Val{:forward}, Val{:hcentral}, Nothing, No
thing, Bool}, ADTypes.AutoForwardDiff{nothing, Nothing}, Val{true}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Vector{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, Nothing, Nothing}, Val{:TrustRegion}, NonlinearSolveBase.JacobianCac
he{Matrix{Float64}, NonlinearSolveBase.FixedShapeJacobianDestination{Float64, Matrix{Float64}}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Vector{Float64}, Vector{Float64}, ADTypes.AutoForwardDiff{nothing, Nothing}, DifferentiationInterfaceForwardDiffExt.ForwardDiffOneArgJacobianPrep{Nothing, ForwardDiff.Jacobia
nConfig{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Float64}, Float64, 3, Vector{ForwardDiff.Dual{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{B
ool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Float64}, Float64, 3}}}, Tuple{Nothing}}}, NonlinearSolveBase.DampedNewtonDescentCache{Matrix{Float64}, Vector{Float64}, Nothing, NonlinearSolveBase.LinearSolveJLCache{LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, NonlinearSolveBase.LinearSolveParameters{Vector{Float64}, Vector{Float64}}, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, LinearA
lgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, LinearSolve._GenericLUFactorizationCache{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Vector{Int64}, Vector{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Vector{Int64}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearSolve.AppleAccelerateLUCache{Matrix{Float64}, Vector{Int32}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.
LU{Float64, Matrix{Float64}, Vector{Int64}}, Base.RefValue{Int64}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Matrix{Float64}, Vector{Float64}, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{false}, Bool, LinearSolve.LinearSolveAdjoint{Missing, Missing, Missing}, Nothing}, Nothing}, Nothing, Nothing, Vector{Float64}, NonlinearSolveFirstOrder.LevenbergMarquardtDampingCache{Float64, Float64, Float64, Float64, Float64, LinearAlgebra.Diagonal{Float64, Vector{Float64}},
 Vector{Float64}, LinearAlgebra.Diagonal{Float64, Vector{Float64}}, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}, Float64}, Nothing, Val{false}, Val{:least_squares}, Nothing}, Nothing, Nothing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegionCache{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Ve
ctor{Float64}, Nothing}, Vector{Float64}, Float64, Vector{Float64}, Float64, typeof(NonlinearSolveBase.L2_NORM), Float64, Vector{Float64}, Vector{Float64}}, Nothing, Nothing, NonlinearSolveBase.NonlinearTerminationModeCache{Vector{Float64}, Float64, NonlinearSolveBase.AbsNormSafeBestTerminationMode{typeof(NonlinearSolveBase.L2_NORM), Nothing, Int64, Float64, Int64}, Float64, Vector{Float64}, Nothing, Nothing, Vector{Float64}, Int64, Vector{Float64}}, NonlinearSolveBase.NonlinearSolveTrace{Val{false}, Val{false}, Nothing, NonlinearSolveBase.NonlinearSolveTracing{Val{:minimal}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64},
 false, Vector{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, Nothing, Nothing}}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, SciMLBase.NoInit, NonlinearSolveBase.NonlinearVerbosity{true, SciMLLogging.None}}, NonlinearSolveFirstOrder.Generalized
FirstOrderAlgorithmCache{Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, ADTypes.AutoForwardDiff{nothing, Nothing}, ADTypes.AutoFiniteDiff{Val{:forward}, Val{:forward}, Val{:hcentral}, Nothing, Nothing, Bo
ol}, ADTypes.AutoForwardDiff{nothing, Nothing}, Val{false}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Vector{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, Nothing, Nothing}, Val{:TrustRegion}, NonlinearSolveBase.JacobianCache{Matri
x{Float64}, NonlinearSolveBase.FixedShapeJacobianDestination{Float64, Matrix{Float64}}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Vector{Float64}, Vector{Float64}, ADTypes.AutoForwardDiff{nothing, Nothing}, DifferentiationInterfaceForwardDiffExt.ForwardDiffOneArgJacobianPrep{Nothing, ForwardDiff.JacobianConfig{
ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Float64}, Float64, 3, Vector{ForwardDiff.Dual{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, No
thing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Float64}, Float64, 3}}}, Tuple{Nothing}}}, NonlinearSolveBase.DoglegCache{Vector{Float64}, Nothing, NonlinearSolveBase.NewtonDescentCache{Vector{Float64}, Nothing, NonlinearSolveBase.LinearSolveJLCache{LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, NonlinearSolveBase.LinearSolveParameters{Vector{Float64}, Vector{Float64}}, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64
}, Vector{Int64}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, LinearSolve._GenericLUFactorizationCache{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Vector{Int64}, Vector{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Vector{Int64}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearSolve.AppleAccelerateLUCache{Matrix{Float64}, Vector{Int32}, Base.RefValue{Int
32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Base.RefValue{Int64}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Matrix{Float64}, Vector{Float64}, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{false}, Bool, LinearSolve.LinearSolveAdjoint{Missing, Missing, Missing}, Nothing}, Nothing}, Nothing, Nothing, Nothing, Val{false}, Val{false}}, NonlinearSolveBase.SteepestDescentCache{Vector{Float64}, Nothing, Nothing, Nothing, Val{false}}, typeof(Non
linearSolveBase.L2_NORM), Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}, Val{false}, Val{false}}, Nothing, Nothing, NonlinearSolveFirstOrder.GenericTrustRegionSchemeCache{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Vector{Float64}, Float6
4, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Nothing, Nothing, Vector{Float64}, Vector{Float64}, Nothing, typeof(NonlinearSolveBase.L2_NORM), Vector{Float64}, Vector{Float64}, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}}, Nothing, Nothing, NonlinearSolveBase.NonlinearTerminationModeCache{Vector{Float64}, Float64, NonlinearSolveBase.AbsNormSafeBestTerminationMode{typeof(NonlinearSol
veBase.L2_NORM), Nothing, Int64, Float64, Int64}, Float64, Vector{Float64}, Nothing, Nothing, Vector{Float64}, Int64, Vector{Float64}}, NonlinearSolveBase.NonlinearSolveTrace{Val{false}, Val{false}, Nothing, NonlinearSolveBase.NonlinearSolveTracing{Val{:minimal}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Vector{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBa
se.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, Nothing, Nothing}}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, SciMLBase.NoInit, NonlinearSolveBase.NonlinearVerbosity{true, SciMLLogging.None}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{LineSearch.BackTracking{Nothing, Float64, Float64, Float64, Val{3}, Float64, Bool}, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, ADTypes.AutoForwardDiff{n
othing, Nothing}, ADTypes.AutoFiniteDiff{Val{:forward}, Val{:forward}, Val{:hcentral}, Nothing, Nothing, Bool}, ADTypes.AutoForwardDiff{nothing, Nothing}, Val{false}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Vector{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Base.Pairs{Symbol, Uni
on{}, Nothing, @NamedTuple{}}, Nothing, Nothing}, Val{:LineSearch}, NonlinearSolveBase.JacobianCache{Matrix{Float64}, NonlinearSolveBase.FixedShapeJacobianDestination{Float64, Matrix{Float64}}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Vector{Float64}, Vector{Float64}, ADTypes.AutoForwardDiff{nothing, Nothing},
 DifferentiationInterfaceForwardDiffExt.ForwardDiffOneArgJacobianPrep{Nothing, ForwardDiff.JacobianConfig{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Float64}, Float64, 3, Vector{ForwardDiff.Dual{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctio
nWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Float64}, Float64, 3}}}, Tuple{Nothing}}}, NonlinearSolveBase.NewtonDescentCache{Vector{Float64}, Nothing, NonlinearSolveBase.LinearSolveJLCache{LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, NonlinearSolveBase.LinearSolveParameters{Vector{Float64}, Vector{Float64}}, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSo
lverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, LinearSolve._GenericLUFactorizationCache{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Vector{Int64}, Vector{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Vector{Int64}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearSolve.AppleAccelerateLUCache{
Matrix{Float64}, Vector{Int32}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Base.RefValue{Int64}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Matrix{Float64}, Vector{Float64}, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{false}, Bool, LinearSolve.LinearSolveAdjoint{Missing, Missing, Missing}, Nothing}, Nothing}, Nothing, Nothing, Nothing, Val{false}, Val{false}}, Nothing, LineSearch.BackTrackingCache{SciMLBase.NonlinearF
unction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Vector{Float64}, LineSearch.var"#9#10"{typeof(+), typeof(*), SciMLBase.NLStats}, LineSearch.var"#11#12"{typeof(+), typeof(*), SciMLBase.NLStats}, Float64, Float64, LineSearch.var"#_get_deriv_op##0#_get_deriv_op##1"{SciMLJacobianOperators.JacobianOperator{false, Float64, SciMLJacobianOperat
ors.JVP, SciMLJacobianOperators.var"#32#33"{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, DifferentiationInterfaceForwardDiffExt.ForwardDiffOneArgPushforwardPrep{Nothing, ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, C
urveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Float64}, Vector{ForwardDiff.Dual{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{
Float64}, Nothing}, Float64}, Float64, 1}}, Tuple{Nothing}}, ADTypes.AutoForwardDiff{nothing, Nothing}}, Nothing, Tuple{Int64, Int64}, Vector{Float64}, Vector{Float64}}}, Vector{Float64}, Vector{Float64}, SciMLBase.NLStats, LineSearch.BackTracking{Nothing, Float64, Float64, Float64, Val{3}, Float64, Bool}}, Nothing, Nothing, Nothing, NonlinearSolveBase.NonlinearTerminationModeCache{Vector{Float64}, Float64, NonlinearSolveBase.AbsNormSafeBestTerminationMode{typeof(NonlinearSolveBase.L2_NORM), Nothing, Int64, Float64, Int64}, Float64, Vector{Float64}, Nothing, Nothing, Vector{Float64}, Int64, Vector{Float64}}, NonlinearSolveBase.Nonl
inearSolveTrace{Val{false}, Val{false}, Nothing, NonlinearSolveBase.NonlinearSolveTracing{Val{:minimal}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Vector{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, Nothing, Nothing}}, Base.Pairs{
Symbol, Union{}, Nothing, @NamedTuple{}}, SciMLBase.NoInit, NonlinearSolveBase.NonlinearVerbosity{true, SciMLLogging.None}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Fan, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDe
scent{Nothing}}, Nothing, ADTypes.AutoForwardDiff{nothing, Nothing}, ADTypes.AutoFiniteDiff{Val{:forward}, Val{:forward}, Val{:hcentral}, Nothing, Nothing, Bool}, ADTypes.AutoForwardDiff{nothing, Nothing}, Val{false}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Vector{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing
, Vector{Float64}, Nothing}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, Nothing, Nothing}, Val{:TrustRegion}, NonlinearSolveBase.JacobianCache{Matrix{Float64}, NonlinearSolveBase.FixedShapeJacobianDestination{Float64, Matrix{Float64}}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Vector{Float64}, Vector{
Float64}, ADTypes.AutoForwardDiff{nothing, Nothing}, DifferentiationInterfaceForwardDiffExt.ForwardDiffOneArgJacobianPrep{Nothing, ForwardDiff.JacobianConfig{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Float64}, Float64, 3, Vector{ForwardDiff.Dual{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false,
 SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Float64}, Float64, 3}}}, Tuple{Nothing}}}, NonlinearSolveBase.DoglegCache{Vector{Float64}, Nothing, NonlinearSolveBase.NewtonDescentCache{Vector{Float64}, Nothing, NonlinearSolveBase.LinearSolveJLCache{LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, NonlinearSolveBase.LinearSo
lveParameters{Vector{Float64}, Vector{Float64}}, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, LinearSolve._GenericLUFactorizationCache{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Vector{Int64}, Vector{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Vector{Int64}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Flo
at64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearSolve.AppleAccelerateLUCache{Matrix{Float64}, Vector{Int32}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Base.RefValue{Int64}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Matrix{Float64}, Vector{Float64}, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{false}, Bool, LinearSolve.LinearSolveAdjoint{Missing, Missing, Missing}, Nothing}, Nothing}, N
othing, Nothing, Nothing, Val{false}, Val{false}}, NonlinearSolveBase.SteepestDescentCache{Vector{Float64}, Nothing, Nothing, Nothing, Val{false}}, typeof(NonlinearSolveBase.L2_NORM), Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}, Val{false}, Val{false}}, Nothing, Nothing, NonlinearSolveFirstOrder.GenericTrustRegionSchemeCache{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Fan, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, No
thing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Vector{Float64}, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Float64, Nothing, Nothing, Vector{Float64}, Vector{Float64}, Nothing, typeof(NonlinearSolveBase.L2_NORM), Vector{Float64}, Vector{Float64}, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Fan, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}}, Nothing, N
othing, NonlinearSolveBase.NonlinearTerminationModeCache{Vector{Float64}, Float64, NonlinearSolveBase.AbsNormSafeBestTerminationMode{typeof(NonlinearSolveBase.L2_NORM), Nothing, Int64, Float64, Int64}, Float64, Vector{Float64}, Nothing, Nothing, Vector{Float64}, Int64, Vector{Float64}}, NonlinearSolveBase.NonlinearSolveTrace{Val{false}, Val{false}, Nothing, NonlinearSolveBase.NonlinearSolveTracing{Val{:minimal}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Vector{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#
fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, Nothing, Nothing}}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, SciMLBase.NoInit, NonlinearSolveBase.NonlinearVerbosity{true, SciMLLogging.None}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache{Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Nonlinear
SolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, ADTypes.AutoForwardDiff{nothing, Nothing}, ADTypes.AutoFiniteDiff{Val{:forward}, Val{:forward}, Val{:hcentral}, Nothing, Nothing, Bool}, ADTypes.AutoForwardDiff{nothing, Nothing}, Val{true}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Vector{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{fal
se, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, Nothing, Nothing}, Val{:TrustRegion}, NonlinearSolveBase.JacobianCache{Matrix{Float64}, NonlinearSolveBase.FixedShapeJacobianDestination{Float64, Matrix{Float64}}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"
}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Vector{Float64}, Vector{Float64}, ADTypes.AutoForwardDiff{nothing, Nothing}, DifferentiationInterfaceForwardDiffExt.ForwardDiffOneArgJacobianPrep{Nothing, ForwardDiff.JacobianConfig{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothin
g, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Float64}, Float64, 3, Vector{ForwardDiff.Dual{ForwardDiff.Tag{SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Float64}, Float64, 3}}}, Tuple{Nothing}}}, NonlinearSolveBase.
GeodesicAccelerationCache{Vector{Float64}, Nothing, NonlinearSolveBase.DampedNewtonDescentCache{Matrix{Float64}, Vector{Float64}, Vector{Vector{Float64}}, NonlinearSolveBase.LinearSolveJLCache{LinearSolve.LinearCache{Matrix{Float64}, Vector{Float64}, Vector{Float64}, NonlinearSolveBase.LinearSolveParameters{Vector{Float64}, Vector{Float64}}, LinearSolve.DefaultLinearSolver, LinearSolve.DefaultLinearSolverInit{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, LinearAlgebra.QRCompactWY{Float64, Matrix{Float64}, Matrix{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, LinearSolve._GenericLUFactorizationCache{Li
nearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Vector{Int64}, Vector{Float64}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Vector{Int64}}, Nothing, Nothing, Nothing, LinearAlgebra.SVD{Float64, Float64, Matrix{Float64}, Vector{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearAlgebra.Cholesky{Float64, Matrix{Float64}}, LinearSolve.AppleAccelerateLUCache{Matrix{Float64}, Vector{Int32}, Base.RefValue{Int32}}, Tuple{LinearAlgebra.LU{Float64, Matrix{Float64}, Vector{Int64}}, Base.RefValue{Int64}}, LinearAlgebra.QRPivoted{Float64, Matrix{Float64}, Vector{Float64}, Vector{Int64}}, Nothing, 
Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Matrix{Float64}, Vector{Float64}, Nothing}, SciMLOperators.IdentityOperator, SciMLOperators.IdentityOperator, Float64, LinearSolve.LinearVerbosity{false}, Bool, LinearSolve.LinearSolveAdjoint{Missing, Missing, Missing}, Nothing}, Nothing}, Nothing, Nothing, Vector{Float64}, NonlinearSolveFirstOrder.LevenbergMarquardtDampingCache{Float64, Float64, Float64, Float64, Float64, LinearAlgebra.Diagonal{Float64, Vector{Float64}}, Vector{Float64}, LinearAlgebra.Diagonal{Float64, Vector{Float64}}, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}, Float
64}, Nothing, Val{false}, Val{:least_squares}, Nothing}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Vector{Float64}, Float64, typeof(NonlinearSolveBase.L2_NORM), Float64, Vector{Float64}, Vector{Float64}, Vector{Float64}}, Nothing, Nothing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegionCache{SciMLBase.No
nlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Vector{Float64}, Float64, Vector{Float64}, Float64, typeof(NonlinearSolveBase.L2_NORM), Float64, Vector{Float64}, Vector{Float64}}, Nothing, Nothing, NonlinearSolveBase.NonlinearTerminationModeCache{Vector{Float64}, Float64, NonlinearSolveBase.AbsNormSafeBestTerminationMode{typeof(
NonlinearSolveBase.L2_NORM), Nothing, Int64, Float64, Int64}, Float64, Vector{Float64}, Nothing, Nothing, Vector{Float64}, Int64, Vector{Float64}}, NonlinearSolveBase.NonlinearSolveTrace{Val{false}, Val{false}, Nothing, NonlinearSolveBase.NonlinearSolveTracing{Val{:minimal}}, SciMLBase.NonlinearLeastSquaresProblem{Vector{Float64}, false, Vector{Float64}, SciMLBase.NonlinearFunction{false, SciMLBase.AutoSpecialize, CurveFit.NonlinearFunctionWrapper{false, Vector{Float64}, Nothing, CurveFit.var"#fn#fn##0"}, LinearAlgebra.UniformScaling{Bool}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, ty
peof(SciMLBase.DEFAULT_OBSERVED_NO_TIME), Nothing, Nothing, Vector{Float64}, Nothing}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, Nothing, Nothing}}, Base.Pairs{Symbol, Union{}, Nothing, @NamedTuple{}}, SciMLBase.NoInit, NonlinearSolveBase.NonlinearVerbosity{true, SciMLLogging.None}}}, NonlinearSolveBase.NonlinearSolvePolyAlgorithm{Val{6}, Tuple{NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRe
gion{Float64}, NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Nothing, Nothing, Nothing, Nothing, Val{true}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Simple, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.SteepestDescent{Nothing}}, Nothing, Nothing, Nothing,
 Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{LineSearch.BackTracking{Nothing, Float64, Float64, Float64, Val{3}, Float64, Bool}, Missing, NonlinearSolveBase.NewtonDescent{Nothing}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.GenericTrustRegionScheme{NonlinearSolveFirstOrder.RadiusUpdateSchemes.__Fan, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}, Rational{Int64}}, NonlinearSolveBase.Dogleg{NonlinearSolveBase.NewtonDescent{Nothing}, NonlinearSolveBase.
SteepestDescent{Nothing}}, Nothing, Nothing, Nothing, Nothing, Val{false}}, NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithm{Missing, NonlinearSolveFirstOrder.LevenbergMarquardtTrustRegion{Float64}, NonlinearSolveBase.GeodesicAcceleration{NonlinearSolveBase.DampedNewtonDescent{Nothing, Float64, NonlinearSolveFirstOrder.LevenbergMarquardtDampingFunction{Float64, Float64, Float64}}, Float64, Float64}, Nothing, Nothing, Nothing, Nothing, Val{true}}}, Val{false}}, Vector{Float64}, Vector{Float64}, Nothing, typeof(NonlinearSolveBase.L2_NORM), Vector{Float64}, Vector{Float64}, NonlinearSolveBase.NonlinearSolveDefaultInit, Nonlinea
rSolveBase.NonlinearVerbosity{true, SciMLLogging.None}}) (0 children)                                                                                          
```

Debugged with Claude :robot: 

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API