### PR TITLE
Release NonlinearSolveFirstOrder 2.5.1

### DIFF
--- a/lib/NonlinearSolveFirstOrder/Project.toml
+++ b/lib/NonlinearSolveFirstOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveFirstOrder"
 uuid = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "2.5.0"
+version = "2.5.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Bumps `NonlinearSolveFirstOrder` 2.5.0 -> 2.5.1 (patch).

Source files changed since 2.5.0:
- `src/trust_region.jl`

Commits:
- NonlinearSolveBase: rebuild a pre-wrapped function when its signatures do not match u0/p (#1226)
- Fix reverse AD through despecialized parameters (#1228)
- Preserve Jacobian cache parameter representation (#1227)
- Preserve TrustRegion cache parameter representation on reinit (#1229)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
