### PR TITLE
Preserve Jacobian cache parameter representation

### DIFF
--- a/lib/NonlinearSolveBase/src/abstract_types.jl
+++ b/lib/NonlinearSolveBase/src/abstract_types.jl
@@ -723,7 +723,7 @@ function not_terminated(cache::AbstractNonlinearSolveCache)
     return !cache.force_stop && cache.nsteps < cache.maxiters
 end
 
-_prepare_reinit_parameters(p, ::Any) = p
+_prepare_reinit_parameters(p, ::Any) = SciMLBase.unwrap_parameters(p)
 _prepare_reinit_parameters(p, ::SciMLBase.DespecializedParameters) =
     SciMLBase.DespecializedParameters(p)
 

--- a/lib/NonlinearSolveBase/src/jacobian.jl
+++ b/lib/NonlinearSolveBase/src/jacobian.jl
@@ -182,7 +182,7 @@ jacobian_destination(J, autodiff) = J
 end
 
 function InternalAPI.reinit!(cache::JacobianCache; p = cache.p, kwargs...)
-    return cache.p = p
+    return cache.p = _prepare_reinit_parameters(p, cache.p)
 end
 
 # Deprecations

--- a/lib/NonlinearSolveBase/test/autodespecialize.jl
+++ b/lib/NonlinearSolveBase/test/autodespecialize.jl
@@ -1,4 +1,4 @@
-using ADTypes: AutoEnzyme
+using ADTypes: AutoEnzyme, AutoForwardDiff
 using NonlinearSolveBase, SciMLBase, Test
 
 struct DynamicParameters
@@ -78,6 +78,21 @@ end
     @test enzyme_prob.f.f === dynamic_residual!
 end
 
+@testset "Jacobian cache preserves raw parameter storage" begin
+    p = DynamicParameters(2.0)
+    prob = dynamic_problem(p)
+    fu = zeros(1)
+    prob.f(fu, prob.u0, p)
+    cache = NonlinearSolveBase.construct_jacobian_cache(
+        prob, nothing, prob.f, fu;
+        stats = SciMLBase.NLStats(0, 0, 0, 0, 0),
+        autodiff = AutoForwardDiff(),
+    )
+
+    wrapped = SciMLBase.DespecializedParameters(p)
+    NonlinearSolveBase.InternalAPI.reinit!(cache; p = wrapped)
+    @test cache.p === p
+end
 
 @testset "AutoDespecialize out-of-place residual" begin
     first_prob = NonlinearSolveBase.get_concrete_problem(


### PR DESCRIPTION
## What changed

Normalize incoming parameters to the representation already stored by a nonlinear cache, and apply that policy when a nested `JacobianCache` is reinitialized. This preserves despecialized storage when the cache was built with it and unwraps `DespecializedParameters` when initialization built the nested cache from a concrete parameter object.

The regression test constructs the latter cache shape directly and verifies that reinitializing it with a despecialized wrapper retains its concrete parameter storage.

This is a focused follow-up to https://github.com/SciML/NonlinearSolve.jl/pull/1199. Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Failing before / passing after

With the new regression test present and the two source changes reverted:

```sh
TMPDIR="$PWD/../.tmp" JULIA_PKG_PRECOMPILE_AUTO=0 timeout 3600 \
  "$HOME/.juliaup/bin/julia" +1.12 --startup-file=no \
  --project=lib/NonlinearSolveBase --color=no \
  -e 'using Pkg; Pkg.instantiate(); include("lib/NonlinearSolveBase/test/autodespecialize.jl")'
```

```text
AutoDespecialize dynamic parameter barrier | 15  15
Jacobian cache preserves raw parameter storage | Error  1
MethodError: Cannot convert SciMLBase.DespecializedParameters to DynamicParameters
```

The identical command with the fix applied exits 0:

```text
AutoDespecialize dynamic parameter barrier | 15  15
Jacobian cache preserves raw parameter storage | 1  1
AutoDespecialize out-of-place residual | 4  4
AutoDespecialize nonlinear problem variants | 4  4
other specialization policies retain concrete parameters | 2  2
```

Aggregate: 26 passed, 0 failed, 0 errored.

## Introduction boundary

The identical Catalyst/SciMLSensitivity reduced solve exits 0 with NonlinearSolve 4.26.0 / NonlinearSolveBase 2.43.0 and exits 1 with the same `DespecializedParameters` → `MTKParameters` conversion on NonlinearSolve 4.27.0 / NonlinearSolveBase 2.44.0. The first-bad release contains the AutoDespecialize implementation from https://github.com/SciML/NonlinearSolve.jl/pull/1164 (`e4166415`).

The reduced solve still fails on the current NonlinearSolveBase 2.49.2 release and current master. With this patch developed into the same environment, it exits 0 with `CATALYST_LOAD_ORDER_NONLINEAR_SUCCESS`.

## Verification

- `GROUP=Core ... julia +1.12 --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test()'`: 363 passed, 0 failed, 0 errored.
- `GROUP=Core ... julia +1.10.12 --project=<clean temporary environment> -e 'using Pkg; Pkg.develop(path=ARGS[1]); Pkg.test("NonlinearSolveBase")' <path>`: 350 passed, 0 failed, 0 errored.
- `GROUP=QA ... julia +1.12 --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test()'`: 20 passed, 0 failed, 0 errored.
- `NONLINEARSOLVE_TEST_GROUP=Core ... julia +1.12 --project=. -e 'using Pkg; Pkg.test()'`: 1,497 passed, 0 failed, 0 errored, 88 pre-existing broken (1,585 total).
- `JULIA_CONDAPKG_BACKEND=Null JULIA_PYTHONCALL_EXE=/usr/bin/python3 ... julia +1.12 --project=docs -e 'using Pkg; Pkg.instantiate(); include("docs/make.jl")'`: exit 0; doctests, linkcheck, document checks, and HTML rendering completed.
- `julia +1.12 --project=@runic -m Runic --check <changed files>`: exit 0.
- `typos <changed files>`: exit 0.
- `git diff --check`: exit 0.

The full Catalyst docs build with current downstream sources is still running at the time of this draft; its terminal result will be added in a PR comment. The reduced downstream reproducer above has completed both failing-before and passing-after.

The registered Catalyst docs graph currently cannot resolve NonlinearSolveBase 2.49.x because TimerOutputs 1 support is pending in https://github.com/pogudingleb/RationalFunctionFields.jl/pull/61 and https://github.com/sumiya11/Groebner.jl/pull/226. I validated the 2.49.2 downstream result using those same one-line compat changes rebased onto the current RationalFunctionFields 0.3.4 and Groebner 0.10.6 releases; no dependency was pinned as a workaround.

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local transcript `/home/crackauc/.codex/sessions/2026/09/04/rollout-2026-09-04T00-54-40-01a06ac4-d6d4-7812-b432-39b974dddab6.jsonl`)
