### PR TITLE
Release SimpleNonlinearSolve 2.14.4

### DIFF
--- a/lib/SimpleNonlinearSolve/Project.toml
+++ b/lib/SimpleNonlinearSolve/Project.toml
@@ -1,7 +1,7 @@
 name = "SimpleNonlinearSolve"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
 authors = ["SciML"]
-version = "2.14.3"
+version = "2.14.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
Bumps `SimpleNonlinearSolve` 2.14.3 -> 2.14.4 (patch).

Source files changed since 2.14.3:
- `src/SimpleNonlinearSolve.jl`

Commits:
- Fix SimpleNonlinearSolve keyword override flags and parameterless GPU solves (#1240)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
