### PR TITLE
Run runic on docstrings and markdown files

### DIFF
--- a/docs/src/basics/diagnostics_api.md
+++ b/docs/src/basics/diagnostics_api.md
@@ -33,7 +33,7 @@ function nlfunc(resid, u0, p)
     resid[1] = u0[1] * u0[1] - p
     resid[2] = u0[2] * u0[2] - p
     resid[3] = u0[3] * u0[3] - p
-    nothing
+    return nothing
 end
 
 prob = NLS.NonlinearProblem(nlfunc, [1.0, 3.0, 5.0], 2.0)

--- a/docs/src/basics/faq.md
+++ b/docs/src/basics/faq.md
@@ -16,19 +16,24 @@ myfun(x, lv) = x * sin(x) - lv
 
 function f(out, levels, u0)
     for i in 1:N
-        out[i] = NLS.solve(
-            NLS.IntervalNonlinearProblem{false}(
-                NLS.IntervalNonlinearFunction{false}(myfun), u0, levels[i]),
-            NLS.Falsi()).u
+        prob = NLS.IntervalNonlinearProblem{false}(
+            NLS.IntervalNonlinearFunction{false}(myfun), u0, levels[i]
+        )
+        sol = NLS.solve(prob, NLS.Falsi())
+        out[i] = sol.u
     end
+    return
 end
 
 function f2(out, levels, u0)
     for i in 1:N
-        out[i] = NLS.solve(
-            NLS.NonlinearProblem{false}(NLS.NonlinearFunction{false}(myfun), u0, levels[i]),
-            NLS.SimpleNewtonRaphson()).u
+        prob = NLS.NonlinearProblem{false}(
+            NLS.NonlinearFunction{false}(myfun), u0, levels[i]
+        )
+        sol = NLS.solve(prob, NLS.SimpleNewtonRaphson())
+        out[i] = sol.u
     end
+    return
 end
 
 BenchmarkTools.@btime f(out, levels, (0.0, 2.0))
@@ -62,7 +67,7 @@ v_init = v_true .+ Random.randn!(similar(v_true)) * 0.1
 
 prob_oop = NLS.NonlinearLeastSquaresProblem{false}(fff_incorrect, v_init)
 try
-    sol = NLS.solve(prob_oop, NLS.LevenbergMarquardt(); maxiters = 10000, abstol = 1e-8)
+    sol = NLS.solve(prob_oop, NLS.LevenbergMarquardt(); maxiters = 10000, abstol = 1.0e-8)
 catch e
     @error e
 end
@@ -77,8 +82,10 @@ be a Dual number. This causes the error. To fix it:
     
     ```@example dual_error_faq
     import ADTypes
-    sol = NLS.solve(prob_oop, NLS.LevenbergMarquardt(; autodiff = ADTypes.AutoFiniteDiff());
-        maxiters = 10000, abstol = 1e-8)
+    sol = NLS.solve(
+        prob_oop, NLS.LevenbergMarquardt(; autodiff = ADTypes.AutoFiniteDiff());
+        maxiters = 10000, abstol = 1.0e-8
+    )
     ```
     
     This worked but, Finite Differencing is not the recommended approach in any scenario.
@@ -93,9 +100,9 @@ be a Dual number. This causes the error. To fix it:
         xx[1] = var[1] - v_true[1]
         return xx - v_true
     end
-    
+
     prob_oop = NLS.NonlinearLeastSquaresProblem{false}(fff_correct, v_init)
-    sol = NLS.solve(prob_oop, NLS.LevenbergMarquardt(); maxiters = 10000, abstol = 1e-8)
+    sol = NLS.solve(prob_oop, NLS.LevenbergMarquardt(); maxiters = 10000, abstol = 1.0e-8)
     ```
 
 ## I thought NonlinearSolve.jl was type-stable and fast. But it isn't, why?

--- a/docs/src/basics/solve.md
+++ b/docs/src/basics/solve.md
@@ -65,8 +65,11 @@ solve(prob, alg; verbose = SciMLLogging.None())
 solve(prob, alg; verbose = SciMLLogging.All())
 
 # Custom configuration
-solve(prob, alg; verbose = NonlinearVerbosity(
-    alias_u0_immutable = SciMLLogging.WarnLevel(),
-    threshold_state = SciMLLogging.InfoLevel()
-))
+solve(
+    prob, alg;
+    verbose = NonlinearVerbosity(
+        alias_u0_immutable = SciMLLogging.WarnLevel(),
+        threshold_state = SciMLLogging.InfoLevel()
+    )
+)
 ```

