### PR TITLE
Preserve TrustRegion parameter representation on reinit

### DIFF
--- a/lib/NonlinearSolveFirstOrder/src/trust_region.jl
+++ b/lib/NonlinearSolveFirstOrder/src/trust_region.jl
@@ -298,6 +298,8 @@ end
 function InternalAPI.reinit!(
         cache::GenericTrustRegionSchemeCache; p = cache.p, u0 = nothing, kwargs...
     )
+    p = cache.p isa SciMLBase.DespecializedParameters ?
+        SciMLBase.DespecializedParameters(p) : SciMLBase.unwrap_parameters(p)
     cache.p = p
     if u0 !== nothing
         u0_norm = cache.internalnorm(u0)

--- a/lib/NonlinearSolveFirstOrder/test/misc_tests__item3.jl
+++ b/lib/NonlinearSolveFirstOrder/test/misc_tests__item3.jl
@@ -1,6 +1,8 @@
 using NonlinearSolveFirstOrder
 
 using NonlinearSolveFirstOrder, SciMLBase
+using ADTypes: AutoEnzyme, AutoForwardDiff
+using Enzyme
 
 f(u, p) = u .* u .- p
 prob = NonlinearProblem(f, [1.0, 1.0], 2.0)
@@ -9,6 +11,19 @@ cache = init(prob, TrustRegion())
 # Get the trust region cache
 tr_cache = cache.trustregion_cache
 @test tr_cache.trust_region == tr_cache.initial_trust_radius
+
+@testset "AutoDespecialize trust region reinitialization" for autodiff in
+    (AutoForwardDiff(), AutoEnzyme())
+    dynamic_f = NonlinearFunction{false, SciMLBase.AutoDespecialize}(f)
+    dynamic_prob = NonlinearProblem(dynamic_f, [1.0, 1.0], 2.0)
+    dynamic_cache = init(
+        dynamic_prob, TrustRegion(; autodiff, jvp_autodiff = autodiff, vjp_autodiff = autodiff)
+    )
+    reinit!(dynamic_cache, [1.0, 1.0]; p = 3.0)
+    dynamic_sol = solve!(dynamic_cache)
+    @test SciMLBase.successful_retcode(dynamic_sol)
+    @test dynamic_sol.u ≈ fill(sqrt(3.0), 2)
+end
 
 # Solve problem to modify the trust region
 sol = solve!(cache)


### PR DESCRIPTION
Preserve the TrustRegion cache's existing raw/despecialized parameter representation during `reinit!`. Enzyme setup unwraps the inner problem, so an outer `AutoDespecialize` cache can otherwise pass wrapped parameters into a raw inner cache and fail conversion. The two-line fix normalizes the parameter used by both the cache and its reinitialization calculations.

The regression test exercises public `reinit!` with explicit ForwardDiff and Enzyme choices for all three AD backends. The Jacobian-cache prerequisite is already merged: https://github.com/SciML/NonlinearSolve.jl/pull/1227 . This PR contains only the TrustRegion follow-up.

## Verification

The exact new regression on unfixed code passed the ForwardDiff case (2/2) and errored in the Enzyme case (exit 1):

```text
MethodError: Cannot `convert` an object of type SciMLBase.DespecializedParameters to an object of type Float64
AutoDespecialize trust region reinitialization | Error  Total
                                              |     1      1
```

With the fix, the same regression passed both cases on Julia 1.12.7 and Julia 1.10.11 (exit 0 on each):

```text
AutoDespecialize trust region reinitialization | Pass  Total
                                              |    2      2
AutoDespecialize trust region reinitialization | Pass  Total
                                              |    2      2
```

From `lib/NonlinearSolveFirstOrder`, the complete native group ran with:

```sh
GROUP=Core JULIA_NUM_THREADS=1 JULIA_NUM_PRECOMPILE_TASKS=1 \
  julia --startup-file=no --heap-size-hint=8G --project=. \
  -e 'using Pkg; Pkg.test(; julia_args=["--heap-size-hint=8G"])'
GROUP=QA julia --project -e 'using Pkg; Pkg.test()'
```

Core: 2,724 assertions across 40 reported testsets, exit 0, including TrustRegion 1,176/1,176 and reinitialization 11/11. QA: 20/20, exit 0. Final output:

```text
SciMLOperator Jacobians | 14  14  19.9s
Testing NonlinearSolveFirstOrder tests passed
```

Runic check, typos on both changed files, and `git diff --check` passed. Rebase onto the merged prerequisite produced an identical tree to the locally validated commit.

The Catalyst documentation-load-order reproducer failed before this fix with the matching parameter conversion error and passed afterward, printing `CATALYST_LOADED_TRUST_REGION_SUCCESS`. The complete composed Catalyst documentation build is still running; no full documentation success is claimed. This change touches no public API, docstring, or documentation file. GPU and full downstream suites were not run locally.

The first native Core attempt ended with SIGKILL of unknown cause. The complete successful retry used the GC heap-size hint above, changed no assertions, and observed unchanged OOM counters throughout.

An executable adjacent-commit comparison identified the original introduction: https://github.com/SciML/NonlinearSolve.jl/commit/e4166415d618e2ae5bb5d0295d38a01bc82d8aa3 fails, while its immediate parent https://github.com/SciML/NonlinearSolve.jl/commit/c8479f4cb0fcc740d85aad0890f247ea093ed1dc passes with the same external dependency versions.

Please ignore this draft until reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra), local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d.
