### PR TITLE
Translate NLsolveJL autodiff symbols for NLsolve 5

### DIFF
--- a/ext/NonlinearSolveNLsolveExt.jl
+++ b/ext/NonlinearSolveNLsolveExt.jl
@@ -1,5 +1,6 @@
 module NonlinearSolveNLsolveExt
 
+using ADTypes: AutoFiniteDiff, AutoForwardDiff
 using LineSearches: Static
 using NLsolve: NLsolve, NonDifferentiable, OnceDifferentiable, nlsolve
 
@@ -7,6 +8,9 @@ using NonlinearSolveBase: NonlinearSolveBase, Utils, TraceMinimal, is_fw_wrapped
 using NonlinearSolve: NonlinearSolve, NLsolveJL
 using SciMLBase: SciMLBase, NonlinearProblem, ReturnCode
 using Setfield: @set
+
+_nlsolve_autodiff(::Val{:central}) = AutoFiniteDiff(; fdtype = Val(:central))
+_nlsolve_autodiff(::Val{:forward}) = AutoForwardDiff()
 
 function SciMLBase.__solve(
         prob::NonlinearProblem, alg::NLsolveJL, args...;
@@ -34,7 +38,8 @@ function SciMLBase.__solve(
     if alg.method in (:anderson, :broyden)
         df = NonDifferentiable(f!, Utils.safe_vec(u0), Utils.safe_vec(resid); inplace = true)
     elseif prob.f.jac === nothing && alg.autodiff isa Symbol
-        df = OnceDifferentiable(f!, u0, resid; alg.autodiff)
+        autodiff = _nlsolve_autodiff(Val(alg.autodiff))
+        df = OnceDifferentiable(f!, u0, resid; autodiff)
     else
         autodiff = alg.autodiff isa Symbol ? nothing : alg.autodiff
         jac! = NonlinearSolveBase.construct_extension_jac(prob, alg, u0, resid; autodiff)

--- a/test/Wrappers/rootfind_tests__item2.jl
+++ b/test/Wrappers/rootfind_tests__item2.jl
@@ -66,13 +66,11 @@ function f!(fvec, x, p)
 end
 
 prob = NonlinearProblem{true}(f!, [0.1; 1.2])
-sol = solve(prob, NLsolveJL(autodiff = :central))
-@test maximum(abs, sol.resid) < 1.0e-6
+@testset "NLsolveJL autodiff = $autodiff" for autodiff in (:central, :forward)
+    sol = solve(prob, NLsolveJL(; autodiff))
+    @test maximum(abs, sol.resid) < 1.0e-6
+end
 sol = solve(prob, SIAMFANLEquationsJL())
-@test maximum(abs, sol.resid) < 1.0e-6
-
-# Test the autodiff technique
-sol = solve(prob, NLsolveJL(autodiff = :forward))
 @test maximum(abs, sol.resid) < 1.0e-6
 
 # Custom Jacobian


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

NLsolve 5 migrated its `autodiff` keyword from symbols to ADTypes backends, while the documented `NLsolveJL` interface still accepts `:central` and `:forward`. Translate those two legacy values at the extension boundary to `AutoFiniteDiff(fdtype = Val(:central))` and `AutoForwardDiff()` respectively, preserving the public wrapper API.

The existing explicit symbol checks are grouped into a named parameterized regression test so both accepted spellings remain covered without duplicating the test body.

## Regression evidence

On clean `upstream/master` at `0057ea080b5c12e1fd10eb8152a35a3bf01eecf4`, the full Julia 1.10 Wrappers group failed twice in `forward_ad_tests__item1.jl`:

```console
$ TMPDIR=/home/crackauc/sandbox/tmp_20260825_174545_75721/tmp JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=Wrappers NONLINEARSOLVE_TEST_GROUP=Wrappers ~/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'
TypeError: in keyword argument autodiff, expected ADTypes.AbstractADType, got a value of type Symbol
...
ERROR: Some tests did not pass: 130672 passed, 0 failed, 2 errored, 0 broken.
```

With this commit applied, the same command passes:

```console
Test Summary:              |   Pass   Total     Time
ForwardDiff.jl Integration | 135631  135631  9m41.2s
...
Test Summary:                   | Pass  Total   Time
Nonlinear Root Finding Problems |   58     58  12.6s
     Testing NonlinearSolve tests passed
```

The standalone regression also failed on the unfixed commit with NLsolve 5.0.1 and passed after the fix for both `autodiff = :central` and `autodiff = :forward`.

## Bisect

`git bisect` identified `4a2745620f2fd0829a7aadd669c07a3fba3ac53c` as the first bad commit. Its parent resolves the supported NLsolve 4.5.1 and both symbol modes solve successfully; that commit changes root compatibility to NLsolve 5, which raises the type error. PR #1208 later aligned the Wrappers sub-environment with NLsolve 5 and exposed the existing incompatibility in that CI group.

## Verification

```console
$ TMPDIR=/home/crackauc/sandbox/tmp_20260825_174545_75721/tmp JULIA_PKG_PRECOMPILE_AUTO=0 GROUP=QA NONLINEARSOLVE_TEST_GROUP=QA ~/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
QA            |   26     26  30.9s
     Testing NonlinearSolve tests passed

$ ~/.juliaup/bin/julia +1.12 --project=~/.julia/environments/runic -m Runic --check ext/NonlinearSolveNLsolveExt.jl test/Wrappers/rootfind_tests__item2.jl
# exit 0
$ typos ext/NonlinearSolveNLsolveExt.jl test/Wrappers/rootfind_tests__item2.jl
# exit 0
$ git diff --check upstream/master...HEAD
# exit 0
```

Docs were not rebuilt because this changes neither public API nor documentation. GPU and downstream groups were not run locally.

## Reviewer judgment

This preserves the currently documented symbol interface through a private translation. Push back if `NLsolveJL` should instead make a breaking public API change to require ADTypes objects.

## Links

- Introducing compatibility commit: https://github.com/SciML/NonlinearSolve.jl/commit/4a2745620f2fd0829a7aadd669c07a3fba3ac53c
- Introducing compatibility PR: https://github.com/SciML/NonlinearSolve.jl/pull/1198
- Wrappers environment PR that exposed the failure: https://github.com/SciML/NonlinearSolve.jl/pull/1208
- Prior closed draft: https://github.com/SciML/NonlinearSolve.jl/pull/1207

🤖 Generated with Codex CLI 0.150.1 (model: unknown; session: local session ID 01a04445-104e-7dc1-bae7-03b57aaf3462).