--- a/docs/src/basics/sparsity_detection.md
+++ b/docs/src/basics/sparsity_detection.md
@@ -40,7 +40,7 @@ Let's say you have a Sparse Jacobian Prototype `jac_prototype`, in this case you
 create your problem as follows:
 
 ```julia
-prob = NonlinearProblem(NonlinearFunction(nlfunc; jac_prototype = jac_prototype), x0)
+prob = NonlinearProblem(NonlinearFunction(nlfunc; jac_prototype), x0)
 ```
 
 NonlinearSolve will automatically perform matrix coloring and use sparse differentiation.
@@ -48,8 +48,7 @@ NonlinearSolve will automatically perform matrix coloring and use sparse differe
 Now you can help the solver further by providing the color vector. This can be done by
 
 ```julia
-prob = NonlinearProblem(
-    NonlinearFunction(nlfunc; jac_prototype = jac_prototype, colorvec = colorvec), x0)
+prob = NonlinearProblem(NonlinearFunction(nlfunc; jac_prototype, colorvec), x0)
 ```
 
 If the `colorvec` is not provided, then it is computed on demand.
@@ -68,10 +67,14 @@ algorithm you want to use, then you can create your problem as follows:
 
 ```julia
 prob = NonlinearProblem(
-    NonlinearFunction(nlfunc; sparsity = SymbolicsSparsityDetector()), x0)  # Remember to have Symbolics.jl loaded
+    NonlinearFunction(nlfunc; sparsity = SymbolicsSparsityDetector()), # Remember to have Symbolics.jl loaded
+    x0
+)
 # OR
 prob = NonlinearProblem(
-    NonlinearFunction(nlfunc; sparsity = TracerSparsityDetector()), x0) # From SparseConnectivityTracer.jl
+    NonlinearFunction(nlfunc; sparsity = TracerSparsityDetector()), # From SparseConnectivityTracer.jl
+    x0
+)
 ```
 
 Refer to the documentation of DifferentiationInterface.jl and SparseConnectivityTracer.jl

--- a/docs/src/basics/termination_condition.md
+++ b/docs/src/basics/termination_condition.md
@@ -10,7 +10,7 @@ termination modes:
 The termination condition is constructed as:
 
 ```julia
-cache = init(du, u, AbsNormSafeBestTerminationMode(); abstol = 1e-9, reltol = 1e-9)
+cache = init(du, u, AbsNormSafeBestTerminationMode(); abstol = 1.0e-9, reltol = 1.0e-9)
 ```
 
 If `abstol` and `reltol` are not supplied, then we choose a default based on the element

--- a/docs/src/native/solvers.md
+++ b/docs/src/native/solvers.md
@@ -176,6 +176,7 @@ function f!(F, u, p)
     end
     F[1] = u[1] - 1.0
     F[end] = u[end]
+    return
 end
 
 n = 1000
@@ -183,8 +184,11 @@ u0 = zeros(n)
 prob = NonlinearProblem(f!, u0)
 
 # Use Newton-Raphson with GMRES and Eisenstat-Walker forcing
-sol = solve(prob, NewtonRaphson(
-    linsolve = KrylovJL_GMRES(),
-    forcing = EisenstatWalkerForcing2()
-))
+sol = solve(
+    prob,
+    NewtonRaphson(
+        linsolve = KrylovJL_GMRES(),
+        forcing = EisenstatWalkerForcing2()
+    )
+)
 ```

--- a/docs/src/tutorials/bound_constraints.md
+++ b/docs/src/tutorials/bound_constraints.md
@@ -128,8 +128,10 @@ function f_ip!(resid, u, p)
 end
 
 nf = NLS.NonlinearFunction(f_ip!)
-prob = NLS.NonlinearLeastSquaresProblem(nf, [5.0, 5.0], [1.0, 2.0];
-    lb = [0.0, 0.0], ub = [10.0, 10.0])
+prob = NLS.NonlinearLeastSquaresProblem(
+    nf, [5.0, 5.0], [1.0, 2.0];
+    lb = [0.0, 0.0], ub = [10.0, 10.0]
+)
 
 sol = NLS.solve(prob, NLS.LevenbergMarquardt())
 sol.u

--- a/docs/src/tutorials/getting_started.md
+++ b/docs/src/tutorials/getting_started.md
@@ -109,7 +109,7 @@ Next we can modify the tolerances. Here let's set some really low tolerances to 
 tight solution:
 
 ```@example 1
-NLS.solve(prob, NLS.TrustRegion(), reltol = 1e-12, abstol = 1e-12)
+NLS.solve(prob, NLS.TrustRegion(), reltol = 1.0e-12, abstol = 1.0e-12)
 ```
 
 There are many more options for doing this configuring. Specifically for handling
@@ -173,6 +173,7 @@ function nlls!(du, u, p)
     du[1] = 2u[1] - 2
     du[2] = u[1] - 4u[2]
     du[3] = 0
+    return
 end
 ```
 
