### PR TITLE
Release 9 sub-libraries

### DIFF
--- a/lib/BracketingNonlinearSolve/Project.toml
+++ b/lib/BracketingNonlinearSolve/Project.toml
@@ -1,6 +1,6 @@
 name = "BracketingNonlinearSolve"
 uuid = "70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
-version = "1.12.5"
+version = "1.12.6"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveFirstOrder/Project.toml
+++ b/lib/NonlinearSolveFirstOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveFirstOrder"
 uuid = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "2.4.0"
+version = "2.4.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -50,7 +50,7 @@ PrecompileTools = "1.2"
 Random = "1.10"
 Reexport = "1.2.2"
 SciMLBase = "3.37"
-SciMLJacobianOperators = "0.1.17"
+SciMLJacobianOperators = "0.1.18"
 SciMLLogging = "2"
 SciMLOperators = "1.24"
 Setfield = "1.1.2"

--- a/lib/NonlinearSolveHomotopyContinuation/Project.toml
+++ b/lib/NonlinearSolveHomotopyContinuation/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveHomotopyContinuation"
 uuid = "2ac3b008-d579-4536-8c91-a1a5998c2f8b"
 authors = ["Aayush Sabharwal <aayush.sabharwal@gmail.com> and contributors"]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/NonlinearSolveQuasiNewton/Project.toml
+++ b/lib/NonlinearSolveQuasiNewton/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveQuasiNewton"
 uuid = "9a2c21bd-3a47-402d-9113-8faf9a0ee114"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.15.1"
+version = "1.15.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/lib/NonlinearSolveSciPy/Project.toml
+++ b/lib/NonlinearSolveSciPy/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveSciPy"
 uuid = "4827a3aa-8a82-4c61-8bd0-3c7d3e464ee5"
 authors = ["SciML"]
-version = "1.3.4"
+version = "1.3.5"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/NonlinearSolveSpectralMethods/Project.toml
+++ b/lib/NonlinearSolveSpectralMethods/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveSpectralMethods"
 uuid = "26075421-4e9a-44e1-8bd1-420ed7ad02b2"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.8.0"
+version = "1.8.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/lib/SCCNonlinearSolve/Project.toml
+++ b/lib/SCCNonlinearSolve/Project.toml
@@ -1,6 +1,6 @@
 name = "SCCNonlinearSolve"
 uuid = "9dfe8606-65a1-4bb3-9748-cb89d1561431"
-version = "1.15.0"
+version = "1.15.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]
@@ -36,7 +36,7 @@ LinearAlgebra = "1.10"
 NonlinearProblemLibrary = "0.1.2"
 NonlinearSolve = "4.8"
 NonlinearSolveBase = "2.44"
-NonlinearSolveFirstOrder = "2.1.2"
+NonlinearSolveFirstOrder = "2.4.1"
 PrecompileTools = "1.2"
 SciMLBase = "3.46"
 StableRNGs = "1"

--- a/lib/SciMLJacobianOperators/Project.toml
+++ b/lib/SciMLJacobianOperators/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLJacobianOperators"
 uuid = "19f34311-ddf3-4b8b-af20-060888a46c0e"
-version = "0.1.17"
+version = "0.1.18"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/SimpleNonlinearSolve/Project.toml
+++ b/lib/SimpleNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleNonlinearSolve"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 authors = ["SciML"]
-version = "2.14.0"
+version = "2.14.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -43,7 +43,7 @@ SimpleNonlinearSolveTrackerExt = "Tracker"
 [compat]
 ADTypes = "1.13"
 ArrayInterface = "7.16"
-BracketingNonlinearSolve = "1.6"
+BracketingNonlinearSolve = "1.12.6"
 ChainRulesCore = "1.24"
 CommonSolve = "0.2.4"
 ConcreteStructs = "0.2.3"


### PR DESCRIPTION
Sub-libraries whose registered tree has drifted from `master` are bumped and released together.

- `BracketingNonlinearSolve` 1.12.5 -> 1.12.6 (patch)
- `NonlinearSolveFirstOrder` 2.4.0 -> 2.4.1 (patch)
- `NonlinearSolveHomotopyContinuation` 0.1.11 -> 0.1.12 (patch)
- `NonlinearSolveQuasiNewton` 1.15.1 -> 1.15.2 (patch)
- `NonlinearSolveSciPy` 1.3.4 -> 1.3.5 (patch)
- `NonlinearSolveSpectralMethods` 1.8.0 -> 1.8.1 (patch)
- `SCCNonlinearSolve` 1.15.0 -> 1.15.1 (patch)
- `SciMLJacobianOperators` 0.1.17 -> 0.1.18 (patch)
- `SimpleNonlinearSolve` 2.14.0 -> 2.14.1 (patch)

Inter-sub-library `[compat]` lower bounds are raised to the new versions in the same commit, so a resolved set never mixes a new sub-library with an older sibling it was not tested against. All bumps are patch/minor - no exported name is removed anywhere in this set, so nothing here is breaking and no retroactive cap is required.

For `0.x` sub-libraries the patch slot is used, since the minor is the breaking axis under Julia's SemVer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R