### PR TITLE
Continue polyalgorithm after stalled least-squares solves

### DIFF
--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -506,7 +506,8 @@ end
         end
         cache.alias_u0 && copyto!(cache.u0_aliased, cache.u0)
         $(sol_syms[i]) = CommonSolve.solve!($(cache_syms[i]))
-        if SciMLBase.successful_retcode($(sol_syms[i]))
+        if SciMLBase.successful_retcode($(sol_syms[i])) &&
+                $(sol_syms[i]).retcode != ReturnCode.StalledSuccess
             stats = $(sol_syms[i]).stats
             cache.best = $(i)
             if cache.alias_u0

--- a/test/Core/polyalg_stalled_success_tests__item1.jl
+++ b/test/Core/polyalg_stalled_success_tests__item1.jl
@@ -1,0 +1,21 @@
+using NonlinearSolve
+using Test
+
+@testset "cache solve escalates after StalledSuccess" begin
+    x = 1.0:10.0
+    expected = [3.0, 2.0, 0.7]
+    y = @. expected[1] + expected[2] * x^expected[3]
+    residual(u, p) = @. y - (u[1] + u[2] * x^u[3])
+    prob = NonlinearLeastSquaresProblem(
+        residual, [0.5, 0.5, 0.5];
+        lb = zeros(3), ub = [10.0, 10.0, 1.0]
+    )
+
+    direct_sol = solve(prob)
+    cached_sol = solve!(init(prob))
+
+    @test direct_sol.u ≈ expected atol = 1.0e-7
+    @test cached_sol.u ≈ direct_sol.u atol = 1.0e-7
+    @test cached_sol.resid ≈ direct_sol.resid atol = 1.0e-7
+    @test cached_sol.retcode == direct_sol.retcode
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,6 +108,7 @@ else
             @time @safetestset "Homotopy maxsteps guard + effort-band step control" include("Core/homotopy_effort_tests__item2.jl")
             @time @safetestset "Homotopy tracking_abstol loosens interior tracking only" include("Core/homotopy_tolerance_tests__item1.jl")
             @time @safetestset "PolyAlgorithm best-subalgorithm retention (reinit! retain_best)" include("Core/polyalg_retention_tests__item1.jl")
+            @time @safetestset "PolyAlgorithm cache StalledSuccess escalation" include("Core/polyalg_stalled_success_tests__item1.jl")
             @time @safetestset "Homotopy drivers retain the winning inner subalgorithm" include("Core/homotopy_retention_tests__item1.jl")
             @time @safetestset "HomotopyPolyAlgorithm stages, fallback, both-fail" include("Core/homotopy_polyalg_tests__item1.jl")
             @time @safetestset "HomotopyPolyAlgorithm warm sweep→fallback handoff" include("Core/homotopy_polyalg_tests__item2.jl")


### PR DESCRIPTION
Ignore this draft until reviewed by @ChrisRackauckas.

## What changed and why

Cache-based `solve!(init(prob))` returned immediately when the first nonlinear least-squares polyalgorithm rung reported `StalledSuccess`. Direct `solve(prob)` and the step-driven cache path already treat that result as a reason to try the next rung. This makes the cache path follow the same rule and adds a bounded nonlinear least-squares regression covering the mismatch.

The bug was exposed by LinearSolve's rank-deficient QR fallback in https://github.com/SciML/LinearSolve.jl/commit/f15353ac. CurveFit's bounded `nonlinfit_reinit` cache returned `[1.578e-12, 9.825684, 1.745e-18]` with residual norm `8.10367`, while direct solve escalated and found `[3.0, 2.0, 0.7]` with residual norm `1.78e-14`.

## Failing before

```text
cached_sol.retcode: StalledSuccess
cached_sol.u: [1.5780331164254596e-12, 9.825684095952546, 1.7454614466180318e-18]
direct_sol.retcode: Success
direct_sol.u: [3.0000000000000497, 1.9999999999999598, 0.7000000000000067]
cache solve escalates after StalledSuccess | 1 pass, 3 fail, 4 total
```