@@ -183,7 +184,8 @@ be skipped for out of place problems):
 ```@example 1
 u0 = [0.0, 0.0]
 prob = NLS.NonlinearLeastSquaresProblem(
-    NLS.NonlinearFunction(nlls!, resid_prototype = zeros(3)), u0)
+    NLS.NonlinearFunction(nlls!, resid_prototype = zeros(3)), u0
+)
 
 NLS.solve(prob)
 ```
@@ -191,7 +193,7 @@ NLS.solve(prob)
 Same as before, we can change the solver and tolerances:
 
 ```@example 1
-NLS.solve(prob, NLS.GaussNewton(), reltol = 1e-12, abstol = 1e-12)
+NLS.solve(prob, NLS.GaussNewton(), reltol = 1.0e-12, abstol = 1.0e-12)
 ```
 
 ## Going Beyond the Basics: How to use the Documentation

--- a/docs/src/tutorials/large_systems.md
+++ b/docs/src/tutorials/large_systems.md
@@ -61,7 +61,7 @@ The resulting `NonlinearProblem` definition is:
 
 ```@example ill_conditioned_nlprob
 import NonlinearSolve as NLS
-import LinearAlgebra
+import LinearAlgebra as LA
 import SparseArrays
 import LinearSolve as LS
 import ADTypes
@@ -81,15 +81,16 @@ function brusselator_2d_loop(du, u, p)
         ip1, im1 = limit(i + 1, N), limit(i - 1, N)
         jp1, jm1 = limit(j + 1, N), limit(j - 1, N)
         du[i, j, 1] = alpha * (
-                        u[im1, j, 1] + u[ip1, j, 1] + u[i, jp1, 1] + u[i, jm1, 1] -
-                        4u[i, j, 1]
-                      ) + B +
-                      u[i, j, 1]^2 * u[i, j, 2] - (A + 1) * u[i, j, 1] + brusselator_f(x, y)
+            u[im1, j, 1] + u[ip1, j, 1] + u[i, jp1, 1] + u[i, jm1, 1] -
+                4u[i, j, 1]
+        ) + B +
+            u[i, j, 1]^2 * u[i, j, 2] - (A + 1) * u[i, j, 1] + brusselator_f(x, y)
         du[i, j, 2] = alpha * (
-                        u[im1, j, 2] + u[ip1, j, 2] + u[i, jp1, 2] + u[i, jm1, 2] -
-                        4u[i, j, 2]
-                      ) + A * u[i, j, 1] - u[i, j, 1]^2 * u[i, j, 2]
+            u[im1, j, 2] + u[ip1, j, 2] + u[i, jp1, 2] + u[i, jm1, 2] -
+                4u[i, j, 2]
+        ) + A * u[i, j, 1] - u[i, j, 1]^2 * u[i, j, 2]
     end
+    return
 end
 p = (3.4, 1.0, 10.0, step(xyd_brusselator))
 
@@ -102,12 +103,12 @@ function init_brusselator_2d(xyd)
         u[I, 1] = 22 * (y * (1 - y))^(3 / 2)
         u[I, 2] = 27 * (x * (1 - x))^(3 / 2)
     end
-    u
+    return u
 end
 
 u0 = init_brusselator_2d(xyd_brusselator)
 prob_brusselator_2d = NLS.NonlinearProblem(
-    brusselator_2d_loop, u0, p; abstol = 1e-10, reltol = 1e-10
+    brusselator_2d_loop, u0, p; abstol = 1.0e-10, reltol = 1.0e-10
 )
 ```
 
@@ -149,16 +150,20 @@ import SparseMatrixColorings
 
 prob_brusselator_2d_autosparse = NLS.NonlinearProblem(
     NLS.NonlinearFunction(brusselator_2d_loop; sparsity = TracerSparsityDetector()),
-    u0, p; abstol = 1e-10, reltol = 1e-10
+    u0, p; abstol = 1.0e-10, reltol = 1.0e-10
 )
 
 autodiff = ADTypes.AutoForwardDiff(; chunksize = 12)
 
 @btime NLS.solve(prob_brusselator_2d_autosparse, NLS.NewtonRaphson(; autodiff));
