### PR TITLE
Release NonlinearSolveSpectralMethods 1.8.2

### DIFF
--- a/lib/NonlinearSolveSpectralMethods/Project.toml
+++ b/lib/NonlinearSolveSpectralMethods/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveSpectralMethods"
 uuid = "26075421-4e9a-44e1-8bd1-420ed7ad02b2"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.8.1"
+version = "1.8.2"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Bumps `NonlinearSolveSpectralMethods` 1.8.1 -> 1.8.2 (patch).

Source files changed since 1.8.1:
- `src/dfsane.jl`

Commits:
- Render cache accessor docs (#1196)
- Drop stale [compat] majors older than one year (#1198)
- Drop @fastmath from L2_NORM/Linf_NORM so isfinite guards survive (#1182)
- Release 4.28.1 (#1202)
- Release 2.48.1 (#1206)
- Align QA NLsolve compat with root project (#1205)
- Widen NonlinearSolveBase LogExpFunctions compat to 0.3.28–1 (#1203)
- Continue polyalgorithm after stalled least-squares solves (#1204)
- Align Wrappers NLsolve compat with root project (#1208)
- Release 2.48.2 (#1210)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
