### PR TITLE
Restore TimerOutputs 0.5 compat in NonlinearSolveBase (fixes OrdinaryDiffEq downstream lanes)

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.49.1"
+version = "2.49.2"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]
@@ -109,7 +109,7 @@ StaticArrays = "1.9"
 StaticArraysCore = "1.4.3"
 SymbolicIndexingInterface = "0.3.43"
 Test = "1.10"
-TimerOutputs = "1"
+TimerOutputs = "0.5.23, 1"
 Tracker = "0.2.35"
 julia = "1.10"
 


### PR DESCRIPTION
> **Note:** this PR should be ignored until reviewed by @ChrisRackauckas.

## What changed and why

`lib/NonlinearSolveBase/Project.toml`: `TimerOutputs = "1"` → `TimerOutputs = "0.5.23, 1"` (restoring the range that https://github.com/SciML/NonlinearSolve.jl/pull/1198 dropped on 2026-08-26 as "stale"), plus a patch bump of NonlinearSolveBase to 2.49.2 (master released 2.49.1 via https://github.com/SciML/NonlinearSolve.jl/pull/1221 while this was being prepared; the resolution logs below were taken with the branch at 2.49.1, before rebasing) so the widened compat can be registered.

The `Downstream.yml` lanes `OrdinaryDiffEq.jl/InterfaceI`, `InterfaceII` and `Regression_I` fail on master since https://github.com/SciML/NonlinearSolve.jl/actions/runs/33303882132 with `Unsatisfiable requirements detected for package AlgebraicMultigrid`. The constraint chain:

1. https://github.com/SciML/OrdinaryDiffEq.jl/pull/4391 (merged 2026-08-30 09:00 UTC, between the last green Downstream run https://github.com/SciML/NonlinearSolve.jl/actions/runs/33290997505 and the first red one) bumped `lib/OrdinaryDiffEqDifferentiation` to `LinearSolve = "5.15"`. Downstream develops OrdinaryDiffEq master, so the test env can no longer downgrade LinearSolve.
2. LinearSolve ≥ 5.14 has `AlgebraicMultigrid = "2"` in its weakdeps compat (`4 - 5.13.1` still allowed `0.5, 1 - 2`). AlgebraicMultigrid is in OrdinaryDiffEq's test target, so it must resolve to 2.0.1.
3. AlgebraicMultigrid 1.2 – 2.0.1 pins `TimerOutputs = "0.5.29 - 0.5"`.
4. NonlinearSolveBase ≥ 2.48.1 (after #1198) requires `TimerOutputs = "1"` → no version left.

The green run escaped this by resolving `LinearSolve v5.13.1` + `AlgebraicMultigrid v0.5.1`; that escape hatch is gone now. Nothing in the General registry changed for these packages — the trigger was the OrdinaryDiffEq compat bump exposing the compat drop from #1198.

The long-term fix belongs in AlgebraicMultigrid (widen its compat to TimerOutputs 1; it only uses `@timeit_debug`). Until that is released, NonlinearSolveBase has to keep accepting TimerOutputs 0.5.

## Verification

Minimal reproducer (Julia 1.12.7): temp project, `Pkg.develop` of `.`, `lib/NonlinearSolveBase`, `lib/SciMLJacobianOperators`, `lib/NonlinearSolveFirstOrder`, `lib/SimpleNonlinearSolve`, then `Pkg.add([AlgebraicMultigrid, LinearSolve@5.15])`.

Before (master `f561fb5cb`):

```
ERROR: LoadError: Unsatisfiable requirements detected for package TimerOutputs [a759f4b9]:
 TimerOutputs [a759f4b9] log:
 ├─possible versions are: 0.4.0 - 1.2.0 or uninstalled
 ├─restricted to versions 1 by NonlinearSolveBase [be0214bd], leaving only versions: 1.0.0 - 1.2.0
 │ └─NonlinearSolveBase [be0214bd] log:
 │   ├─possible versions are: 2.49.0 or uninstalled
 │   ├─restricted to versions 2.45.0 - 2 by NonlinearSolveFirstOrder [5959db7a], leaving only versions: 2.49.0
 │   └─NonlinearSolveBase [be0214bd] is fixed to version 2.49.0
 └─restricted by compatibility requirements with AlgebraicMultigrid [2169fc97] to versions: 0.5.29 — no versions left
   └─AlgebraicMultigrid [2169fc97] log:
     ├─possible versions are: 0.2.0 - 2.0.1 or uninstalled
     ├─restricted to versions * by an explicit requirement, leaving only versions: 0.2.0 - 2.0.1
     ├─restricted by compatibility requirements with Compat [34da2185] to versions: 0.4.0 - 2.0.1 or uninstalled, leaving only versions: 0.4.0 - 2.0.1
     └─restricted by compatibility requirements with LinearSolve [7ed4a6bd] to versions: 2.0.1 or uninstalled, leaving only versions: 2.0.1
       └─LinearSolve [7ed4a6bd] log:
         ├─possible versions are: 0.1.0 - 5.15.0 or uninstalled
         ├─restricted to versions 5.4.0 - 5 by NonlinearSolveFirstOrder [5959db7a], leaving only versions: 5.4.0 - 5.15.0
         └─restricted to versions 5.15 by an explicit requirement, leaving only versions: 5.15.0
```

After (this branch), same script:

```
⌅ [a759f4b9] ↓ TimerOutputs v1.2.0 ⇒ v0.5.29
  [2169fc97] AlgebraicMultigrid v2.0.1
  [7ed4a6bd] LinearSolve v5.15.0
  [be0214bd] NonlinearSolveBase v2.49.1 `~/sandbox/NonlinearSolve-downstream/lib/NonlinearSolveBase`
```

CI-shaped check: temp project developing the five upstream projects above plus OrdinaryDiffEq master (`ff71f2f3f`) and its `lib/OrdinaryDiffEqDifferentiation`, `Pkg.add` of every non-developed name in OrdinaryDiffEq's `test` target — resolves with the fix:

```
  [2169fc97] AlgebraicMultigrid v2.0.1
  [7ed4a6bd] LinearSolve v5.15.0
  [be0214bd] NonlinearSolveBase v2.49.1 `.../lib/NonlinearSolveBase`
  [4302a76b] OrdinaryDiffEqDifferentiation v3.11.1 `.../OrdinaryDiffEq-downstream/lib/OrdinaryDiffEqDifferentiation`
```

Tests of `lib/NonlinearSolveBase` with the newly re-allowed version pinned (`Pkg.add(PackageSpec(name="TimerOutputs", version="0.5.29"))`, Julia 1.12.7):

```
⌃ [a759f4b9] TimerOutputs v0.5.29
GROUP=Core  ->  362 passed of 362, "Testing NonlinearSolveBase tests passed", exit=0
GROUP=QA    ->  QA | 20 20 51.8s, "Testing NonlinearSolveBase tests passed", exit=0
```

`typos` on the diff: clean. Runic not applicable (only `Project.toml` changed).

## Not verified

- The Downstream OrdinaryDiffEq lanes themselves (a full OrdinaryDiffEq `InterfaceI` run); only the environment resolution the lanes die in was reproduced and shown to pass.
- Root/other sublibrary test groups; only `lib/NonlinearSolveBase` `Core` and `QA` were run, since NonlinearSolveBase is the only project in the repo that depends on TimerOutputs.

## Things to push back on

- This intentionally reverses part of #1198. The "older than one year" rule was applied to a compat that a live downstream dependency (AlgebraicMultigrid 2.0.1, the only version LinearSolve ≥ 5.14 accepts) still pins to. Once AlgebraicMultigrid releases with TimerOutputs 1 compat, the `0.5.23` part can be dropped again.
- Pre-existing and unrelated to this PR: `NonlinearSolveBase.@static_timeit` calls `TimerOutputs.timer_expr(__module__, false, to, name, expr)`, but `timer_expr` has taken a leading `source::LineNumberNode` since TimerOutputs 0.5.27, so `enable_timer_outputs()` makes NonlinearSolveBase fail to precompile with any TimerOutputs ≥ 0.5.27 (ArgumentError on 0.5.29, MethodError on 1.2.0). The default (timers disabled) is unaffected. Tracked separately in an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Code 2.1.251, model: claude-fable-5)

https://claude.ai/code/session_016LsC6pp9z6s5EABX9DnVjE