-@btime NLS.solve(prob_brusselator_2d_autosparse,
-    NLS.NewtonRaphson(; autodiff, linsolve = LS.KLUFactorization()));
-@btime NLS.solve(prob_brusselator_2d_autosparse,
-    NLS.NewtonRaphson(; autodiff, linsolve = LS.KrylovJL_GMRES()));
+@btime NLS.solve(
+    prob_brusselator_2d_autosparse,
+    NLS.NewtonRaphson(; autodiff, linsolve = LS.KLUFactorization())
+);
+@btime NLS.solve(
+    prob_brusselator_2d_autosparse,
+    NLS.NewtonRaphson(; autodiff, linsolve = LS.KrylovJL_GMRES())
+);
 nothing # hide
 ```
 
@@ -201,7 +206,7 @@ ff = NLS.NonlinearFunction(brusselator_2d_loop; jac_prototype = jac_sparsity)
 Build the `NonlinearProblem`:
 
 ```@example ill_conditioned_nlprob
-prob_brusselator_2d_sparse = NLS.NonlinearProblem(ff, u0, p; abstol = 1e-10, reltol = 1e-10)
+prob_brusselator_2d_sparse = NLS.NonlinearProblem(ff, u0, p; abstol = 1.0e-10, reltol = 1.0e-10)
 ```
 
 Now let's see how the version with sparsity compares to the version without:
@@ -254,9 +259,10 @@ used in the solution of the ODE. An example of this with using
 # FIXME: On 1.10+ this is broken. Skipping this for now.
 import IncompleteLU
 
-incompletelu(W, p = nothing) = IncompleteLU.ilu(W, τ = 50.0), LinearAlgebra.I
+incompletelu(W, p = nothing) = IncompleteLU.ilu(W, τ = 50.0), LA.I
 
-@btime NLS.solve(prob_brusselator_2d_sparse,
+@btime NLS.solve(
+    prob_brusselator_2d_sparse,
     NLS.NewtonRaphson(linsolve = LS.KrylovJL_GMRES(precs = incompletelu), concrete_jac = true)
 );
 nothing # hide
@@ -279,14 +285,15 @@ parameter. Another option is to use
 which is more automatic. The setup is very similar to before:
 
 ```@example ill_conditioned_nlprob
-import AlgebraicMultigrid
+import AlgebraicMultigrid as AM
 
 function algebraicmultigrid(W, p = nothing)
-    return AlgebraicMultigrid.aspreconditioner(AlgebraicMultigrid.ruge_stuben(convert(AbstractMatrix, W))),
-    LinearAlgebra.I
+    return AM.aspreconditioner(AM.ruge_stuben(convert(AbstractMatrix, W))),
+        LA.I
 end
 
