### PR TITLE
Release SciMLJacobianOperators 0.1.19

### DIFF
--- a/lib/SciMLJacobianOperators/Project.toml
+++ b/lib/SciMLJacobianOperators/Project.toml
@@ -1,6 +1,6 @@
 name = "SciMLJacobianOperators"
 uuid = "19f34311-ddf3-4b8b-af20-060888a46c0e"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
Bumps `SciMLJacobianOperators` 0.1.18 -> 0.1.19 (patch).

Source files changed since 0.1.18:
- `src/SciMLJacobianOperators.jl`

Commits:
- Drop stale [compat] majors older than one year (#1198)
- Drop @fastmath from L2_NORM/Linf_NORM so isfinite guards survive (#1182)
- Release 4.28.1 (#1202)
- Release 2.48.1 (#1206)
- Align QA NLsolve compat with root project (#1205)
- Widen NonlinearSolveBase LogExpFunctions compat to 0.3.28–1 (#1203)
- Continue polyalgorithm after stalled least-squares solves (#1204)
- Align Wrappers NLsolve compat with root project (#1208)
- Release 2.48.2 (#1210)
- Preserve despecialized parameters during reinit (#1199)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
