### PR TITLE
Fix Float32 trust-region arithmetic in GPU kernels

### DIFF
--- a/lib/SimpleNonlinearSolve/src/trust_region.jl
+++ b/lib/SimpleNonlinearSolve/src/trust_region.jl
@@ -122,7 +122,7 @@ function SciMLBase.__solve(
         end
     end
 
-    fₖ = 0.5 * norm_fx^2
+    fₖ = norm_fx^2 / T(2)
     H = transpose(J) * J
     g = NLBUtils.restructure(x, J' * NLBUtils.safe_vec(fx))
     shrink_counter = 0
@@ -189,7 +189,7 @@ function SciMLBase.__solve(
         if NLBUtils.unwrap_val(alg.nlsolve_update_rule)
             if r > η₃
                 Δ = t₂ * L2_NORM(δ)
-            elseif r > 0.5
+            elseif r > T(0.5)
                 Δ = max(Δ, t₂ * L2_NORM(δ))
             end
         end

--- a/lib/SimpleNonlinearSolve/test/gpu/cuda_tests__item2.jl
+++ b/lib/SimpleNonlinearSolve/test/gpu/cuda_tests__item2.jl
@@ -4,6 +4,8 @@ using SciMLBase
 using StaticArrays, CUDA, SimpleNonlinearSolve, ADTypes, LineSearch
 using NonlinearSolveBase: ImmutableNonlinearProblem
 
+include("trust_region_float32.jl")
+
 if CUDA.functional()
     CUDA.allowscalar(false)
 
@@ -53,6 +55,20 @@ if CUDA.functional()
                 true
             end
         end
+    end
+
+    function trust_region_kernel!(out, prob, alg)
+        out[1] = solve(prob, alg).u[1]
+        return nothing
+    end
+
+    test_trust_region_float32() do prob, alg
+        out = CUDA.zeros(Float32, 1)
+        io = IOBuffer()
+        CUDA.@device_code_llvm io = io dump_module = true @cuda trust_region_kernel!(
+            out, prob, alg
+        )
+        return Array(out), String(take!(io))
     end
 
     @testset "Immutable problem without parameters" begin

--- a/lib/SimpleNonlinearSolve/test/gpu/trust_region_float32.jl
+++ b/lib/SimpleNonlinearSolve/test/gpu/trust_region_float32.jl
@@ -1,0 +1,14 @@
+function test_trust_region_float32(compile_solve)
+    prob = convert(
+        SciMLBase.ImmutableNonlinearProblem,
+        NonlinearProblem{false}((u, p) -> u .- 1.0f0, SVector(0.0f0))
+    )
+    return @testset "Float32 trust-region arithmetic" begin
+        @testset "$update" for update in (Val(false), Val(true))
+            alg = SimpleTrustRegion(; nlsolve_update_rule = update)
+            result, ir = compile_solve(prob, alg)
+            @test result ≈ [1.0f0]
+            @test isnothing(match(r"\b(?:fmul|fdiv|fsub|fadd|fcmp)\b[^\n]*\bdouble\b", ir))
+        end
+    end
+end


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

`SimpleTrustRegion` promotes its first objective value to Float64 when solving a Float32 problem. That introduces double arithmetic into GPU kernels and prevents compilation on Metal and oneAPI devices without Float64 support. Compute the initial objective in the solution element type, matching subsequent objectives, and type the alternate radius-update threshold consistently.

The existing CUDA kernel group now checks both radius-update rules for a correct Float32 solution and absence of double arithmetic/comparisons in generated LLVM. Its assertions are shared with the local OpenCL/POCL reproducer; no dependencies or test groups are added.

History tracing with `git log -S` and inspection of its parent identifies https://github.com/SciML/NonlinearSolve.jl/commit/cb2d24a82acee84a80fa281d80beea607daf6930 as the introduction of both literals. The parent had no trust-region implementation. This is source-history attribution, not a run of the 2024 dependency environment.

### Verification

Julia 1.13.0, OpenCL 0.10.11, GPUCompiler 2.6.0, pocl_jll 7.1.3+9. The same shared regression was run against a copy of the package with the two source expressions reverted, then against this fix:

```text
$ julia +1.13.0 --project=scratch/trust-region/before-env scratch/trust-region/shared-opencl.jl
Test Summary:                   | Pass  Fail  Total   Time
Float32 trust-region arithmetic |    2     2      4  40.1s
  Val{false}()                  |    1     1      2  39.4s
  Val{true}()                   |    1     1      2   0.7s
Evaluated: isnothing(RegexMatch("fmul double"))

$ julia +1.13.0 --project=scratch/ci-investigation/trust-region-env scratch/trust-region/shared-opencl.jl
Test Summary:                   | Pass  Total   Time
Float32 trust-region arithmetic |    4      4  38.2s
```

The unfixed solve returns the correct result on POCL, which supports Float64; the generated-code assertion discriminates the unsupported arithmetic that fails on the other backends.

```text
$ GROUP=QA julia +1.13.0 --project=NonlinearSolve-trust-region/lib/SimpleNonlinearSolve -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total   Time
QA            |   20     20  50.3s
     Testing SimpleNonlinearSolve tests passed
```

```text
$ GROUP=Core julia +1.13.0 --project=NonlinearSolve-trust-region/lib/SimpleNonlinearSolve -e 'using Pkg; Pkg.test()'
Test Summary:           | Pass  Total   Time
Derivative Free Methods |  234    234  43.0s
Test Summary: | Pass  Total  Time
Newton Fails  |   12     12  5.3s
Test Summary:      | Pass  Total  Time
Kwargs Propagation |    9      9  1.0s
     Testing SimpleNonlinearSolve tests passed
```

Across the Core summaries: 35,620 passed and four pre-existing broken tests; this PR adds no skips or broken tests.

Runic, `typos` over added lines, and `git diff --check` passed. CUDA, Metal, and oneAPI execution were not run locally because the required hardware/driver is unavailable. The newly added CUDA test will run in the existing CUDA CI group. No docstrings or public API were changed, so no docs build was run.

<details>
<summary>Local OpenCL wrapper using the same committed test assertions</summary>

Run from the repository root in a local environment containing this checkout of SimpleNonlinearSolve, SciMLBase, StaticArrays, KernelAbstractions, OpenCL, pocl_jll, Test, and InteractiveUtils:

```julia
using SimpleNonlinearSolve, SciMLBase, StaticArrays, KernelAbstractions
using OpenCL, pocl_jll, Test, InteractiveUtils
versioninfo()
include("lib/SimpleNonlinearSolve/test/gpu/trust_region_float32.jl")
@kernel function trust_region_kernel!(out, prob, alg)
    i = @index(Global)
    out[i] = solve(prob, alg).u[1]
end
backend = OpenCL.OpenCLBackend()
test_trust_region_float32() do prob, alg
    out = KernelAbstractions.zeros(backend, Float32, 1)
    io = IOBuffer()
    OpenCL.@device_code_llvm io = io dump_module = true trust_region_kernel!(backend)(out, prob, alg; ndrange = 1)
    KernelAbstractions.synchronize(backend)
    return Array(out), String(take!(io))
end
```
</details>

### Links

- Metal failure in downstream initialization: https://buildkite.com/julialang/diffeqgpu-dot-jl/builds/1685#01a099f7-68ed-43b4-8f11-4004cb96aeaa
- oneAPI failure at the same objective calculation: https://buildkite.com/julialang/diffeqgpu-dot-jl/builds/1685#01a099f7-68ea-4dbe-97c1-0a87c6effe28
- Downstream PR requiring a released fix: https://github.com/SciML/DiffEqGPU.jl/pull/532

🤖 Generated with Codex CLI 0.153.4 (model: gpt-6-astra; local session ID: 01a07fcc-1c4f-7ee3-9a1e-51eaab7df293).