-@btime NLS.solve(prob_brusselator_2d_sparse,
+@btime NLS.solve(
+    prob_brusselator_2d_sparse,
     NLS.NewtonRaphson(
         linsolve = LS.KrylovJL_GMRES(; precs = algebraicmultigrid), concrete_jac = true
     )
@@ -299,11 +306,15 @@ or with a Jacobi smoother:
 ```@example ill_conditioned_nlprob
 function algebraicmultigrid2(W, p = nothing)
     A = convert(AbstractMatrix, W)
-    Pl = AlgebraicMultigrid.aspreconditioner(AlgebraicMultigrid.ruge_stuben(
-        A, presmoother = AlgebraicMultigrid.Jacobi(rand(size(A, 1))),
-        postsmoother = AlgebraicMultigrid.Jacobi(rand(size(A, 1)))
-    ))
-    return Pl, LinearAlgebra.I
+    n = size(A, 1)
+    Pl = AM.aspreconditioner(
+        AM.ruge_stuben(
+            A,
+            presmoother = AM.Jacobi(rand(n)),
+            postsmoother = AM.Jacobi(rand(n))
+        )
+    )
+    return Pl, LA.I
 end
 
 @btime NLS.solve(
@@ -326,11 +337,15 @@ import DifferentiationInterface: DenseSparsityDetector
 
 prob_brusselator_2d_exact_tracer = NLS.NonlinearProblem(
     NLS.NonlinearFunction(brusselator_2d_loop; sparsity = TracerSparsityDetector()),
-    u0, p; abstol = 1e-10, reltol = 1e-10)
+    u0, p; abstol = 1.0e-10, reltol = 1.0e-10
+)
 prob_brusselator_2d_approx_di = NLS.NonlinearProblem(
-    NLS.NonlinearFunction(brusselator_2d_loop;
-        sparsity = DenseSparsityDetector(ADTypes.AutoForwardDiff(); atol = 1e-4)),
-    u0, p; abstol = 1e-10, reltol = 1e-10)
+    NLS.NonlinearFunction(
+        brusselator_2d_loop;
+        sparsity = DenseSparsityDetector(ADTypes.AutoForwardDiff(); atol = 1.0e-4)
+    ),
+    u0, p; abstol = 1.0e-10, reltol = 1.0e-10
+)
 
 @btime NLS.solve(prob_brusselator_2d_exact_tracer, NLS.NewtonRaphson());
 @btime NLS.solve(prob_brusselator_2d_approx_di, NLS.NewtonRaphson());

--- a/docs/src/tutorials/modelingtoolkit.md
+++ b/docs/src/tutorials/modelingtoolkit.md
@@ -18,9 +18,11 @@ MTK.@mtkbuild ns = MTK.NonlinearSystem(eqs, [x, y, z], [σ, ρ, β])
 
 u0 = [x => 1.0, y => 0.0, z => 0.0]
 
-ps = [σ => 10.0
-      ρ => 26.0
-      β => 8 / 3]
+ps = [
+    σ => 10.0
+    ρ => 26.0
+    β => 8 / 3
+]
 
 prob = NLS.NonlinearProblem(ns, u0, ps)
 sol = NLS.solve(prob, NLS.NewtonRaphson())
@@ -57,8 +59,10 @@ solved more simply. Let's take a look at a quick system:
 
 ```julia
 MTK.@variables u1 u2 u3 u4 u5
-eqs = [0 ~ u1 - sin(u5), 0 ~ u2 - cos(u1), 0 ~ u3 - hypot(u1, u2),
-    0 ~ u4 - hypot(u2, u3), 0 ~ u5 - hypot(u4, u1)]
+eqs = [
+    0 ~ u1 - sin(u5), 0 ~ u2 - cos(u1), 0 ~ u3 - hypot(u1, u2),
+    0 ~ u4 - hypot(u2, u3), 0 ~ u5 - hypot(u4, u1),
+]
 MTK.@named sys = MTK.NonlinearSystem(eqs, [u1, u2, u3, u4, u5], [])
 ```
 

--- a/docs/src/tutorials/optimizing_parameterized_ode.md
+++ b/docs/src/tutorials/optimizing_parameterized_ode.md
@@ -17,6 +17,7 @@ function lotka_volterra!(du, u, p, t)
     α, β, δ, γ = p
     du[1] = dx = α * x - β * x * y
     du[2] = dy = -δ * y + γ * x * y
+    return
 end
 
 # Initial condition
@@ -55,7 +56,8 @@ Now, we can use any NLLS solver to solve this problem.
 ```@example parameterized_ode
 res = NLS.solve(
     nlls_prob, NLS.LevenbergMarquardt(); maxiters = 1000, show_trace = Val(true),
-    trace_level = NLS.TraceWithJacobianConditionNumber(25))
+    trace_level = NLS.TraceWithJacobianConditionNumber(25)
+)
 nothing # hide
 ```
 
@@ -66,8 +68,10 @@ res
 We can also use Trust Region methods.
 
 ```@example parameterized_ode
-res = NLS.solve(nlls_prob, NLS.TrustRegion(); maxiters = 1000, show_trace = Val(true),
-    trace_level = NLS.TraceWithJacobianConditionNumber(25))
+res = NLS.solve(
+    nlls_prob, NLS.TrustRegion(); maxiters = 1000, show_trace = Val(true),
+    trace_level = NLS.TraceWithJacobianConditionNumber(25)
+)
 nothing # hide
 ```
 

--- a/docs/src/tutorials/snes_ex2.md
+++ b/docs/src/tutorials/snes_ex2.md
@@ -19,7 +19,7 @@ u0 = fill(0.5, 128)
 function form_residual!(resid, x, _)
     n = length(x)
     xp = LinRange(0.0, 1.0, n)
-    F = 6xp .+ (xp .+ 1e-12) .^ 6
+    F = 6xp .+ (xp .+ 1.0e-12) .^ 6
 
     dx = 1 / (n - 1)
     resid[1] = x[1]
@@ -39,7 +39,8 @@ details.
 ```@example snes_ex2
 nlfunc_dense = NLS.NonlinearFunction(form_residual!)
 nlfunc_sparse = NLS.NonlinearFunction(
-    form_residual!; sparsity = SparseConnectivityTracer.TracerSparsityDetector())
+    form_residual!; sparsity = SparseConnectivityTracer.TracerSparsityDetector()
+)
 
 nlprob_dense = NLS.NonlinearProblem(nlfunc_dense, u0)
 nlprob_sparse = NLS.NonlinearProblem(nlfunc_sparse, u0)
@@ -49,14 +50,14 @@ Now we can solve the problem using `PETScSNES` or with one of the native `Nonlin
 solvers.
 
 ```@example snes_ex2
