### PR TITLE
Add dependabot for julia updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,26 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "julia"
+    directories:
+      - "/"
+      - "/docs"
+      - "/lib/*"
+      - "/lib/*/test/*"
+      - "/test/Adjoint"
+      - "/test/Bounds"
+      - "/test/Downstream"
+      - "/test/gpu"
+      - "/test/qa"
+      - "/test/trim"
+      - "/test/Wrappers"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      all-julia-packages:
+        # One PR per dependency spanning every directory, so a compat bump lands
+        # in all of the sublibraries at once rather than one package at a time.
+        group-by: dependency-name
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,7 @@ updates:
       - "/docs"
       - "/lib/*"
       - "/lib/*/test/*"
-      - "/test/Adjoint"
-      - "/test/Bounds"
-      - "/test/Downstream"
-      - "/test/gpu"
-      - "/test/qa"
-      - "/test/trim"
-      - "/test/Wrappers"
+      - "/test/*"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This adds a dependabot setup for julia updates and therefore closes #1183. For some reason #954 just removed the CompatHelper setup without adding an analogous dependabot setting. This looks unintended to me (the bot wrote "Remove retired `CompatHelper.yml` (Dependabot drives `[compat]`)", which is wrong). I used the same setup as in OrdinaryDiffEq.jl adapted to this repo. Once this is merged, dependabot will probably create a few PRs updating compat bounds. I would be thankful if these are handled timely, such that packages depending on NonlinearSolve.jl can update their compats as well to allow for newer versions.
