### PR TITLE
Construct NonlinearSolution without spelling out its type parameters

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.49.0"
+version = "2.49.1"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/polyalg.jl
+++ b/lib/NonlinearSolveBase/src/polyalg.jl
@@ -405,19 +405,28 @@ function build_solution_less_specialize(
         store_original::Val = Val(false), kwargs...
     )
     if store_original isa Val{true}
+        return less_specialized_solution(
+            Any, u, resid, prob, alg, retcode, original, left, right, stats, trace
+        )
+    end
+    return less_specialized_solution(
+        Nothing, u, resid, prob, alg, retcode, nothing, left, right, stats, trace
+    )
+end
+
+# SciMLBase ≥ 3.51 appends the return code type to `NonlinearSolution`'s parameters.
+let retcode_param = fieldtype(SciMLBase.NonlinearSolution, :retcode) === ReturnCode.T ?
+        () : (:(typeof(retcode)),)
+    @eval function less_specialized_solution(
+            ::Type{O}, u, resid, prob, alg, retcode, original, left, right, stats, trace
+        ) where {O}
         return SciMLBase.NonlinearSolution{
             eltype(eltype(u)), ndims(u), typeof(u), typeof(resid), typeof(prob),
-            typeof(alg), Any, typeof(left), typeof(stats), typeof(trace),
+            typeof(alg), O, typeof(left), typeof(stats), typeof(trace), $(retcode_param...),
         }(
             u, resid, prob, alg, retcode, original, left, right, stats, trace
         )
     end
-    return SciMLBase.NonlinearSolution{
-        eltype(eltype(u)), ndims(u), typeof(u), typeof(resid), typeof(prob),
-        typeof(alg), Nothing, typeof(left), typeof(stats), typeof(trace),
-    }(
-        u, resid, prob, alg, retcode, nothing, left, right, stats, trace
-    )
 end
 
 function findmin_caches(prob::AbstractNonlinearProblem, caches)

--- a/lib/SCCNonlinearSolve/Project.toml
+++ b/lib/SCCNonlinearSolve/Project.toml
@@ -1,6 +1,6 @@
 name = "SCCNonlinearSolve"
 uuid = "9dfe8606-65a1-4bb3-9748-cb89d1561431"
-version = "1.15.2"
+version = "1.15.3"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/SCCNonlinearSolve/src/SCCNonlinearSolve.jl
+++ b/lib/SCCNonlinearSolve/src/SCCNonlinearSolve.jl
@@ -83,6 +83,17 @@ probvec(prob::LinearProblem) = prob.b
 
 iteratively_build_sols(alg, sols; kwargs...) = sols
 
+# SciMLBase ≥ 3.51 appends the return code type to `NonlinearSolution`'s parameters.
+let retcode_param = fieldtype(SciMLBase.NonlinearSolution, :retcode) === SciMLBase.ReturnCode.T ?
+        () : (SciMLBase.ReturnCode.T,)
+    @eval function nonlinear_solution_type(::Type{T}, ::Type{uType}, ::Type{rType}) where {T, uType, rType}
+        return SciMLBase.NonlinearSolution{
+            T, 1, uType, rType, NamedTuple{(:p,), Tuple{Nothing}},
+            Nothing, Nothing, Nothing, Nothing, Nothing, $(retcode_param...),
+        }
+    end
+end
+
 function solve_single_scc(alg, prob, explicitfun, sols; kwargs...)
     SciMLBase.invoke_with_despecialized_parameters(
         explicitfun, (prob.p, sols)
@@ -131,10 +142,7 @@ function iteratively_build_sols(alg, probs::AbstractVector, explicitfuns::Abstra
     uType = typeof(probvec(prob1))
     T = eltype(uType)
     rType = uType  # resid has same type as u for nonlinear problems
-    ST = SciMLBase.NonlinearSolution{
-        T, 1, uType, rType,
-        NamedTuple{(:p,), Tuple{Nothing}}, Nothing, Nothing, Nothing, Nothing, Nothing,
-    }
+    ST = nonlinear_solution_type(T, uType, rType)
     sols = Vector{ST}(undef, length(probs))
     for i in eachindex(probs)
         sols[i] = solve_single_scc(alg, probs[i], explicitfuns[i], view(sols, 1:(i - 1)); kwargs...)::ST

--- a/lib/SimpleNonlinearSolve/Project.toml
+++ b/lib/SimpleNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleNonlinearSolve"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 authors = ["SciML"]
-version = "2.14.1"
+version = "2.14.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/lib/SimpleNonlinearSolve/src/utils.jl
+++ b/lib/SimpleNonlinearSolve/src/utils.jl
@@ -198,10 +198,8 @@ function compute_hvvp(prob, autodiff, fx, x, dir)
     return only(DI.pushforward(jvp_fn, autodiff, x, (dir,), Constant(prob.p)))
 end
 
-function nonlinear_solution_new_alg(
-        sol::SciMLBase.NonlinearSolution{T, N, uType, R, P, A, O, uType2, S, Tr}, alg
-    ) where {T, N, uType, R, P, A, O, uType2, S, Tr}
-    return SciMLBase.NonlinearSolution{T, N, uType, R, P, typeof(alg), O, uType2, S, Tr}(
+function nonlinear_solution_new_alg(sol::SciMLBase.NonlinearSolution, alg)
+    return SciMLBase.NonlinearSolution(
         sol.u, sol.resid, sol.prob, alg, sol.retcode, sol.original, sol.left, sol.right,
         sol.stats, sol.trace
     )


### PR DESCRIPTION
> Draft. Ignore this PR until reviewed by @ChrisRackauckas.

## What changed and why

SciML/SciMLBase.jl#1563 appends a `retcode` type parameter to `NonlinearSolution`, and the three places in this repo that spell out all of its parameters then fail to precompile — which is what #1563's downstream and docs lanes currently show. This makes those sites layout-agnostic so they work with both the released SciMLBase and #1563:

- `build_solution_less_specialize` (`lib/NonlinearSolveBase/src/polyalg.jl`) and the SCC solution element type pick the layout once at load time via `fieldtype(SciMLBase.NonlinearSolution, :retcode)`.
- `nonlinear_solution_new_alg` (`lib/SimpleNonlinearSolve/src/utils.jl`) uses the positional constructor, which computes the same parameters.

Patch bumps (rebased onto master after the 2.49.0 / 1.15.2 releases): NonlinearSolveBase 2.49.1, SCCNonlinearSolve 1.15.3, SimpleNonlinearSolve 2.14.2. Intended to merge and be released before #1563; carved out of #1197, which will be rebased on it.

## Verification

Julia 1.12.4, each sublibrary's own project with the local NonlinearSolveBase developed in:

```
GROUP=Core  NonlinearSolveBase      Testing NonlinearSolveBase tests passed
GROUP=Core  SCCNonlinearSolve       Testing SCCNonlinearSolve tests passed
GROUP=Core  SimpleNonlinearSolve    Testing SimpleNonlinearSolve tests passed
```

The same code precompiles and passes the NonlinearSolve Reactant test group against #1563 (that run is in #1197). Runic-formatted; `typos` clean.

## Not verified

- QA groups (the change adds no imports or public names); GPU groups.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5) on behalf of Chris Rackauckas. Session: https://claude.ai/code/session_016LsC6pp9z6s5EABX9DnVjE
