### PR TITLE
Release BracketingNonlinearSolve 1.12.7

### DIFF
--- a/lib/BracketingNonlinearSolve/Project.toml
+++ b/lib/BracketingNonlinearSolve/Project.toml
@@ -1,6 +1,6 @@
 name = "BracketingNonlinearSolve"
 uuid = "70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
-version = "1.12.6"
+version = "1.12.7"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
Bumps `BracketingNonlinearSolve` 1.12.6 -> 1.12.7 (patch).

Source files changed since 1.12.6:
- `ext/BracketingNonlinearSolveForwardDiffExt.jl`
- `src/utils.jl`

Commits:
- Render cache accessor docs (#1196)
- Drop stale [compat] majors older than one year (#1198)
- Drop @fastmath from L2_NORM/Linf_NORM so isfinite guards survive (#1182)
- Release 4.28.1 (#1202)
- Release 2.48.1 (#1206)
- Align QA NLsolve compat with root project (#1205)
- Widen NonlinearSolveBase LogExpFunctions compat to 0.3.28–1 (#1203)
- Continue polyalgorithm after stalled least-squares solves (#1204)
- Align Wrappers NLsolve compat with root project (#1208)
- Release 2.48.2 (#1210)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