-sol_dense_nr = NLS.solve(nlprob_dense, NLS.NewtonRaphson(); abstol = 1e-8)
-sol_dense_snes = NLS.solve(nlprob_dense, NLS.PETScSNES(); abstol = 1e-8)
+sol_dense_nr = NLS.solve(nlprob_dense, NLS.NewtonRaphson(); abstol = 1.0e-8)
+sol_dense_snes = NLS.solve(nlprob_dense, NLS.PETScSNES(); abstol = 1.0e-8)
 sol_dense_nr .- sol_dense_snes
 ```
 
 ```@example snes_ex2
-sol_sparse_nr = NLS.solve(nlprob_sparse, NLS.NewtonRaphson(); abstol = 1e-8)
-sol_sparse_snes = NLS.solve(nlprob_sparse, NLS.PETScSNES(); abstol = 1e-8)
+sol_sparse_nr = NLS.solve(nlprob_sparse, NLS.NewtonRaphson(); abstol = 1.0e-8)
+sol_sparse_snes = NLS.solve(nlprob_sparse, NLS.PETScSNES(); abstol = 1.0e-8)
 sol_sparse_nr .- sol_sparse_snes
 ```
 
@@ -68,19 +69,19 @@ runtimes.
 ### Dense Jacobian
 
 ```@example snes_ex2
-@benchmark NLS.solve($(nlprob_dense), $(NLS.NewtonRaphson()); abstol = 1e-8)
+@benchmark NLS.solve($(nlprob_dense), $(NLS.NewtonRaphson()); abstol = 1.0e-8)
 ```
 
 ```@example snes_ex2
-@benchmark NLS.solve($(nlprob_dense), $(NLS.PETScSNES()); abstol = 1e-8)
+@benchmark NLS.solve($(nlprob_dense), $(NLS.PETScSNES()); abstol = 1.0e-8)
 ```
 
 ### Sparse Jacobian
 
 ```@example snes_ex2
-@benchmark NLS.solve($(nlprob_sparse), $(NLS.NewtonRaphson()); abstol = 1e-8)
+@benchmark NLS.solve($(nlprob_sparse), $(NLS.NewtonRaphson()); abstol = 1.0e-8)
 ```
 
 ```@example snes_ex2
-@benchmark NLS.solve($(nlprob_sparse), $(NLS.PETScSNES()); abstol = 1e-8)
+@benchmark NLS.solve($(nlprob_sparse), $(NLS.PETScSNES()); abstol = 1.0e-8)
 ```

--- a/lib/NonlinearSolveBase/src/arclength.jl
+++ b/lib/NonlinearSolveBase/src/arclength.jl
@@ -1,10 +1,12 @@
 """
-    ArcLengthContinuation(; inner = nothing, initial_step_factor = 0.1,
+    ArcLengthContinuation(;
+        inner = nothing, initial_step_factor = 0.1,
         adaptive = true, min_ds = nothing, max_step_factor = 1.0,
         expand_factor = 2.0, expand_threshold = 2, max_angle = π / 6,
         predictor = :secant, autodiff = nothing, linsolve = nothing,
         tracking_maxiters = 10, maxsteps = 10000, theta = 0.5,
-        store_original = Val(false))
+        store_original = Val(false)
+    )
 
 Pseudo-arclength continuation solver for a `SciMLBase.HomotopyProblem`. Unlike
 [`HomotopySweep`](@ref), which marches the scalar parameter ``λ`` monotonically, this

--- a/lib/NonlinearSolveBase/src/descent/damped_newton.jl
+++ b/lib/NonlinearSolveBase/src/descent/damped_newton.jl
@@ -1,6 +1,8 @@
 """
-    DampedNewtonDescent(; linsolve = nothing, initial_damping, damping_fn,
-                          min_norm_mode = :auto)
+    DampedNewtonDescent(;
+        linsolve = nothing, initial_damping, damping_fn,
+        min_norm_mode = :auto
+    )
 
 A Newton descent algorithm with damping. The damping factor is computed using the
 `damping_fn` function. The descent direction is computed as ``(JᵀJ + λDᵀD) δu = -fu``. For

--- a/lib/NonlinearSolveBase/src/homotopy_polyalg.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_polyalg.jl
@@ -96,10 +96,12 @@ below) — by default it is dropped so the returned solution stays concretely ty
 using NonlinearSolve
 
 alg = HomotopyPolyAlgorithm() # HomotopySweep, then ArcLengthContinuation on failure
-alg = HomotopyPolyAlgorithm((
-    HomotopySweep(; inner = NewtonRaphson()),
-    ArcLengthContinuation(; predictor = :tangent),
-))
+alg = HomotopyPolyAlgorithm(
+    (
+        HomotopySweep(; inner = NewtonRaphson()),
+        ArcLengthContinuation(; predictor = :tangent),
+    )
+)
 alg = HomotopyPolyAlgorithm(; warm_handoff = false) # always restart stages cold
 ```
 """

--- a/lib/NonlinearSolveBase/src/homotopy_sweep.jl
+++ b/lib/NonlinearSolveBase/src/homotopy_sweep.jl
@@ -1,9 +1,11 @@
 """
