### PR TITLE
Release SCCNonlinearSolve 1.15.3

### DIFF
--- a/lib/SCCNonlinearSolve/Project.toml
+++ b/lib/SCCNonlinearSolve/Project.toml
@@ -1,6 +1,6 @@
 name = "SCCNonlinearSolve"
 uuid = "9dfe8606-65a1-4bb3-9748-cb89d1561431"
-version = "1.15.2"
+version = "1.15.3"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
 
 [deps]


### PR DESCRIPTION
Bumps `SCCNonlinearSolve` 1.15.2 -> 1.15.3 (patch).

Source files changed since 1.15.2:
- `src/SCCNonlinearSolve.jl`

Commits:
- Require all components to stall before resetting Broyden (#1184)
- Add adaptive Jacobian reuse to first-order solvers (#1072)
- Release 4.29.1 (#1220)
- Release 2.49.1 (#1221)
- Release 1.15.3 (#1222)
- Fix @static_timeit for TimerOutputs ≥ 0.5.27 (#1224) (#1225)
- NonlinearSolveBase: rebuild a pre-wrapped function when its signatures do not match u0/p (#1226)
- Fix reverse AD through despecialized parameters (#1228)
- Preserve Jacobian cache parameter representation (#1227)
- Preserve TrustRegion cache parameter representation on reinit (#1229)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
