### PR TITLE
Let solve_cache! drive a polyalgorithm cache

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.46.0"
+version = "2.47.0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
+++ b/lib/NonlinearSolveBase/src/NonlinearSolveBase.jl
@@ -139,7 +139,7 @@ include("forward_diff.jl")
         get_precondition, get_postcondition, supports_postcondition,
     )
 )
-@compat(public, (get_u, get_fu, get_nsteps))
+@compat(public, (get_u, get_fu, get_nsteps, get_termination_cache, get_trace))
 @compat(public, (supports_deferred_residual, refresh_residual!))
 @compat(public, (residual_only_termination_mode, trace_is_active))
 @compat(public, (NonlinearSolveNoInitCache,))

--- a/lib/NonlinearSolveBase/src/abstract_types.jl
+++ b/lib/NonlinearSolveBase/src/abstract_types.jl
@@ -733,6 +733,42 @@ end
 SciMLBase.isinplace(cache::AbstractNonlinearSolveCache) = SciMLBase.isinplace(cache.prob)
 
 """
+    get_trace(cache::AbstractNonlinearSolveCache)
+
+Return the trace object a solver cache records its iteration history into.
+
+The default returns `cache.trace`. Caches that keep it elsewhere should overload this hook,
+such as a polyalgorithm forwarding to its active subsolver.
+
+# Examples
+
+```julia
+trace = NonlinearSolveBase.get_trace(cache)
+```
+"""
+function get_trace(cache::AbstractNonlinearSolveCache)
+    return cache.trace
+end
+
+"""
+    get_termination_cache(cache::AbstractNonlinearSolveCache)
+
+Return the termination-condition cache through which a solver cache reports its status.
+
+The default returns `cache.termination_cache`. Caches that keep it elsewhere should overload
+this hook, such as a polyalgorithm forwarding to its active subsolver.
+
+# Examples
+
+```julia
+tc = NonlinearSolveBase.get_termination_cache(cache)
+```
+"""
+function get_termination_cache(cache::AbstractNonlinearSolveCache)
+    return cache.termination_cache
+end
+
+"""
     get_abstol(cache::AbstractNonlinearSolveCache) -> Real
 
 Return the absolute tolerance currently stored in a nonlinear solver cache or problem.
@@ -759,7 +795,7 @@ abstol = NonlinearSolveBase.get_abstol(cache)
 ```
 """
 function get_abstol(cache::AbstractNonlinearSolveCache)
-    return get_abstol(cache.termination_cache)
+    return get_abstol(get_termination_cache(cache))
 end
 
 """
@@ -789,7 +825,7 @@ reltol = NonlinearSolveBase.get_reltol(cache)
 ```
 """
 function get_reltol(cache::AbstractNonlinearSolveCache)
-    return get_reltol(cache.termination_cache)
+    return get_reltol(get_termination_cache(cache))
 end
 
 ## SII Interface

--- a/lib/NonlinearSolveBase/src/polyalg.jl
+++ b/lib/NonlinearSolveBase/src/polyalg.jl
@@ -123,6 +123,17 @@ end
     verbose
 end
 
+# A polyalgorithm holds no termination cache of its own; the subsolver it is currently
+# running owns one. Forwarding lets `solve_cache!`, `get_abstol` and `get_reltol` work on a
+# polyalgorithm cache instead of throwing `has no field termination_cache`.
+function get_termination_cache(cache::NonlinearSolvePolyAlgorithmCache)
+    return get_termination_cache(cache.caches[cache.current])
+end
+
+function get_trace(cache::NonlinearSolvePolyAlgorithmCache)
+    return get_trace(cache.caches[cache.current])
+end
+
 function update_initial_values!(cache::NonlinearSolvePolyAlgorithmCache, u0, p)
     foreach(cache.caches) do subcache
         update_initial_values!(subcache, u0, p)

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -376,10 +376,10 @@ function _run_cache_to_completion!(
     # A driver may have stepped with `evaluate_residual = false`; the residual has to be
     # brought forward before it is reported, since nothing downstream re-evaluates it.
     refresh_residual!(cache)
-    update_from_termination_cache!(cache.termination_cache, cache)
+    update_from_termination_cache!(get_termination_cache(cache), cache)
 
     update_trace!(
-        cache.trace, cache.nsteps, get_u(cache), get_fu(cache), nothing, nothing, nothing;
+        get_trace(cache), cache.nsteps, get_u(cache), get_fu(cache), nothing, nothing, nothing;
         last = Val(true)
     )
 


### PR DESCRIPTION
`NonlinearSolveBase.solve_cache!` throws on a `NonlinearSolvePolyAlgorithmCache`:

```julia
using NonlinearSolve
import NonlinearSolveBase as NLSB

prob = NonlinearProblem((u, p) -> u .^ 2 .- p, [1.5, 1.5], [2.0, 3.0])
NLSB.solve_cache!(init(prob, RobustMultiNewton()))
# ERROR: type NonlinearSolvePolyAlgorithmCache has no field termination_cache
```

It passes the `applicable(InternalAPI.step!, cache)` guard, so it is accepted, and then
`_run_cache_to_completion!` reads `cache.termination_cache` and `cache.trace` as raw fields at
the end. A polyalgorithm has neither: the subsolver it is currently running owns both. It does
have `nsteps`, `retcode` and `maxiters`, which is why it gets all the way to the last few lines
before failing. `FastShortcutNonlinearPolyalg` fails identically.

This follows the hook pattern #1187 just documented for `get_u`, whose docstring names "a
polyalgorithm forwarding to its active subsolver" as the reason such a hook exists. Two more
accessors in the same shape, `get_termination_cache` and `get_trace`, each defaulting to the
field it reads today, with `NonlinearSolvePolyAlgorithmCache` forwarding both to
`caches[current]`. `get_abstol` and `get_reltol` read the same field and now go through the
hook, so those work on a polyalgorithm cache too.

Nothing changes for a cache that has the fields, since the defaults return exactly what the
call sites read before.

## Verified

Same problem, checked against what the normal `solve` path returns:

| | `solve_cache!` | error vs `sqrt.([2, 3])` | agrees with `solve()` | `get_abstol` |
| --- | --- | --- | --- | --- |
| `NewtonRaphson` | Success | 0 | yes | 3e-13 |
| `RobustMultiNewton` | Success | 2.22e-16 | yes | 3e-13 |
| `FastShortcutNonlinearPolyalg` | Success | 4.97e-16 | yes | 3e-13 |
| `TrustRegion` | Success | 2.22e-16 | yes | 3e-13 |

All four throw on master except `NewtonRaphson` and `TrustRegion`, and `get_abstol` on a
polyalgorithm cache throws on master.

`test/Core/cache_solve_tests__item1.jl`, the file #1187 extended, passes.

## Why

`ImplicitDiscreteSolve` drives its stage solve through `solve_cache!` so it can use the step
observer, and today it cannot accept a polyalgorithm as `nlsolve` because of this
(SciML/OrdinaryDiffEq.jl#4138). The `NonlinearSolveNoInitCache` branch #1187 documented covers
the SimpleNonlinearSolve half; this covers the other one.

## AI Disclosure

Claude assisted with this work.
