### PR TITLE
Release 4.28.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.28.0"
+version = "4.28.1"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Unreleased **source** changes have accumulated on the default branch since the last registered version.

This is a **patch** bump: the exported public surface is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R