### PR TITLE
NonlinearSolveBase: rebuild a pre-wrapped function when its signatures do not match u0/p

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.49.2"
+version = "2.49.3"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/autospecialize.jl
+++ b/lib/NonlinearSolveBase/src/autospecialize.jl
@@ -83,6 +83,8 @@ end
 
 function _despecialize_parameters(prob)
     SciMLBase.specialization(prob.f) === SciMLBase.AutoDespecialize || return prob
+    # Already despecialized and wrapped (e.g. concretized at construction): skip the `remake`.
+    prob.p isa SciMLBase.DespecializedParameters && is_fw_wrapped(prob.f.f) && return prob
     f = _map_parameter_callbacks(_wrap_parameter_callback, prob.f)
     p = SciMLBase.DespecializedParameters(prob.p)
     return SciMLBase.remake(prob; f, p)
@@ -222,7 +224,9 @@ Non-array state (e.g. scalar `Number` u0) is not wrapped because the Dual-aware
 because `promote_u0` upgrades `u0` to a `Dual`-eltype array whenever the user's
 outer-AD pass injected duals into `p`; in that case the wrapper's signatures would
 be keyed off the outer Dual tag and miss the inner value-typed dispatch that the
-forward-diff extension builds via `Utils.value` / `nodual_value`.
+forward-diff extension builds via `Utils.value` / `nodual_value`. For the same reason an
+already-wrapped function is unwrapped (via [`get_raw_f`](@ref)) when `u0` has since been
+promoted to a Dual eltype, e.g. by `remake` of a problem that was wrapped at construction.
 """
 function maybe_wrap_nonlinear_f(prob::AbstractNonlinearProblem)
     u0 = prob.u0
@@ -235,8 +239,13 @@ function maybe_wrap_nonlinear_f(prob::AbstractNonlinearProblem)
     # constructed on the outer-AD path. The unwrapped function works fine.
     EnzymeCore.within_autodiff() && return prob.f.f
 
-    # Already wrapped — idempotent
-    is_fw_wrapped(prob.f.f) && return prob.f.f
+    # Already wrapped — idempotent, unless `remake`/`promote_u0` has since injected an
+    # outer-AD Dual eltype into `u0`: the stored wrapper has no signature for it, so hand
+    # back the raw callable and let the value-typed inner solve rebuild the wrapper.
+    if is_fw_wrapped(prob.f.f)
+        SciMLBase.isdualtype(eltype(u0)) && return get_raw_f(prob.f.f)
+        return prob.f.f
+    end
 
     # Only wrap IIP functions. OOP wrapping requires guessing the return type,
     # which doesn't always work (see DiffEqBase for precedent).

--- a/lib/NonlinearSolveBase/src/autospecialize.jl
+++ b/lib/NonlinearSolveBase/src/autospecialize.jl
@@ -124,6 +124,19 @@ Otherwise return `f` unchanged.
 get_raw_f(f) = f
 get_raw_f(f::AutoSpecializeCallable) = f.orig
 
+_wrapper_argtypes(::FunctionWrappers.FunctionWrapper{R, A}) where {R, A} = A
+
+"""
+    wrapper_accepts(f, args::Tuple) -> Bool
+
+Return `true` if `f`, wrapped by the AutoSpecialize infrastructure, carries a precompiled
+signature matching `args`. The wrapper is built for one state/parameter type at wrap time,
+so a problem that was wrapped and later `remake`d with a different `u0` or `p` type
+(another eltype, an outer-AD Dual, a different array type) has no matching signature.
+"""
+wrapper_accepts(f::AutoSpecializeCallable, args::Tuple) =
+    any(fw -> args isa _wrapper_argtypes(fw), f.fw.fw)
+
 """
     _uses_enzyme_ad(ad) -> Bool
 
@@ -224,9 +237,12 @@ Non-array state (e.g. scalar `Number` u0) is not wrapped because the Dual-aware
 because `promote_u0` upgrades `u0` to a `Dual`-eltype array whenever the user's
 outer-AD pass injected duals into `p`; in that case the wrapper's signatures would
 be keyed off the outer Dual tag and miss the inner value-typed dispatch that the