-    HomotopySweep(; inner = nothing, nsteps = nothing, adaptive = true,
+    HomotopySweep(;
+        inner = nothing, nsteps = nothing, adaptive = true,
         initial_step_factor = 0.1, min_dλ = nothing, max_step_factor = 1.0,
         expand_factor = 2.0, expand_threshold = 2, expand_quality = 0.25,
         predictor = :secant, tracking_maxiters = 10, tracking_abstol = nothing,
-        maxsteps = 10000, store_original = Val(false))
+        maxsteps = 10000, store_original = Val(false)
+    )
 
 Natural-parameter continuation solver for `SciMLBase.HomotopyProblem`. The
 scalar continuation parameter ``λ`` is swept across the problem's `λspan`. The sweep

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -5,7 +5,7 @@ end
 
 """
 ```julia
-solve(prob::NonlinearProblem, alg::Union{AbstractNonlinearAlgorithm,Nothing}; kwargs...)
+solve(prob::NonlinearProblem, alg::Union{AbstractNonlinearAlgorithm, Nothing}; kwargs...)
 ```
 
 ## Arguments

--- a/lib/NonlinearSolveBase/src/verbosity.jl
+++ b/lib/NonlinearSolveBase/src/verbosity.jl
@@ -36,7 +36,7 @@ Create a `NonlinearVerbosity` using a preset configuration:
 - `SciMLLogging.Detailed()`: Comprehensive debugging information
 - `SciMLLogging.All()`: Maximum verbosity
 
-    NonlinearVerbosity(; error_control=nothing, numerical=nothing, sensitivity=nothing, linear_verbosity=nothing, kwargs...)
+    NonlinearVerbosity(; error_control = nothing, numerical = nothing, sensitivity = nothing, linear_verbosity = nothing, kwargs...)
 
 Create a `NonlinearVerbosity` with group-level or individual field control.
 

--- a/lib/NonlinearSolveSciPy/src/NonlinearSolveSciPy.jl
+++ b/lib/NonlinearSolveSciPy/src/NonlinearSolveSciPy.jl
@@ -25,7 +25,7 @@ using NonlinearSolveBase: NonlinearSolveBase, AbstractNonlinearSolveAlgorithm,
     construct_extension_function_wrapper
 
 """
-    SciPyLeastSquares(; method="trf", loss="linear")
+    SciPyLeastSquares(; method = "trf", loss = "linear")
 
 Wrapper over `scipy.optimize.least_squares` (via PythonCall) for solving
 `NonlinearLeastSquaresProblem`s.  The keyword arguments correspond to the
@@ -84,7 +84,7 @@ least-squares method.
 SciPyLeastSquaresLM() = SciPyLeastSquares(method = "lm")
 
 """
-    SciPyRoot(; method="hybr")
+    SciPyRoot(; method = "hybr")
 
 Wrapper over `scipy.optimize.root` for solving `NonlinearProblem`s.  Available
 methods include "hybr" (default), "lm", "broyden1", "broyden2", "anderson",
@@ -103,7 +103,7 @@ function SciPyRoot(; method::String = "hybr")
 end
 
 """
-    SciPyRootScalar(; method="brentq")
+    SciPyRootScalar(; method = "brentq")
 
 Wrapper over `scipy.optimize.root_scalar` for scalar `IntervalNonlinearProblem`s
 (bracketing problems).  The default method uses Brent's algorithm ("brentq").

