### PR TITLE
Release NonlinearSolveBase 2.49.5

### DIFF
--- a/lib/NonlinearSolveBase/Project.toml
+++ b/lib/NonlinearSolveBase/Project.toml
@@ -1,6 +1,6 @@
 name = "NonlinearSolveBase"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "2.49.4"
+version = "2.49.5"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
Bumps `NonlinearSolveBase` 2.49.4 -> 2.49.5 (patch).

Source files changed since 2.49.4:
- `src/arclength.jl`
- `src/autospecialize.jl`
- `src/homotopy_polyalg.jl`
- `src/homotopy_sweep.jl`
- `src/solve.jl`

Commits:
- Remove name duplicates in keyword arguments/named tuples (#1238)
- Add 32-bit Core CI lane via test_groups.toml (#1239)
- Add a native bounded trust-region solver (#1219)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
