### PR TITLE
Fix SimpleNonlinearSolve keyword override flags and parameterless GPU solves

### DIFF
--- a/lib/SimpleNonlinearSolve/src/SimpleNonlinearSolve.jl
+++ b/lib/SimpleNonlinearSolve/src/SimpleNonlinearSolve.jl
@@ -142,8 +142,8 @@ function CommonSolve.solve(
     new_p = p !== nothing ? p : prob.p
     return simplenonlinearsolve_solve_up(
         prob, sensealg,
-        new_u0, u0 === nothing,
-        new_p, p === nothing,
+        new_u0, u0 !== nothing,
+        new_p, p !== nothing,
         alg, args...;
         prob.kwargs..., kwargs...
     )

--- a/lib/SimpleNonlinearSolve/test/core/rootfind_tests__item5.jl
+++ b/lib/SimpleNonlinearSolve/test/core/rootfind_tests__item5.jl
@@ -4,3 +4,16 @@ include("setup_rootfindtestsnippet.jl")
 prob = NonlinearProblem(quadratic_f, ones(4), 2.0; maxiters = 2)
 sol = solve(prob, SimpleNewtonRaphson())
 @test sol.retcode === ReturnCode.MaxIters
+
+@testset "Initial state and parameter overrides" begin
+    for make_prob in (identity, prob -> convert(SciMLBase.ImmutableNonlinearProblem, prob))
+        prob = make_prob(NonlinearProblem{false}((u, p) -> u .* u .- p, 1.0, 1.0))
+        for (u0, p, expected) in (
+                (nothing, nothing, 1.0), (-1.0, nothing, -1.0),
+                (nothing, 4.0, 2.0), (-1.0, 4.0, -2.0),
+            )
+            sol = solve(prob, SimpleNewtonRaphson(); u0, p)
+            @test sol.u ≈ expected
+        end
+    end
+end

--- a/lib/SimpleNonlinearSolve/test/gpu/cuda_tests__item2.jl
+++ b/lib/SimpleNonlinearSolve/test/gpu/cuda_tests__item2.jl
@@ -1,4 +1,5 @@
 using SimpleNonlinearSolve
+using SciMLBase
 
 using StaticArrays, CUDA, SimpleNonlinearSolve, ADTypes, LineSearch
 using NonlinearSolveBase: ImmutableNonlinearProblem
@@ -52,5 +53,20 @@ if CUDA.functional()
                 true
             end
         end
+    end
+
+    @testset "Immutable problem without parameters" begin
+        prob = convert(
+            SciMLBase.ImmutableNonlinearProblem,
+            NonlinearProblem{false}((u, p) -> u .- 1.0f0, SVector(0.0f0))
+        )
+        function parameterless_kernel!(out, prob)
+            sol = solve(prob, SimpleNewtonRaphson())
+            out[1] = sol.u[1]
+            return nothing
+        end
+        out = CUDA.zeros(Float32, 1)
+        @cuda parameterless_kernel!(out, prob)
+        @test Array(out) ≈ [1.0f0]
     end
 end


### PR DESCRIPTION
Supplying both `u0` and `p` to a SimpleNonlinearSolve solve currently ignores both overrides because the `u0_changed`/`p_changed` flags are inverted. Correct the two predicates so supplied overrides trigger `remake`, while calls without overrides avoid it. The latter also restores parameterless immutable nonlinear solves inside OpenCL kernels, which previously compiled through an unnecessary `remake` and failed with invalid GPU IR.

Added all four keyword combinations for mutable and immutable problems to the existing Core kwargs tests, plus a parameterless kernel regression to the existing CUDA group. No dependencies or public signatures change.

Ignore this PR until reviewed by @ChrisRackauckas.

### Failing before / passing after

On unmodified owner master `0dccd34d125638394c2f3e5e53be3b5e272896a0`, running the exact new Core testset with Julia 1.12.7 produced:

```text
Test Summary:                         | Pass  Fail  Total  Time
Initial state and parameter overrides |    6     2      8  2.9s
```

Both failures are simultaneous keyword overrides. The identical testset after the fix:

```text
Test Summary:                         | Pass  Total  Time
Initial state and parameter overrides |    8      8  0.6s
```

Command: `julia +1.12 --project=scratch/nonlinear-owner-fix-env scratch/nonlinear_override_regression.jl` (the script imports SimpleNonlinearSolve/SciMLBase/Test and contains the new testset verbatim).

An independent owner-level reproduction uses OpenCL 0.10.11 / GPUCompiler 2.5.4 / POCL and imports no DiffEqGPU:

```julia
using SimpleNonlinearSolve, SciMLBase, StaticArrays, KernelAbstractions
using OpenCL, pocl_jll, Test
f(u, p) = u .- 1f0
prob = convert(SciMLBase.ImmutableNonlinearProblem,
    NonlinearProblem{false}(f, SVector(0f0)))
@kernel function nonlinear_kernel!(out, prob)
    i = @index(Global)
    sol = solve(prob, SimpleNewtonRaphson())
    out[i] = sol.u[1]
end
backend = OpenCL.OpenCLBackend()
out = KernelAbstractions.zeros(backend, Float32, 3)
nonlinear_kernel!(backend)(out, prob; ndrange = 3)
KernelAbstractions.synchronize(backend)
@test Array(out) ≈ fill(1f0, 3)
```

Before: `InvalidIRError`, including unsupported `julia.new_gc_frame` and `typejoin` calls through `remake`. After: exit 0 with the output assertion passing. The same environment with clean DiffEqGPU master and its initialization-preprocessing test changes from InvalidIR to:

```text
Test Summary:                          | Pass  Total   Time
Initialization preprocessing runs once |    2      2  49.5s
```

Source-history tracing finds the inverted predicates introduced in https://github.com/SciML/NonlinearSolve.jl/commit/cc61d5a0d69470000f07957853af583e38b2508f . This is source provenance; no historical 2024 dependency-environment runtime bisect is claimed.

### Validation

Commands:

```sh
GROUP=Core julia +1.12 --project=lib/SimpleNonlinearSolve -e 'using Pkg; Pkg.test()'
GROUP=QA julia +1.12 --project=lib/SimpleNonlinearSolve -e 'using Pkg; Pkg.test()'
```

Core completed with 35,620 passing assertions and four pre-existing broken assertions; no tests were skipped, disabled, or altered to suppress failure. Tail:

```text
Test Summary:      | Pass  Total  Time
Kwargs Propagation |    9      9  1.8s
     Testing SimpleNonlinearSolve tests passed
```

QA:

```text
Test Summary: | Pass  Total     Time
QA            |   20     20  1m09.4s
     Testing SimpleNonlinearSolve tests passed
```

Runic, typos over the changed files, and `git diff --check` pass. No docs/public API additions; docs build not run. CUDA hardware tests, adjoint tests, and the full monorepo suite were not run. The new CUDA regression uses the same problem/solve/output operation exercised locally through OpenCL/POCL, but CUDA compilation itself remains unverified.

🤖 Generated with Codex (harness version: unknown; exact model ID: unknown). Local session ID: `01a07fcc-1c4f-7ee3-9a1e-51eaab7df293`; no shareable conversation URL exposed.
