### PR TITLE
Release 2.48.1

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.48.0"
+version = "2.48.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
Drop @fastmath from the norms so divergence guards survive

Release the accumulated source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R