### PR TITLE
Release NonlinearSolveSciPy 1.3.6

### DIFF
--- a/lib/NonlinearSolveSciPy/Project.toml
+++ b/lib/NonlinearSolveSciPy/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveSciPy"
 uuid = "4827a3aa-8a82-4c61-8bd0-3c7d3e464ee5"
 authors = ["SciML"]
-version = "1.3.5"
+version = "1.3.6"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Bumps `NonlinearSolveSciPy` 1.3.5 -> 1.3.6 (patch).

Source files changed since 1.3.5:
- `src/NonlinearSolveSciPy.jl`

Commits:
- Render cache accessor docs (#1196)
- Drop stale [compat] majors older than one year (#1198)
- Drop @fastmath from L2_NORM/Linf_NORM so isfinite guards survive (#1182)
- Release 4.28.1 (#1202)
- Release 2.48.1 (#1206)
- Align QA NLsolve compat with root project (#1205)
- Widen NonlinearSolveBase LogExpFunctions compat to 0.3.28–1 (#1203)
- Continue polyalgorithm after stalled least-squares solves (#1204)
- Align Wrappers NLsolve compat with root project (#1208)
- Release 2.48.2 (#1210)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
