### PR TITLE
Release NonlinearSolveBase 2.48.0

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.47.0"
+version = "2.48.0"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
PR #1189 (`Let solve_cache! drive a polyalgorithm cache`) bumped `lib/NonlinearSolveBase` to `2.47.0`, but **2.47.0 was already registered** from a different commit (registered tree `6f61af71`, current tree `c2b6f224`). Registering the current tree as 2.47.0 is impossible, so this moves to `2.48.0`.

**Minor**, not patch: #1189 adds `get_termination_cache` and `get_trace` to the `@compat(public, ...)` declaration in `NonlinearSolveBase.jl`, so the public surface grew.

This is the release required to consume #1189 - it is what lets `solve_cache!` accept a polyalgorithm cache (`RobustMultiNewton`, `FastShortcutNonlinearPolyalg`), unblocking `ImplicitDiscreteSolve` from taking a polyalgorithm as `nlsolve` (SciML/OrdinaryDiffEq.jl#4138).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R