### PR TITLE
Release NonlinearSolveFirstOrder 2.6.1

### DIFF
--- a/lib/NonlinearSolveFirstOrder/Project.toml
+++ b/lib/NonlinearSolveFirstOrder/Project.toml
@@ -1,7 +1,7 @@
 name = "NonlinearSolveFirstOrder"
 uuid = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
 authors = ["Avik Pal <avikpal@mit.edu> and contributors"]
-version = "2.6.0"
+version = "2.6.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Bumps `NonlinearSolveFirstOrder` 2.6.0 -> 2.6.1 (patch).

Source files changed since 2.6.0:
- `src/NonlinearSolveFirstOrder.jl`
- `src/eisenstat_walker.jl`
- `src/forward_diff.jl`
- `src/gauss_newton.jl`
- `src/jacobian_reuse.jl`
- `src/levenberg_marquardt.jl`
- `src/poly_algs.jl`
- `src/pseudo_transient.jl`
- `src/raphson.jl`
- `src/solve.jl`
- `src/trust_region.jl`

Commits:
- Skip FWW wrapping for Dual-eltype u0
- Use ArrayInterface.promote_eltype instead of similar for VdT
- Fix GPU/runic failures after rebase
- Bump julia-actions/setup-julia from 2 to 3
- Avoid dense N×N Jacobian allocation for Anderson (#862)
- Update Project.toml
- Bump Sundials and OrdinaryDiffEqTsit5 compat (consolidates #921–#924)
- Update documentation with latest improvements
- Add ModAB algorithm to precompilation workload
- Limit algorithms to ModAB for bracketing solve

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