-forward-diff extension builds via `Utils.value` / `nodual_value`. For the same reason an
-already-wrapped function is unwrapped (via [`get_raw_f`](@ref)) when `u0` has since been
-promoted to a Dual eltype, e.g. by `remake` of a problem that was wrapped at construction.
+forward-diff extension builds via `Utils.value` / `nodual_value`.
+
+A function that is already wrapped (e.g. a problem concretized at construction and later
+`remake`d) is reused only if its signatures match the current `u0` and `p`
+([`wrapper_accepts`](@ref)); otherwise it is unwrapped via [`get_raw_f`](@ref) and wrapped
+again for the new types, or left raw when the new `u0` is Dual-typed.
 """
 function maybe_wrap_nonlinear_f(prob::AbstractNonlinearProblem)
     u0 = prob.u0
@@ -237,30 +253,28 @@ function maybe_wrap_nonlinear_f(prob::AbstractNonlinearProblem)
     # defeat Enzyme's static activity analysis (and `set_runtime_activity` is
     # not sufficient to recover correctness), so the wrapper must not be
     # constructed on the outer-AD path. The unwrapped function works fine.
-    EnzymeCore.within_autodiff() && return prob.f.f
+    f = prob.f.f
+    EnzymeCore.within_autodiff() && return f
 
-    # Already wrapped — idempotent, unless `remake`/`promote_u0` has since injected an
-    # outer-AD Dual eltype into `u0`: the stored wrapper has no signature for it, so hand
-    # back the raw callable and let the value-typed inner solve rebuild the wrapper.
-    if is_fw_wrapped(prob.f.f)
-        SciMLBase.isdualtype(eltype(u0)) && return get_raw_f(prob.f.f)
-        return prob.f.f
+    if is_fw_wrapped(f)
+        wrapper_accepts(f, (u0, u0, p)) && return f
+        f = get_raw_f(f)
     end
 
     # Only wrap IIP functions. OOP wrapping requires guessing the return type,
     # which doesn't always work (see DiffEqBase for precedent).
-    SciMLBase.isinplace(prob) || return prob.f.f
+    SciMLBase.isinplace(prob) || return f
 
     # Only wrap array-typed state. The ForwardDiff-aware `wrapfun_iip` dispatches
     # on `AbstractArray` state and builds signatures over `similar(u0, ::DualT)`.
-    u0 isa AbstractArray || return prob.f.f
+    u0 isa AbstractArray || return f
 
     # Skip wrapping when `u0` already carries a Dual eltype — `promote_u0` does
     # this whenever outer-AD injected duals into `p`. The wrapper's signatures
     # would then be keyed off the outer Dual tag and miss the inner value-typed
     # dispatch that the forward-diff extension builds via `Utils.value` /
     # `nodual_value`.
-    SciMLBase.isdualtype(eltype(u0)) && return prob.f.f
+    SciMLBase.isdualtype(eltype(u0)) && return f
 
     # Only wrap when AutoSpecialize (the default), AutoDespecialize, or
     # AutoDePSpecialize is active.
@@ -274,10 +288,12 @@ function maybe_wrap_nonlinear_f(prob::AbstractNonlinearProblem)
         spec === SciMLBase.AutoSpecialize || spec === SciMLBase.AutoDespecialize ||
             spec === SciMLBase.AutoDePSpecialize
     ) ||
-        return prob.f.f
+        return f
 
-    orig = prob.f.f
-    spec === SciMLBase.AutoDespecialize && (orig = ParameterDespecializationWrapper(orig))
+    orig = f
+    if spec === SciMLBase.AutoDespecialize && !(orig isa ParameterDespecializationWrapper)
+        orig = ParameterDespecializationWrapper(orig)
+    end
     inputs = (u0, u0, p)
     return AutoSpecializeCallable(wrapfun_iip(orig, inputs), orig)
 end
@@ -341,6 +357,8 @@ end
 @inline (f::AutoDePSpecializeCallable)(args...) = f.fw(args...)
 
 is_fw_wrapped(::AutoDePSpecializeCallable) = true
+wrapper_accepts(f::AutoDePSpecializeCallable, args::Tuple) =
+    any(fw -> args isa _wrapper_argtypes(fw), f.fw.fw)
 
 # A non-FunctionWrapper callable that still accepts the OpaqueParams `p`: it
 # unpacks to the concrete `ptype` and forwards to the raw residual. Used by

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -311,11 +311,11 @@ run_tests(;
             )
         end
 
-        @safetestset "maybe_wrap_nonlinear_f unwraps a pre-wrapped f under a Dual u0" begin
-            # A problem wrapped at construction (`get_concrete_problem`) and later
-            # `remake`d with an outer-AD Dual `u0`/`p` must not keep the wrapper: its
-            # signatures were built for the value eltype and cannot be called with
-            # the outer Dual, so the raw callable has to be handed back instead.
+        @safetestset "maybe_wrap_nonlinear_f rebuilds a pre-wrapped f whose signatures do not match u0" begin
+            # A problem wrapped at construction (`get_concrete_problem`) carries signatures
+            # for the state/parameter types it was wrapped with. After `remake` with other
+            # types the wrapper must not be reused as-is: it is rebuilt for a new value
+            # eltype, and dropped in favour of the raw callable for an outer-AD Dual eltype.
             using NonlinearSolveBase, SciMLBase, ForwardDiff
 
             resid!(du, u, p) = (du .= u .^ 2 .- p.k; nothing)
@@ -327,8 +327,23 @@ run_tests(;
                     NonlinearProblem(f, [1.0, 2.0], (; k = 2.0))
                 )
                 @test NonlinearSolveBase.is_fw_wrapped(wrapped.f.f)
+                @test NonlinearSolveBase.wrapper_accepts(
+                    wrapped.f.f, (wrapped.u0, wrapped.u0, wrapped.p)
+                )
                 @test NonlinearSolveBase.maybe_wrap_f(wrapped) === wrapped
 
+                # Different value eltype: the old wrapper has no signature, a new one is built.
+                u0 = Float32[1, 2]
+                p = (; k = 2.0f0)
+                @test !NonlinearSolveBase.wrapper_accepts(wrapped.f.f, (u0, u0, wrapped.p))
+                f32 = NonlinearSolveBase.get_concrete_problem(SciMLBase.remake(wrapped; u0, p))
+                @test NonlinearSolveBase.is_fw_wrapped(f32.f.f)
+                @test NonlinearSolveBase.wrapper_accepts(f32.f.f, (f32.u0, f32.u0, f32.p))
+                du = similar(f32.u0)
+                f32.f(du, f32.u0, f32.p)
+                @test du == Float32[-1, 2]
+
+                # Outer-AD Dual eltype: no wrapper at all, the raw callable is handed back.
                 u0 = [dual(1.0, 1.0), dual(2.0, 0.0)]
                 p = (; k = dual(2.0, 1.0))
                 dualprob = SciMLBase.remake(wrapped; u0, p)

--- a/lib/NonlinearSolveBase/test/runtests.jl
+++ b/lib/NonlinearSolveBase/test/runtests.jl
@@ -311,6 +311,36 @@ run_tests(;
             )
         end
 
+        @safetestset "maybe_wrap_nonlinear_f unwraps a pre-wrapped f under a Dual u0" begin
+            # A problem wrapped at construction (`get_concrete_problem`) and later
+            # `remake`d with an outer-AD Dual `u0`/`p` must not keep the wrapper: its
+            # signatures were built for the value eltype and cannot be called with
+            # the outer Dual, so the raw callable has to be handed back instead.
+            using NonlinearSolveBase, SciMLBase, ForwardDiff
+
+            resid!(du, u, p) = (du .= u .^ 2 .- p.k; nothing)
+            DualF = ForwardDiff.Dual{ForwardDiff.Tag{typeof(identity), Float64}, Float64, 1}
+            dual(v, ∂) = DualF(v, ForwardDiff.Partials((∂,)))
+            for spec in (SciMLBase.AutoSpecialize, SciMLBase.AutoDespecialize)
+                f = NonlinearFunction{true, spec}(resid!)
+                wrapped = NonlinearSolveBase.get_concrete_problem(
+                    NonlinearProblem(f, [1.0, 2.0], (; k = 2.0))
+                )
+                @test NonlinearSolveBase.is_fw_wrapped(wrapped.f.f)
+                @test NonlinearSolveBase.maybe_wrap_f(wrapped) === wrapped
+
+                u0 = [dual(1.0, 1.0), dual(2.0, 0.0)]
+                p = (; k = dual(2.0, 1.0))
+                dualprob = SciMLBase.remake(wrapped; u0, p)
+                concrete = NonlinearSolveBase.get_concrete_problem(dualprob)
+                @test !NonlinearSolveBase.is_fw_wrapped(concrete.f.f)
+                du = similar(concrete.u0)
+                concrete.f(du, concrete.u0, concrete.p)
+                @test ForwardDiff.value.(du) == [-1.0, 2.0]
+                @test ForwardDiff.partials.(du, 1) == [1.0, -1.0]
+            end
+        end
+
         @safetestset "EnzymeExt _accum_tangent! caches accumulation (#935)" include("enzyme_accum_tangent.jl")
 
         @safetestset "PolyAlgorithm solution type is concrete (#878)" include("polyalg_solution_type.jl")


### PR DESCRIPTION
> **Draft — please ignore until reviewed by @ChrisRackauckas.**

## What changed and why

`maybe_wrap_nonlinear_f` returned an already-wrapped `AutoSpecializeCallable` unchanged. A wrapper built by `get_concrete_problem` carries `FunctionWrappersWrapper` signatures for exactly the state and parameter types it was wrapped with, so a problem that was wrapped at construction time and then `remake`d with different types (another value eltype, a different array type, an outer-AD Dual) was handed a wrapper with no matching signature: the call throws `NoFunctionWrapperFoundError` (or falls into the slow fallback path, depending on the policy).

The check is now general: `wrapper_accepts(f, (u0, u0, p))` asks whether the stored wrapper has a signature for the current arguments. If it does, the wrapper is reused; if not, the raw callable is recovered with `get_raw_f` and goes through the normal wrapping path, which rebuilds the wrapper for the new types, or leaves the function raw when `u0` is Dual-typed (the existing rule for outer AD). `_despecialize_parameters` also skips its `remake` when the problem is already despecialized and wrapped, so concretizing an already-concretized problem is a no-op.

Motivation: https://github.com/SciML/ModelingToolkit.jl/pull/5062 stores initialization problems pre-wrapped; `ReconstructInitializeprob` / `remake` later change their `u0`/`p` types. That PR does not require this one (the `AllowNonIsBits` fallback keeps non-isbits cases working), but benefits from it.

## Verification

New testset `maybe_wrap_nonlinear_f rebuilds a pre-wrapped f whose signatures do not match u0` in `lib/NonlinearSolveBase/test/runtests.jl`: wrap at construction, then `remake` with (a) `Float32` `u0`/`p` — expects a rebuilt wrapper that accepts the new types and computes the right residual, and (b) an outer-AD Dual `u0`/`p` — expects the raw callable and correct values/partials; both for `AutoSpecialize` and `AutoDespecialize`.

Against **master** `NonlinearSolveBase` (`78b1484f`), same testset (`wrapper_accepts` does not exist there, so those assertions error; the Float32 call itself throws):

```
maybe_wrap_nonlinear_f rebuilds a pre-wrapped f whose signatures do not match u0: Error During Test at newtest_only.jl:17
  Expression: NonlinearSolveBase.wrapper_accepts(wrapped.f.f, (wrapped.u0, wrapped.u0, wrapped.p))
...
maybe_wrap_nonlinear_f rebuilds a pre-wrapped f whose signatures do not match u0: Error During Test at newtest_only.jl:2
  No matching function wrapper was found!
Test Summary:                                                                    | Pass  Error  Total  Time
maybe_wrap_nonlinear_f rebuilds a pre-wrapped f whose signatures do not match u0 |    3      4      7  3.8s
```

With this PR, `NONLINEARSOLVE_TEST_GROUP=Core julia --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test()'` (Julia 1.12.7):

```
maybe_wrap_nonlinear_f rebuilds a pre-wrapped f whose signatures do not match u0 |   20     20  2.7s
...
     Testing NonlinearSolveBase tests passed
```

`NONLINEARSOLVE_TEST_GROUP=QA`: `Testing NonlinearSolveBase tests passed`. Runic and typos clean on the changed files.

## Not verified

- Downstream solver-package groups (NonlinearSolveFirstOrder etc.), Enzyme paths, GPU arrays; only NonlinearSolveBase `Core` and `QA` were run locally.
- Julia 1.10.

## For the reviewer

- `wrapper_accepts` compares against the base signature only (`(u0, u0, p)`); the inner-AD Dual signatures the ForwardDiff extension adds are keyed off that base type, so a base match implies the Dual ones match too.
- `_despecialize_parameters`' early return assumes that when `f.f` is already wrapped and `p` is already `DespecializedParameters`, the other callbacks (`jac`, …) were wrapped in the same earlier pass. That holds for anything produced by `maybe_wrap_f`.
- Version bumped to 2.49.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)
https://claude.ai/code/session_01FeJYXni9MkJhPFA9yxYvfn
