### PR TITLE
Fix reverse AD through despecialized parameters

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.49.2"
+version = "2.49.3"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]
@@ -59,7 +59,7 @@ NonlinearSolveBaseEnzymeExt = ["ChainRulesCore", "Enzyme"]
 NonlinearSolveBaseForwardDiffExt = "ForwardDiff"
 NonlinearSolveBaseLineSearchExt = "LineSearch"
 NonlinearSolveBaseLinearSolveExt = "LinearSolve"
-NonlinearSolveBaseMooncakeExt = "Mooncake"
+NonlinearSolveBaseMooncakeExt = ["ChainRulesCore", "Mooncake"]
 NonlinearSolveBaseReverseDiffExt = "ReverseDiff"
 NonlinearSolveBaseSparseArraysExt = "SparseArrays"
 NonlinearSolveBaseSparseMatrixColoringsExt = "SparseMatrixColorings"

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseChainRulesCoreExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseChainRulesCoreExt.jl
@@ -8,7 +8,10 @@ using SciMLBase: AbstractSensitivityAlgorithm
 using Setfield: @set
 
 import ChainRulesCore
-import ChainRulesCore: NoTangent, Tangent
+import ChainRulesCore: AbstractZero, NoTangent, Tangent
+
+_unwrap_despecialized_tangent(dp) = SciMLBase.unwrap_parameters(dp)
+_unwrap_despecialized_tangent(dp::NamedTuple{(:params,)}) = dp.params
 
 # Reverse-mode AD (Zygote, Mooncake) cannot differentiate through FunctionWrapper
 # internals (llvmcall). When SciMLSensitivity builds the adjoint problem it calls
