### PR TITLE
Release NonlinearSolveSciPy 1.3.7

### DIFF
--- a/lib/NonlinearSolveSciPy/Project.toml
+++ b/lib/NonlinearSolveSciPy/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveSciPy"
 uuid = "4827a3aa-8a82-4c61-8bd0-3c7d3e464ee5"
 authors = ["SciML"]
-version = "1.3.6"
+version = "1.3.7"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Bumps `NonlinearSolveSciPy` 1.3.6 -> 1.3.7 (patch).

Source files changed since 1.3.6:
- `src/NonlinearSolveSciPy.jl`

Commits:
- Remove name duplicates in keyword arguments/named tuples (#1238)
- Add 32-bit Core CI lane via test_groups.toml (#1239)
- Add a native bounded trust-region solver (#1219)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
