### PR TITLE
NonlinearSolveBase: report the wrapped arity for despecialization wrappers

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.49.3"
+version = "2.49.4"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]

--- a/lib/NonlinearSolveBase/src/autospecialize.jl
+++ b/lib/NonlinearSolveBase/src/autospecialize.jl
@@ -50,6 +50,14 @@ end
 
 SciMLBase.unwrapped_f(f::ParameterDespecializationWrapper) = SciMLBase.unwrapped_f(f.f)
 
+# Both wrappers forward through a single `(args...)` method, which `SciMLBase.numargs`
+# would report as arity 1. Reporting the wrapped function's arity keeps
+# `SciMLBase.isinplace` on its arity fast path instead of the method-table introspection
+# fallback, which Enzyme cannot differentiate through when a wrapped problem is `remake`d
+# inside reverse-mode AD.
+SciMLBase.numargs(f::ParameterDespecializationWrapper) = SciMLBase.numargs(f.f)
+SciMLBase.numargs(f::AutoSpecializeCallable) = SciMLBase.numargs(f.orig)
+
 _wrap_parameter_callback(::Nothing) = nothing
 _wrap_parameter_callback(f::ParameterDespecializationWrapper) = f
 _wrap_parameter_callback(f) = ParameterDespecializationWrapper(f)

--- a/lib/NonlinearSolveBase/test/autodespecialize.jl
+++ b/lib/NonlinearSolveBase/test/autodespecialize.jl
@@ -133,3 +133,28 @@ end
         @test prob.p === p
     end
 end
+
+@testset "wrapped callbacks report the wrapped function's arity" begin
+    using Enzyme
+    prob = NonlinearSolveBase.get_concrete_problem(dynamic_problem(DynamicParameters(2.0)))
+    @test prob.f.f isa NonlinearSolveBase.AutoSpecializeCallable
+    @test prob.f.jac isa NonlinearSolveBase.ParameterDespecializationWrapper
+    @test SciMLBase.numargs(prob.f.f) == SciMLBase.numargs(dynamic_residual!)
+    @test SciMLBase.numargs(prob.f.jac) == SciMLBase.numargs(dynamic_jacobian!)
+    @test SciMLBase.isinplace(prob.f.jac, 3, "jac", true)
+
+    # `remake` rebuilds the `NonlinearFunction`, which re-derives `isinplace` for every
+    # callback; that must stay differentiable when the wrapped problem is remade under
+    # Enzyme reverse mode.
+    function remake_loss(u, prob)
+        new_prob = remake(prob; u0 = prob.u0 .* u[1])
+        return sum(new_prob.u0)
+    end
+    u = [1.5]
+    du = zero(u)
+    Enzyme.autodiff(
+        Enzyme.set_runtime_activity(Enzyme.Reverse), Enzyme.Const(remake_loss),
+        Enzyme.Active, Enzyme.Duplicated(u, du), Enzyme.Const(prob)
+    )
+    @test du[1] ≈ sum(prob.u0)
+end


### PR DESCRIPTION
> **Draft — please ignore until reviewed by @ChrisRackauckas.**

## What changed and why

`ParameterDespecializationWrapper` and `AutoSpecializeCallable` forward through a single `(args...)` method, so `SciMLBase.numargs` reported arity `[1]` for every wrapped residual/callback. When a problem that was wrapped at construction (ModelingToolkit's initialization problems after https://github.com/SciML/ModelingToolkit.jl/pull/5062) is `remake`d, `remake(::NonlinearProblem)` rebuilds the `NonlinearFunction`, whose constructor re-derives `isinplace` for `jac`/`jvp`/`vjp`. Arity 1 pushes that check into `SciMLBase.isinplace`'s method-table introspection fallback (`any(isequal(Vararg{Any}), methods(f).ms[1].sig.parameters)`), which Enzyme reverse mode cannot differentiate through:

```
BoundsError: attempt to access Core.SimpleVector at index [2]
  [3] _any @ ./anyall.jl:130
  ...
  [13] isinplace @ SciMLBase/src/utils.jl:368
  [15] NonlinearFunction @ SciMLBase/src/scimlfunctions.jl:4711
  [17] remake @ SciMLBase/src/remake.jl:368
  [19] remake @ SciMLBase/src/remake.jl:1377
```

(from https://github.com/SciML/ModelingToolkit.jl/actions/runs/33963346747/job/101298982372, SciMLSensitivity `Core8` against MTK PR 5062.)

The fix defines `SciMLBase.numargs` (public, documented as the arity hook for "foreign-function wrappers") for both wrapper types, delegating to the wrapped function, so the arity fast path is taken. Version bumped to 2.49.4.

## Verification

Failing before (registry NonlinearSolveBase 2.49.3, Enzyme 0.13.200, Julia 1.12.7; the concretized initialization problem of an MTK DAE built with `jac = true`):

```
jac :: NonlinearSolveBase.ParameterDespecializationWrapper numargs = [1]
remake(initializeprob) under Enzyme: FAILED: BoundsError: attempt to access Core.SimpleVector at index [2]
```

Passing after (this branch dev'd into the same environment):

```
jac :: NonlinearSolveBase.ParameterDespecializationWrapper numargs = (2, 3)
remake(initializeprob) under Enzyme: OK du=[0.0] (expected 0.0)
```

The new testset in `test/autodespecialize.jl` asserts `numargs` of the wrapped `f`/`jac` equals that of the raw functions (this is `[1] != [3]` on master, so it fails without the fix) and runs `Enzyme.autodiff(Reverse, ...)` through `remake` of a `get_concrete_problem` result.

```
GROUP=Core julia +1.12 --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test()'
AutoDespecialize dynamic-p |   32     32  1m21.2s     (26 before this PR)
     Testing NonlinearSolveBase tests passed

GROUP=QA   julia +1.12 --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test()'
     Testing NonlinearSolveBase tests passed
```

Runic (`--check --diff`, Runic 1.10.0) and `typos` on the diff: clean.

## Not verified

Only the `NonlinearSolveBase` sublibrary was tested locally; downstream `NonlinearSolve` groups and the SciMLSensitivity `Core8` run against the fixed version are still in progress locally and will be reported on the MTK PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-fable-5-1)
https://claude.ai/code/session_01FeJYXni9MkJhPFA9yxYvfn