@@ -58,7 +61,15 @@ function ChainRulesCore.rrule(
     # When using Mooncake, we pass in sol.u to inner_thunking_pb directly as this is the only field relevant to the solution's cotangent (given solve_up, AbstractNonlinearProblem setting).
 
     function solve_up_adjoint(∂sol)
-        return inner_thunking_pb(∂sol isa Tangent{Any, <:NamedTuple} ? ∂sol.u : ∂sol)
+        adjoints = inner_thunking_pb(
+            ∂sol isa Tangent{Any, <:NamedTuple} ? ∂sol.u : ∂sol
+        )
+        dp = adjoints[5]
+        if p isa SciMLBase.DespecializedParameters && !(dp isa AbstractZero)
+            dp = _unwrap_despecialized_tangent(dp)
+            return Base.setindex(adjoints, Tangent{typeof(p)}(; params = dp), 5)
+        end
+        return adjoints
     end
     return primal, solve_up_adjoint
 end

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseEnzymeExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseEnzymeExt.jl
@@ -22,6 +22,16 @@ import SciMLStructures
 # returns a structured cotangent whose gradient contribution may live in
 # non-Tunable fields such as `caches` (e.g. SCC sub-problem buffers feeding
 # `explicitfuns!`), so those fields are walked in as well.
+_unwrap_despecialized_tangent(darg) = SciMLBase.unwrap_parameters(darg)
+_unwrap_despecialized_tangent(darg::NamedTuple{(:params,)}) = darg.params
+
+function _accum_tangent!(
+        dval::SciMLBase.DespecializedParameters, darg; diff_tunables::Bool = true
+    )
+    darg = _unwrap_despecialized_tangent(darg)
+    return _accum_tangent!(dval.params, darg; diff_tunables)
+end
+
 function _accum_tangent!(dval, darg; diff_tunables::Bool = true)
     if SciMLStructures.isscimlstructure(dval) && !(dval isa AbstractArray)
         if SciMLStructures.isscimlstructure(darg)
@@ -84,8 +94,18 @@ function _accum_nested!(dst::Tuple, src::Tuple)
     end
     return nothing
 end
+function _accum_nested!(dst, src::NamedTuple)
+    for field in fieldnames(typeof(src))
+        value = getfield(src, field)
+        value === nothing && continue
+        hasfield(typeof(dst), field) || continue
+        _accum_nested!(getfield(dst, field), value)
+    end
+    return nothing
+end
 _accum_nested!(::Any, ::Nothing) = nothing
 _accum_nested!(::Nothing, ::Any) = nothing
+_accum_nested!(::Nothing, ::NamedTuple) = nothing
 _accum_nested!(::Nothing, ::Nothing) = nothing
 
 # `solve_up`'s differentiable inputs (prob/u0/p) are positional; its keyword
@@ -176,7 +196,8 @@ function Enzyme.EnzymeRules.reverse(
     # SCCNonlinearProblem's `explicitfuns!` coupling). Reproducing that
     # predicate here lets the accumulator walk every non-Tunable field of a
     # structured `darg` so the meaningful cotangent isn't dropped.
-    diff_tunables = let s = sensealg.val, pv = p.val
+    diff_tunables = let s = sensealg.val,
+            pv = SciMLBase.unwrap_parameters(p.val)
         if s isa SciMLBase.AbstractSensitivityAlgorithm &&
                 hasproperty(s, :diff_tunables)
             !(getproperty(s, :diff_tunables) isa Val{false})

--- a/lib/NonlinearSolveBase/ext/NonlinearSolveBaseMooncakeExt.jl
+++ b/lib/NonlinearSolveBase/ext/NonlinearSolveBaseMooncakeExt.jl
@@ -1,10 +1,57 @@
 module NonlinearSolveBaseMooncakeExt
 
 using NonlinearSolveBase, Mooncake
+using ChainRulesCore: ChainRulesCore
 using SciMLBase: SciMLBase
 using Mooncake: rrule!!, CoDual, zero_fcodual, @is_primitive,
     @from_chainrules, @zero_adjoint, @mooncake_overlay, MinimalCtx,
     NoPullback
+
+_accum_cr_tangent!(f, r, ::Nothing) = r
+function _accum_cr_tangent!(f::NamedTuple, r::Mooncake.NoRData, t::NamedTuple)
+    map(_accum_full_tangent!, f, t)
+    return r
+end
+function _accum_cr_tangent!(f::Mooncake.NoFData, r::NamedTuple, t::NamedTuple)
+    return map((ri, ti) -> _accum_cr_tangent!(f, ri, ti), r, t)
+end
+function _accum_cr_tangent!(f::NamedTuple, r::NamedTuple, t::NamedTuple)
+    return map(_accum_cr_tangent!, f, r, t)
+end
+function _accum_cr_tangent!(
+        f::Mooncake.FData, r::Mooncake.RData{R}, t::NamedTuple
+    ) where {R}
+    return Mooncake.RData{R}(map(_accum_cr_tangent!, f.data, r.data, t))
+end
+function _accum_cr_tangent!(
+        f::Mooncake.MutableTangent, r::Mooncake.NoRData, t::NamedTuple
+    )
+    f.fields = map(_accum_full_tangent!, f.fields, t)
+    return r
+end
+_accum_cr_tangent!(f, r, t) = Mooncake.increment_and_get_rdata!(f, r, t)
+
+_accum_full_tangent!(f, ::Nothing) = f
+function _accum_full_tangent!(f::Mooncake.MutableTangent, t::NamedTuple)
+    f.fields = map(_accum_full_tangent!, f.fields, t)
+    return f
+end
+function _accum_full_tangent!(f::Mooncake.Tangent, t::NamedTuple)
+    return Mooncake.Tangent(map(_accum_full_tangent!, f.fields, t))
+end
+_accum_full_tangent!(f, t) = Mooncake.increment!!(f, t)
+
+# `@from_chainrules` delegates unsupported cotangent conversions to this documented
+# extension point; keep the otherwise-pirated signature specific to this wrapper.
+function Mooncake.increment_and_get_rdata!(
+        f::Mooncake.FData{F}, r::Mooncake.RData{R},
+        t::ChainRulesCore.Tangent{SciMLBase.DespecializedParameters}
+    ) where {
+        F <: NamedTuple{(:params,)},
+        R <: NamedTuple{(:params,)},
+    }
+    return _accum_cr_tangent!(f, r, getfield(t, :backing))
+end
 
 @from_chainrules MinimalCtx Tuple{
     typeof(NonlinearSolveBase.solve_up),

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -981,19 +981,16 @@ function _solve_adjoint(
     alg = extract_alg(args, kwargs, prob.kwargs)
     _prob = get_concrete_problem(prob; u0 = u0, p = p, kwargs...)
 
-    # Enzyme cannot differentiate through FunctionWrappers' `llvmcall`, so its
-    # traced forward solve runs on the unwrapped function (see
-    # `maybe_unwrap_prob_for_enzyme`, #940). That unwrap is keyed off the solver's
-    # own autodiff, which for an MTK DAE initialization is ForwardDiff even when
-    # the *outer* differentiation is Enzyme — so it does not fire here. Key off
-    # the originator instead: the EnzymeOriginator adjoint primal must have the
-    # same (unwrapped) type as Enzyme's traced forward, otherwise the custom
-    # `solve_up` rule's returned primal type mismatches the inferred return type
-    # (`EnzymeRuntimeException: Expected return type of primal to be ...`).
-    if originator isa SciMLBase.EnzymeOriginator
-        if _prob.p isa SciMLBase.DespecializedParameters
-            _prob = _unwrap_despecialized_problem(_prob)
-        elseif is_fw_wrapped(_prob.f.f)
+    # The inner sensitivity calculation needs the concrete parameter layout to
+    # differentiate non-Tunable SciMLStructure fields. The outer AD rules restore
+    # the DespecializedParameters tangent boundary.
+    adjoint_p = p
+    if _prob.p isa SciMLBase.DespecializedParameters
+        _prob = _unwrap_despecialized_problem(_prob)
+        adjoint_p = _prob.p
+    elseif originator isa SciMLBase.EnzymeOriginator
+        # Match the unwrapped callable used by Enzyme's traced forward solve.
+        if is_fw_wrapped(_prob.f.f)
             @set! _prob.f.f = get_raw_f(_prob.f.f)
         end
     end
@@ -1005,11 +1002,13 @@ function _solve_adjoint(
 
     return if length(args) > 1
         _concrete_solve_adjoint(
-            _prob, alg, sensealg, u0, p, originator,
+            _prob, alg, sensealg, u0, adjoint_p, originator,
             Base.tail(args)...; kwargs...
         )
     else
-        _concrete_solve_adjoint(_prob, alg, sensealg, u0, p, originator; kwargs...)
+        _concrete_solve_adjoint(
+            _prob, alg, sensealg, u0, adjoint_p, originator; kwargs...
+        )
     end
 end
 

--- a/lib/NonlinearSolveBase/test/enzyme_accum_tangent.jl
+++ b/lib/NonlinearSolveBase/test/enzyme_accum_tangent.jl
@@ -3,6 +3,7 @@ module EnzymeAccumTangentTests
 using Test
 using NonlinearSolveBase
 import ChainRulesCore, Enzyme  # triggers NonlinearSolveBaseEnzymeExt
+import SciMLBase
 import SciMLStructures
 import SciMLStructures: Tunable
 
@@ -54,6 +55,28 @@ const EXT = Base.get_extension(NonlinearSolveBase, :NonlinearSolveBaseEnzymeExt)
     EXT._accum_tangent!(dval2, darg3)
     @test dval2.tunable == [1.0, 2.0]
     @test dval2.caches[1] == zeros(3)
+end
+
+@testset "EnzymeExt accumulates nested tangents through DespecializedParameters" begin
+    dval = SciMLBase.DespecializedParameters(MockMTKParams([0.0, 0.0], (zeros(3),)))
+    darg = (;
+        params = (;
+            tunable = [1.0, 2.0],
+            caches = ([10.0, 20.0, 30.0],),
+        ),
+    )
+
+    EXT._accum_tangent!(dval, darg)
+    @test dval.params.tunable == [1.0, 2.0]
+    @test dval.params.caches[1] == [10.0, 20.0, 30.0]
+
+    dval = SciMLBase.DespecializedParameters(MockMTKParams([0.0, 0.0], (zeros(3),)))
+    darg = SciMLBase.DespecializedParameters(
+        MockMTKParams([1.0, 2.0], ([10.0, 20.0, 30.0],))
+    )
+    EXT._accum_tangent!(dval, darg; diff_tunables = false)
+    @test dval.params.tunable == [1.0, 2.0]
+    @test dval.params.caches[1] == [10.0, 20.0, 30.0]
 end
 
 end

--- a/test/Adjoint/adjoint_tests__item1.jl
+++ b/test/Adjoint/adjoint_tests__item1.jl
@@ -1,4 +1,5 @@
 using NonlinearSolve
+using SciMLBase
 
 using ForwardDiff, ReverseDiff, SciMLSensitivity, Tracker, Zygote, Enzyme, Mooncake
 
@@ -9,6 +10,27 @@ function solve_nlprob(p)
     sol = solve(prob, NewtonRaphson())
     res = sol isa AbstractArray ? sol : sol.u
     return sum(abs2, res)
+end
+
+function solve_despecialized_nlprob(p)
+    f = NonlinearFunction{false, SciMLBase.AutoDespecialize}(ff)
+    prob = NonlinearSolveBase.get_concrete_problem(NonlinearProblem(f, [1.0, 2.0], p))
+    return sum(abs2, solve(prob, NewtonRaphson()).u)
+end
+
+function solve_despecialized_structured_nlprob(p)
+    f = NonlinearFunction{false, SciMLBase.AutoDespecialize}(
+        (u, p) -> u .^ 2 .- (p.values .+ p.coeffs.shift)
+    )
+    prob = NonlinearSolveBase.get_concrete_problem(NonlinearProblem(f, [1.0, 2.0], p))
+    return sum(abs2, solve(prob, NewtonRaphson()).u)
+end
+
+function zygote_mooncake_grad(f, p)
+    zygote_grad = only(Zygote.gradient(f, p))
+    cache = Mooncake.prepare_gradient_cache(f, p)
+    mooncake_grad = Mooncake.value_and_gradient!!(cache, f, p)[2][2]
+    return zygote_grad, mooncake_grad
 end
 
 p = [3.0, 2.0]
@@ -25,3 +47,17 @@ cache = Mooncake.prepare_gradient_cache(solve_nlprob, p)
 @test ∂p_zygote ≈ ∂p_tracker ≈ ∂p_reversediff ≈ ∂p_enzyme
 @test ∂p_zygote ≈ ∂p_forwarddiff ≈ ∂p_tracker ≈ ∂p_reversediff ≈ ∂p_enzyme
 @test ∂p_forwarddiff ≈ ∂p_mooncake
+
+∂p_despecialized_zygote, ∂p_despecialized_mooncake = zygote_mooncake_grad(
+    solve_despecialized_nlprob, p
+)
+
+@test ∂p_despecialized_zygote ≈ ∂p_despecialized_mooncake
+
+p_structured = (; values = p, coeffs = (; shift = 1.0))
+∂p_structured_zygote, ∂p_structured_mooncake = zygote_mooncake_grad(
+    solve_despecialized_structured_nlprob, p_structured
+)
+
+@test ∂p_structured_zygote.values ≈ ∂p_structured_mooncake.values
+@test ∂p_structured_zygote.coeffs.shift ≈ ∂p_structured_mooncake.coeffs.shift


### PR DESCRIPTION
> Please ignore this draft until it has been reviewed by @ChrisRackauckas.

## What changed

Reverse-mode sensitivity calculations now unwrap `DespecializedParameters` before the inner adjoint solve and restore the wrapper-shaped cotangent at the outer AD boundary. Enzyme accumulation now follows structured non-tunable fields through that wrapper, while the Mooncake bridge converts the resulting nested `NamedTuple` cotangents into Mooncake forward/reverse data.

This is the NonlinearSolveBase companion needed by https://github.com/SciML/ModelingToolkit.jl/pull/5062: that PR intentionally despecializes MTK initialization problems, which exposed the existing reverse-AD assumptions about concrete parameter layout. The separate https://github.com/SciML/NonlinearSolve.jl/pull/1226 addresses a prewrapped-function signature mismatch and does not handle these structured cotangents.

## Regression evidence

Before this fix, `SciMLSensitivity/test/Core8/desauty_dae_mwe.jl` reported `13 pass, 4 errors, 5 broken`: Enzyme and Mooncake could not propagate through the newly despecialized SCC initialization problems. After the initial exception paths were repaired, the same run reported `17 pass, 4 fail, 5 broken` because all four SCC parameter gradients were zero. The new structured Mooncake regression test also failed before the final converter with:

```text
ArgumentError: The fdata type @NamedTuple{values::Vector{Float64}}, rdata type Mooncake.NoRData, and tangent type @NamedTuple{values::Vector{Float64}} combination is not supported with @from_chainrules or @from_rrule.
```

With this change, the same downstream SCC test reports:

```text
Test Summary:               | Pass  Broken  Total      Time
DAE with SCC Initialization |   21       5     26  14m26.0s
```

The five `broken` assertions predate this change and were not altered.

## Verification

- `GROUP=Adjoint julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` — all three safe testsets passed: 6/6 Adjoint, 3/3 `maybe_wrap_nonlinear_f`, and 1/1 Enzyme reverse-mode.
- `julia +1.12 --project=test/Adjoint -e 'using Test; include("test/Adjoint/adjoint_tests__item1.jl")'` — exit 0, including vector and nested structured `AutoDespecialize` gradients through Zygote and Mooncake.
- `julia +1.10 --project=test/Adjoint -e 'using Test; include("test/Adjoint/adjoint_tests__item1.jl")'` — exit 0.
- `julia +1.12 --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test()'` — 366/366 assertions passed after developing the already-open SparseColumnPivotedQR fix described below; the new Enzyme accumulation test was 10/10.
- `GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'` — 28/28 passed with the same dependency fix developed.
- `julia +1.12 --project=. -e 'include("test/Core8/desauty_dae_mwe.jl")'` in SciMLSensitivity with local ModelingToolkit and NonlinearSolveBase — 21 passed, 5 pre-existing broken.
- `SnoopCompileCore.@snoop_invalidations` while loading NonlinearSolveBase, ChainRulesCore, and Mooncake — upstream and this branch are exactly equal at `logedges=397`, `logmeths=8543`.
- `julia +1.12 -m Runic --check <changed Julia files>` — clean.
- `typos <changed files>` — clean.
- `git diff --check` — clean.

The unmodified dependency resolve currently fails before tests because AMD 0.5.4 removed the private `AMD.SS_Int` binding used by SparseColumnPivotedQR 2.1.7. This reproduces on clean NonlinearSolve master. The existing fix https://github.com/SciML/SparseColumnPivotedQR.jl/pull/71 replaces that private access with public `colamd`; its CI is green, and developing it while retaining AMD 0.5.4 makes clean-master and this branch pass. The regression is tracked at https://github.com/SciML/SparseColumnPivotedQR.jl/issues/72.

## Review notes

The Mooncake method is deliberately restricted to `ChainRulesCore.Tangent{SciMLBase.DespecializedParameters}`. [Mooncake documents `increment_and_get_rdata!` as the extension point](https://github.com/chalk-lab/Mooncake.jl/blob/v0.5.51/src/tools_for_rules.jl#L450-L515) when `@from_chainrules` cannot convert a tangent combination; a broad `NamedTuple` method here would be type piracy beyond this package's wrapper.

I did not run `GROUP=Everything`, GPU jobs, downstream packages beyond the targeted SciMLSensitivity regression, or the docs build. No public API or documentation changed.

🤖 Generated with Codex (version unknown; model: unknown; session: local thread 01a06c1d-564b-7ef0-ada6-d83a233b55e2)
