### PR TITLE
Benchmark each revision with its local sublibraries on Julia LTS

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,13 +6,12 @@ on:
     paths-ignore: ['docs/**']
 
 permissions:
-  pull-requests: write
   contents: read
 
 jobs:
   benchmark:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -20,10 +19,29 @@ jobs:
     env:
       # Force consistent Julia depot path for self-hosted runners
       JULIA_DEPOT_PATH: ~/.julia
+      JULIA_PKG_PRECOMPILE_AUTO: '0'
     steps:
-      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+      - uses: actions/checkout@v6
         with:
-          julia-version: ${{ matrix.version }}
-          script: "benchmark/benchmarks.jl"
-          extra-pkgs: "StableRNGs"
-          job-summary: true
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/cache@v2
+      - name: Install benchmark tools
+        run: |
+          mkdir -p .benchmark/tmp
+          export TMPDIR="$GITHUB_WORKSPACE/.benchmark/tmp"
+          echo "TMPDIR=$TMPDIR" >> "$GITHUB_ENV"
+          julia --startup-file=no -e 'using Pkg; Pkg.activate(".benchmark/tools"); Pkg.add(PackageSpec(name="AirspeedVelocity", version="0.6.5"))'
+      - name: Benchmark both revisions with their local source packages
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: julia --startup-file=no --project=.benchmark/tools benchmark/ci.jl "$BASE_SHA" "$HEAD_SHA" results
+      - uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results-${{ matrix.version }}
+          path: results/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ docs/src/assets/Project.toml
 .vscode
 wip
 .CondaPkg
+
+.benchmark/

--- a/benchmark/ci.jl
+++ b/benchmark/ci.jl
@@ -1,0 +1,47 @@
+using AirspeedVelocity, Pkg, TOML
+
+function benchmark_revisions(repo, revisions, output; script = nothing, kwargs...)
+    repo, output = abspath(repo), abspath(output)
+    revisions = String.(revisions)
+    scratch = joinpath(repo, ".benchmark", "checkouts")
+    mkpath(scratch)
+    mkpath(output)
+    checkouts = map(revisions) do revision
+        path = mktempdir(scratch)
+        run(`git clone --shared --no-checkout $repo $path`)
+        run(`git -C $path checkout --detach $revision`)
+        path
+    end
+    package = TOML.parsefile(joinpath(first(checkouts), "Project.toml"))["name"]
+    script = script === nothing ? joinpath(first(checkouts), "benchmark", "benchmarks.jl") : abspath(script)
+    for (revision, checkout) in zip(revisions, checkouts)
+        # A local path lets AirspeedVelocity develop that revision's source packages on LTS.
+        AirspeedVelocity.benchmark(
+            PackageSpec(; name = package, path = checkout, rev = revision);
+            script, output_dir = output, extra_pkgs = ["StableRNGs"], kwargs...
+        )
+    end
+    return AirspeedVelocity.load_results(package, revisions; input_dir = output)
+end
+
+function write_benchmark_summary(io, results)
+    println(io, "## Benchmark results (Julia $(VERSION))\n")
+    for (label, key) in (("Time", "median"), ("Memory", "memory"))
+        println(io, "### $label\n")
+        println(io, AirspeedVelocity.create_table(results; add_ratio_col = true, key))
+        println(io)
+    end
+    return
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    length(ARGS) == 3 || error("Usage: ci.jl BASE_SHA HEAD_SHA OUTPUT_DIR")
+    results = benchmark_revisions(pwd(), ARGS[1:2], ARGS[3])
+    if haskey(ENV, "GITHUB_STEP_SUMMARY")
+        open(ENV["GITHUB_STEP_SUMMARY"], "a") do io
+            write_benchmark_summary(io, results)
+        end
+    else
+        write_benchmark_summary(stdout, results)
+    end
+end


### PR DESCRIPTION
The benchmark job fails on Julia LTS when a PR introduces an unregistered monorepo sublibrary version. The existing remote-URL installation ignores local `[sources]` on Julia 1.10 and attempts to resolve that sublibrary from the registry. Benchmark each revision from an independent local clone instead, allowing AirspeedVelocity to develop that revision's local source packages before installing the root package.

The same baseline benchmark script runs against both revisions. The workflow keeps the Julia release/LTS matrix, writes time and memory comparisons to the job summary, and uploads JSON results. It uses the existing AirspeedVelocity 0.6.5 tool through its public API. Package dependencies and solver behavior are unchanged.

### Verification

Reproduced the original remote-URL failure locally on Julia 1.10.11 against the reflective feature revision:
```text
ERROR: Unsatisfiable requirements detected for package NonlinearSolveFirstOrder:
possible versions are: 1.0.0-2.6.1 or uninstalled
restricted to versions 2.7.0-2 by NonlinearSolve — no versions left
NonlinearSolve is fixed to version 4.31.0
```

Ran the new `benchmark_revisions` driver locally on **Julia 1.10.11 and 1.12.7**, comparing the actual baseline and feature revisions with a one-sample Newton benchmark. The benchmark asserts that `pkgdir(NonlinearSolveFirstOrder)` lies inside the driver's local checkouts. Both versions produced JSON results for both revisions and printed:
```text
LOCAL_SOURCE_VERSION=2.6.1
[runner] Finished benchmarks for NonlinearSolve@40f6f613950636e22c25077124a93b914c1df669.
LOCAL_SOURCE_VERSION=2.7.0
[runner] Finished benchmarks for NonlinearSolve@9ea6e621313afacb1988855c73ee9935f29e79dd.
```
The initial local invocation returned `SubString` revisions from `readchomp`, which AirspeedVelocity's results loader rejects. The driver now normalizes revisions to `String`; loading both generated artifacts and rendering the time/memory tables was verified separately after that correction. GitHub supplies string-valued `ARGS`.

Exact benchmark invocation (with the appropriate Julia version and its binary directory first in `PATH`):
```julia
include("benchmark/ci.jl")
revs = [readchomp(`git rev-parse origin/master`), readchomp(`git rev-parse 9ea6e6213`)]
benchmark_revisions(pwd(), revs, "../scratch/benchmark-results";
    script="../scratch/benchmark-smoke.jl", nsamples_load_time=1)
results = AirspeedVelocity.load_results("NonlinearSolve", String.(revs);
    input_dir="../scratch/benchmark-results")
write_benchmark_summary(stdout, results)
```

`GROUP=QA julia +1.12 --compiled-modules=existing --project -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'`:
```text
Test Summary: | Pass  Total     Time
QA            |   28     28  2m38.5s
Testing NonlinearSolve tests passed
```
Runic, `typos`, `actionlint`, and `git diff --check` passed. The full production benchmark suite and GitHub artifact upload were not run locally; the local test exercises package resolution, actual solver execution, distinct source versions, result loading, and table rendering. No checks were disabled.

### Links

- Blocking feature draft: https://github.com/SciML/NonlinearSolve.jl/pull/1256

Ignore this draft until reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.154.0 (model: gpt-6-astra). Session: local transcript `/home/crackauc/.codex/sessions/2026/09/12/rollout-2026-09-12T04-30-15-01a094bd-179a-7972-97ec-36badb9448cd.jsonl`.
