### PR TITLE
Render cache accessor docs

### DIFF
--- a/docs/src/devdocs/internal_interfaces.md
+++ b/docs/src/devdocs/internal_interfaces.md
@@ -118,6 +118,8 @@ The public stepping entry point is `CommonSolve.step!`, while the
 allocation-sensitive completion entry point is `NonlinearSolveBase.solve_cache!`.
 
 ```@docs
+NonlinearSolveBase.get_termination_cache
+NonlinearSolveBase.get_trace
 NonlinearSolveBase.solve_cache!
 ```
 


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Render `NonlinearSolveBase.get_termination_cache` and `NonlinearSolveBase.get_trace` in the developer API documentation. They became public in https://github.com/SciML/NonlinearSolve.jl/commit/2db9bd8e85162fc6f2d8e8c96ac7b379ef974a39, but were not added to an `@docs` block, causing the `NonlinearSolveBase` QA group to fail on `master`.

## Failing before / passing after

On unmodified `master` at `7a9c9044b1f30028a41736ed3f4156d351919f6b`:

```text
public API is rendered in docs: Test Failed
  Evaluated: isempty([:get_termination_cache, :get_trace])

Test Summary: | Pass  Fail  Total   Time
QA            |   19     1     20  52.5s
```

The parent of the introducing commit, `7fb68dc4d1e400e898ca584596fe529a2461155f`, passes the same command:

```text
Test Summary: | Pass  Total   Time
QA            |   20     20  53.1s
     Testing NonlinearSolveBase tests passed
```

With this patch applied:

```text
Test Summary: | Pass  Total   Time
QA            |   20     20  56.2s
     Testing NonlinearSolveBase tests passed
```

Command:

```bash
GROUP=QA timeout 3600 /home/crackauc/.juliaup/bin/julia +release \
  --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test()'
```

## Additional verification

```bash
export TMPDIR=/home/crackauc/tmp
export PIXI_CACHE_DIR="$PWD/docs/.pixi-cache"
export RATTLER_CACHE_DIR="$PWD/docs/.pixi-cache"
timeout 3600 /home/crackauc/.juliaup/bin/julia +release --project=docs docs/make.jl
```

```text
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
[ Info: Automatic `version="4.28.0"` for inventory from ../Project.toml
[ Warning: Documenter could not auto-detect the building environment. Skipping deployment.
Process exited with code 0
```

Also run:

- `git diff --check` — no output.
- `typos docs/src/devdocs/internal_interfaces.md` — no output.
- Runic — no changed Julia files to format.

## Not verified

GPU, downstream, and allowed-to-fail jobs were not run; this patch changes only a rendered `@docs` list. The two entries are grouped with cache-driving developer hooks; a reviewer may prefer the adjacent cache-state section instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01NB3oFTNzGW79UtDt8AyjsM