## Passing after

```text
cache solve escalates after StalledSuccess | 4 pass, 4 total
```

CurveFit's original reproducer with this NonlinearSolveBase checkout produced:

```text
u=[3.0000000000000497,1.9999999999999598,0.7000000000000067]
retcode=Success
residual_norm=1.778575899402738e-14
```

## Verification

After rebasing over the current upstream releases and the merged QA compat correction https://github.com/SciML/NonlinearSolve.jl/pull/1205:

```text
GROUP=Core julia +release --project -e 'using Pkg; Pkg.test()'
PolyAlgorithm cache StalledSuccess escalation | 4 pass, 4 total
Testing NonlinearSolve tests passed

GROUP=QA julia +release --project -e 'using Pkg; Pkg.test()'
QA | 28 pass, 28 total, 1m01.2s
Testing NonlinearSolve tests passed

julia +release -m Runic --check lib/NonlinearSolveBase/src/solve.jl test/Core/polyalg_stalled_success_tests__item1.jl test/runtests.jl
# exit 0

git diff upstream/master | typos -
# exit 0

git diff --check upstream/master
# exit 0
```

Fresh CI on this rebased head passes Linux Core on Julia lts, current, and pre; QA; PolyAlgorithms; Bounds; Adjoint; Downstream; Trim; Verbosity; documentation; downgrade; formatting; spelling; and the completed sublibrary jobs.

## CI failure classification

The six completed red checks reproduce independently of this polyalgorithm change:

- Wrappers fails on Julia lts, current, and pre because its isolated environment still pins NLsolve 4.5 while the root requires NLsolve 5. Aligning the environment exposes NLsolve 5's requirement for ADTypes backends instead of legacy symbols. Draft https://github.com/SciML/NonlinearSolve.jl/pull/1207 fixes both parts and reports Wrappers 135631/135631 and QA 28/28 passing.
- ModelingToolkit InterfaceI, InterfaceII, and Initialization fail while reconstructing nested symbolic metadata, with values such as `Base.ImmutableDict{DataType, Any}` appearing where scope/name tuples are expected. The focused SymbolicUtils fix https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1033 has a fail-before/pass-after regression and passes SymbolicUtils Core with 17,887 tests; the same checkout also passes the affected SymbolicAnalysis groups.

Tracker/LogExpFunctions failures from the pre-rebase head are resolved by merged https://github.com/SciML/NonlinearSolve.jl/pull/1203; exact current-master Simple Core and Adjoint runs pass.

macOS and CUDA jobs remain queued for lack of runners at the time of this update.

## Not verified

GPU, adjoint, bounds-extension, downstream, trim, and full `Everything` groups were not run locally for this branch. Documentation was not built locally because no public API or documentation changed.

## Reviewer note

The behavioral choice is limited to `NonlinearSolvePolyAlgorithm`: a `StalledSuccess` rung now escalates exactly as the direct-solve and step-driven paths already do. If every rung stalls or fails, the existing lowest-residual selection remains unchanged.

## Links

- Triggering LinearSolve change: https://github.com/SciML/LinearSolve.jl/commit/f15353ac
- CurveFit downstream PR: https://github.com/SciML/CurveFit.jl/pull/135
- Separate merged QA compat correction: https://github.com/SciML/NonlinearSolve.jl/pull/1205
- Tracker/LogExpFunctions fix: https://github.com/SciML/NonlinearSolve.jl/pull/1203
- NLsolve 5 Wrappers fix: https://github.com/SciML/NonlinearSolve.jl/pull/1207
- Nested ImmutableDict fix: https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/1033

🤖 Generated with Codex CLI 0.150.1 (model: unknown; session: local session ID 01a0441e-3d2f-7170-ab6e-58ef72975a9f).
