### PR TITLE
Preserve despecialized parameters during reinit

### DIFF
--- a/lib/NonlinearSolveBase/src/abstract_types.jl
+++ b/lib/NonlinearSolveBase/src/abstract_types.jl
@@ -723,11 +723,17 @@ function not_terminated(cache::AbstractNonlinearSolveCache)
     return !cache.force_stop && cache.nsteps < cache.maxiters
 end
 
-function SciMLBase.reinit!(cache::AbstractNonlinearSolveCache; kwargs...)
-    return InternalAPI.reinit!(cache; u = get_u(cache), kwargs...)
+_prepare_reinit_parameters(p, ::Any) = p
+_prepare_reinit_parameters(p, ::SciMLBase.DespecializedParameters) =
+    SciMLBase.DespecializedParameters(p)
+
+function SciMLBase.reinit!(cache::AbstractNonlinearSolveCache; p = cache.p, kwargs...)
+    p = _prepare_reinit_parameters(p, cache.p)
+    return InternalAPI.reinit!(cache; u = get_u(cache), p, kwargs...)
 end
-function SciMLBase.reinit!(cache::AbstractNonlinearSolveCache, u0; kwargs...)
-    return InternalAPI.reinit!(cache; u0, u = get_u(cache), kwargs...)
+function SciMLBase.reinit!(cache::AbstractNonlinearSolveCache, u0; p = cache.p, kwargs...)
+    p = _prepare_reinit_parameters(p, cache.p)
+    return InternalAPI.reinit!(cache; u0, u = get_u(cache), p, kwargs...)
 end
 
 SciMLBase.isinplace(cache::AbstractNonlinearSolveCache) = SciMLBase.isinplace(cache.prob)

