### PR TITLE
Release NonlinearSolve 4.29.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolve"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.29.1"
+version = "4.29.2"
 authors = ["SciML"]
 
 [deps]


### PR DESCRIPTION
Bumps `NonlinearSolve` 4.29.1 -> 4.29.2 (patch).

Source files changed since 4.29.1:
- `src/extension_algs.jl`

Commits:
- NonlinearSolveBase: rebuild a pre-wrapped function when its signatures do not match u0/p (#1226)
- Fix reverse AD through despecialized parameters (#1228)
- Preserve Jacobian cache parameter representation (#1227)
- Preserve TrustRegion cache parameter representation on reinit (#1229)
- Run runic on docstrings and markdown files (#1231)
- Release NonlinearSolveFirstOrder 2.5.1 (#1232)
- NonlinearSolveBase: report the wrapped arity for despecialization wrappers (#1230)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