--- a/lib/NonlinearSolveSpectralMethods/src/dfsane.jl
+++ b/lib/NonlinearSolveSpectralMethods/src/dfsane.jl
@@ -1,6 +1,6 @@
 """
     DFSane(;
-        sigma_min = 1 // 10^10, sigma_max = 1e10, sigma_1 = 1, M::Int = 10,
+        sigma_min = 1 // 10^10, sigma_max = 1.0e10, sigma_1 = 1, M::Int = 10,
         gamma = 1 // 10^4, tau_min = 1 // 10, tau_max = 1 // 2, n_exp::Int = 2,
         max_inner_iterations::Int = 100, eta_strategy = (fn_1, n, x_n, f_n) -> fn_1 / n^2
     )

--- a/lib/SciMLJacobianOperators/src/SciMLJacobianOperators.jl
+++ b/lib/SciMLJacobianOperators/src/SciMLJacobianOperators.jl
@@ -40,8 +40,10 @@ A Jacobian Operator Provides both JVP and VJP without materializing either (if p
 ### Constructor
 
 ```julia
-JacobianOperator(prob::AbstractNonlinearProblem, fu, u; jvp_autodiff = nothing,
-    vjp_autodiff = nothing, skip_vjp::Val = Val(false), skip_jvp::Val = Val(false))
+JacobianOperator(
+    prob::AbstractNonlinearProblem, fu, u; jvp_autodiff = nothing,
+    vjp_autodiff = nothing, skip_vjp::Val = Val(false), skip_jvp::Val = Val(false)
+)
 ```
 
 By default, the `JacobianOperator` will compute `JVP`. Use `Base.adjoint` or

--- a/lib/SimpleNonlinearSolve/README.md
+++ b/lib/SimpleNonlinearSolve/README.md
@@ -19,5 +19,5 @@ using SimpleNonlinearSolve, StaticArrays
 f(u, p) = u .* u .- 2
 u0 = @SVector[1.0, 1.0]
 probN = NonlinearProblem{false}(f, u0)
-solver = solve(probN, SimpleNewtonRaphson(), abstol = 1e-9)
+solver = solve(probN, SimpleNewtonRaphson(), abstol = 1.0e-9)
 ```

--- a/lib/SimpleNonlinearSolve/src/dfsane.jl
+++ b/lib/SimpleNonlinearSolve/src/dfsane.jl
@@ -1,7 +1,7 @@
 """
     SimpleDFSane(;
-        σ_min::Real = 1e-10, σ_max::Real = 1e10, σ_1::Real = 1.0,
-        M::Union{Int, Val} = Val(10), γ::Real = 1e-4, τ_min::Real = 0.1, τ_max::Real = 0.5,
+        σ_min::Real = 1.0e-10, σ_max::Real = 1.0e10, σ_1::Real = 1.0,
+        M::Union{Int, Val} = Val(10), γ::Real = 1.0e-4, τ_min::Real = 0.1, τ_max::Real = 0.5,
         nexp::Int = 2, η_strategy::Function = (f_1, k, x, F) -> f_1 ./ k^2
     )
 

--- a/lib/SimpleNonlinearSolve/src/simple_homotopy_sweep.jl
+++ b/lib/SimpleNonlinearSolve/src/simple_homotopy_sweep.jl
@@ -1,9 +1,11 @@
 """
-    SimpleHomotopySweep(; inner = SimpleNewtonRaphson(), nsteps = nothing,
+    SimpleHomotopySweep(;
+        inner = SimpleNewtonRaphson(), nsteps = nothing,
         adaptive = true, initial_step_factor = 0.1, min_dλ = nothing,
         max_step_factor = 1.0, expand_factor = 2.0, expand_threshold = 2,
         expand_quality = 0.25, predictor = :secant, tracking_maxiters = 10,
-        tracking_abstol = nothing, maxsteps = 10000)
+        tracking_abstol = nothing, maxsteps = 10000
+    )
 
 Natural-parameter continuation solver for a `SciMLBase.HomotopyProblem`, the
 SimpleNonlinearSolve counterpart of `HomotopySweep`. The algorithm is the same —

--- a/src/extension_algs.jl
+++ b/src/extension_algs.jl
@@ -44,8 +44,8 @@ end
 """
     FastLevenbergMarquardtJL(
         linsolve::Symbol = :cholesky;
-        factor = 1e-6, factoraccept = 13.0, factorreject = 3.0, factorupdate = :marquardt,
-        minscale = 1e-12, maxscale = 1e16, minfactor = 1e-28, maxfactor = 1e32,
+        factor = 1.0e-6, factoraccept = 13.0, factorreject = 3.0, factorupdate = :marquardt,
+        minscale = 1.0e-12, maxscale = 1.0e16, minfactor = 1.0e-28, maxfactor = 1.0e32,
         autodiff = nothing
     )
 
@@ -408,7 +408,7 @@ end
 
 """
     SIAMFANLEquationsJL(;
-        method = :newton, delta = 1e-3, linsolve = nothing, autodiff = missing
+        method = :newton, delta = 1.0e-3, linsolve = nothing, autodiff = missing
     )
 
 ### Keyword Arguments


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Make documentation example style consistent with code style. Also introduces some auxiliary variables to make examples easier to read, and adds some import aliases (`LinearAlgebra` → `LA`, `AlgebraicMultigrid` → `AM`)