--- a/lib/NonlinearSolveBase/src/polyalg.jl
+++ b/lib/NonlinearSolveBase/src/polyalg.jl
@@ -179,11 +179,17 @@ function Base.show(io::IO, ::MIME"text/plain", cache::NonlinearSolvePolyAlgorith
     return NonlinearSolveBase.show_nonlinearsolve_cache(io, cache.caches[cache.current], 4)
 end
 
-function SciMLBase.reinit!(cache::NonlinearSolvePolyAlgorithmCache; kwargs...)
-    return InternalAPI.reinit!(cache; kwargs...)
+function SciMLBase.reinit!(
+        cache::NonlinearSolvePolyAlgorithmCache; p = cache.prob.p, kwargs...
+    )
+    p = _prepare_reinit_parameters(p, cache.prob.p)
+    return InternalAPI.reinit!(cache; p, kwargs...)
 end
-function SciMLBase.reinit!(cache::NonlinearSolvePolyAlgorithmCache, u0; kwargs...)
-    return InternalAPI.reinit!(cache; u0, kwargs...)
+function SciMLBase.reinit!(
+        cache::NonlinearSolvePolyAlgorithmCache, u0; p = cache.prob.p, kwargs...
+    )
+    p = _prepare_reinit_parameters(p, cache.prob.p)
+    return InternalAPI.reinit!(cache; u0, p, kwargs...)
 end
 # Every RETAIN_REPROBE_INTERVAL-th retained `reinit!` whose retained subalgorithm sits
 # above `start_index` starts one solve from `start_index` again instead. Without this,

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -936,6 +936,7 @@ get_u(cache::NonlinearSolveNoInitCache) = SII.state_values(cache.prob)
 function SciMLBase.reinit!(
         cache::NonlinearSolveNoInitCache, u0 = cache.prob.u0; p = cache.prob.p, kwargs...
     )
+    p = _prepare_reinit_parameters(p, cache.prob.p)
     cache.prob = SciMLBase.remake(cache.prob; u0, p)
     cache.kwargs = merge(cache.kwargs, kwargs)
     return cache

--- a/test/Core/autodespecialize_tests__item1.jl
+++ b/test/Core/autodespecialize_tests__item1.jl
@@ -1,4 +1,5 @@
 using NonlinearSolve, SciMLBase, Test
+using SymbolicIndexingInterface: parameter_values
 
 struct SolveDynamicParameters
     rate::Float64
@@ -34,3 +35,14 @@ second_sol = solve!(second_cache)
 @test SciMLBase.successful_retcode(second_sol)
 @test first_sol.u[1] ≈ sqrt(2.0)
 @test second_sol.u[1] ≈ sqrt(3.0)
+
+replacement_parameters = SolveOtherDynamicParameters(4.0, 2)
+for alg in (NewtonRaphson(), SimpleNewtonRaphson(), nothing)
+    cache = init(first_prob, alg)
+    reinit!(cache, [1.0]; p = replacement_parameters)
+    @test parameter_values(cache) isa SciMLBase.DespecializedParameters
+    @test SciMLBase.unwrap_parameters(parameter_values(cache)) === replacement_parameters
+    sol = solve!(cache)
+    @test SciMLBase.successful_retcode(sol)
+    @test sol.u[1] ≈ 2.0
+end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Preserve `AutoDespecialize`'s parameter wrapper when `reinit!` replaces a cache's parameters with a different concrete type. The public cache boundary now normalizes replacement parameters against the wrapper stored by the problem before updating nested Jacobian and linear caches. The same rule covers initialized solver caches, polyalgorithm caches, and `NonlinearSolveNoInitCache` without requiring callers such as OrdinaryDiffEq or ModelingToolkit to know NonlinearSolve's cache representation.

The regression reinitializes Newton, no-init, and default polyalgorithm caches with a new parameter type, verifies that the wrapper contains the current payload, and solves the updated problem. This is the generic replacement for the caller-side workaround in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4325.

## Failing before

With the new regression test but without the source fix, the initialized cache fails before the solve:

```text
AutoDespecialize dynamic parameters: Error During Test
MethodError: Cannot `convert` an object of type SolveOtherDynamicParameters to an object of type SciMLBase.DespecializedParameters
Stacktrace:
  NonlinearSolveBase.InternalAPI.reinit!(::NonlinearSolveBase.JacobianCache; p = ...)
  SciMLBase.reinit!(::NonlinearSolveFirstOrder.GeneralizedFirstOrderAlgorithmCache, ...)
```

The no-init path independently fails on the unfixed source while assigning the remade problem:

```text
MethodError: Cannot `convert` an object of type
  NonlinearProblem{..., SolveOtherDynamicParameters, ...}
to an object of type
  NonlinearProblem{..., SciMLBase.DespecializedParameters, ...}
```

## Passing after

```text
$ julia +1.12 --startup-file=no --project=. -e 'include("test/Core/autodespecialize_tests__item1.jl")'
exit 0

$ NONLINEARSOLVE_TEST_GROUP=Core julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
AutoDespecialize dynamic parameters | 19 pass / 19 total
PolyAlgorithm best-subalgorithm retention (reinit! retain_best) | 46 pass / 46 total
Testing NonlinearSolve tests passed

$ NONLINEARSOLVE_TEST_GROUP=QA julia +1.12 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'
QA | 28 pass / 28 total
Testing NonlinearSolve tests passed
```

I also removed OrdinaryDiffEq's local wrapping expression in a disposable current-master checkout, path-developed this branch's NonlinearSolve and NonlinearSolveBase, and ran the ModelingToolkit Robertson `FBDF` + `NonlinearSolveAlg` reproducer:

```text
ModelingToolkit v11.40.0
NonlinearSolve v4.28.0 <local branch>
NonlinearSolveBase v2.48.0 <local branch>
OrdinaryDiffEqBDF v2.4.5 <local current master>
OrdinaryDiffEqNonlinearSolve v2.9.1 <local current master>
GENERIC_REINIT_ROBERTSON_SUCCESS
exit 0
```

```text
$ julia +1.12 --startup-file=no -m Runic --check <changed Julia files>
exit 0
$ typos --diff <changed paths>
exit 0
$ git diff --check
exit 0
```

## Not verified

GPU, prerelease Julia, docs, and the full `Everything` group were not run locally. No public name, docstring, or documentation was changed.
