### PR TITLE
Release NonlinearSolveSpectralMethods 1.8.3

### DIFF
--- a/lib/NonlinearSolveSpectralMethods/Project.toml
+++ b/lib/NonlinearSolveSpectralMethods/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveSpectralMethods"
 uuid = "26075421-4e9a-44e1-8bd1-420ed7ad02b2"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "1.8.2"
+version = "1.8.3"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"


### PR DESCRIPTION
Bumps `NonlinearSolveSpectralMethods` 1.8.2 -> 1.8.3 (patch).

Source files changed since 1.8.2:
- `src/dfsane.jl`

Commits:
- Remove name duplicates in keyword arguments/named tuples (#1238)
- Add 32-bit Core CI lane via test_groups.toml (#1239)
- Add a native bounded trust-region solver (#1219)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
