### PR TITLE
Apply the chain rule to bounded-problem derivative callbacks

### DIFF
--- a/lib/NonlinearSolveBase/src/bounds_transform.jl
+++ b/lib/NonlinearSolveBase/src/bounds_transform.jl
@@ -133,7 +133,8 @@ end
 function (d::BoundedDerivative{:jac})(J, u, p)
     d.f(J, _transform_u(d.wrapper, u), p)
     scale = _transform_derivative(d.wrapper, u)
-    J .*= transpose(vec(scale))
+    # Preserve structural zeros when the transform derivative vanishes.
+    LinearAlgebra.rmul!(J, Diagonal(vec(scale)))
     return J
 end
 

--- a/lib/NonlinearSolveBase/src/bounds_transform.jl
+++ b/lib/NonlinearSolveBase/src/bounds_transform.jl
@@ -29,6 +29,18 @@ function _from_unbounded(t, lb, ub)
     end
 end
 
+function _from_unbounded_derivative(t, lb, ub)
+    if isfinite(lb) && isfinite(ub)
+        return (ub - lb) * logistic(t) * logistic(-t)
+    elseif isfinite(lb)
+        return exp(t)
+    elseif isfinite(ub)
+        return -exp(t)
+    else
+        return one(t)
+    end
+end
+
 # Clamp a value into the strict interior of [lb, ub] so that _to_unbounded (logit)
 # doesn't receive 0 or 1, which would give ±Inf. Only applied once to u0 before
 # the initial transform — it's a no-op if u0 is already in the interval.
@@ -67,6 +79,10 @@ function _normalize_bound(bound, fill_value, u0)
     end
 end
 
+function _normalize_bound(bound, fill_value, u0::Number)
+    return convert(typeof(u0), isnothing(bound) ? fill_value : bound)
+end
+
 function _normalize_bounds(lb, ub, u0)
     new_lb = _normalize_bound(lb, -Inf, u0)
     new_ub = _normalize_bound(ub, Inf, u0)
@@ -93,6 +109,54 @@ function _transform_u(w::BoundedWrapper, u)
     tmp = _bounds_tmp(w.u_cache, u)
     @. tmp = _from_unbounded(u, w.lb, w.ub)
     return tmp
+end
+
+function _transform_u(w::BoundedWrapper, u::Number)
+    return _from_unbounded(u, w.lb, w.ub)
+end
+
+@concrete struct BoundedDerivative{kind}
+    f
+    wrapper
+end
+
+function _transform_derivative(w, u)
+    return _from_unbounded_derivative.(u, w.lb, w.ub)
+end
+
+function (d::BoundedDerivative{:jac})(u, p)
+    J = d.f(_transform_u(d.wrapper, u), p)
+    scale = _transform_derivative(d.wrapper, u)
+    return scale isa Number ? J * scale : J * Diagonal(vec(scale))
+end
+
+function (d::BoundedDerivative{:jac})(J, u, p)
+    d.f(J, _transform_u(d.wrapper, u), p)
+    scale = _transform_derivative(d.wrapper, u)
+    J .*= transpose(vec(scale))
+    return J
+end
+
+function (d::BoundedDerivative{:jvp})(v, u, p)
+    scale = _transform_derivative(d.wrapper, u)
+    return d.f(scale .* v, _transform_u(d.wrapper, u), p)
+end
+
+function (d::BoundedDerivative{:jvp})(Jv, v, u, p)
+    scale = _transform_derivative(d.wrapper, u)
+    d.f(Jv, scale .* v, _transform_u(d.wrapper, u), p)
+    return Jv
+end
+
+function (d::BoundedDerivative{:vjp})(v, u, p)
+    Jv = d.f(v, _transform_u(d.wrapper, u), p)
+    return _transform_derivative(d.wrapper, u) .* Jv
+end
+
+function (d::BoundedDerivative{:vjp})(Jv, v, u, p)
+    d.f(Jv, v, _transform_u(d.wrapper, u), p)
+    Jv .*= _transform_derivative(d.wrapper, u)
+    return Jv
 end
 
 function (w::BoundedWrapper{false})(u, p)
@@ -151,7 +215,9 @@ function transform_bounded_problem(prob, alg)
     # FixedSizeDiffCache if we're using ForwardDiff. Not every algorithm has an
     # `autodiff` field (e.g. `QuasiNewtonAlgorithm`), so guard the access.
     alg_ad = alg !== nothing && hasproperty(alg, :autodiff) ? alg.autodiff : nothing
-    make_u_cache = if alg_ad === nothing || alg_ad isa AutoForwardDiff
+    make_u_cache = if prob.u0 isa Number
+        () -> prob.u0
+    elseif alg_ad === nothing || alg_ad isa AutoForwardDiff
         () -> FixedSizeDiffCache(prob.u0)
     else
         () -> similar(prob.u0)
@@ -172,7 +238,22 @@ function transform_bounded_problem(prob, alg)
     )
 
     new_f = if orig_f isa NonlinearFunction
-        @set orig_f.f = wrapped
+        nf = @set orig_f.f = wrapped
+        if SciMLBase.has_jac(orig_f)
+            nf = @set nf.jac = BoundedDerivative{:jac}(orig_f.jac, wrapped)
+        end
+        if SciMLBase.has_jvp(orig_f)
+            nf = @set nf.jvp = BoundedDerivative{:jvp}(orig_f.jvp, wrapped)
+        end
+        if SciMLBase.has_vjp(orig_f)
+            nf = @set nf.vjp = BoundedDerivative{:vjp}(orig_f.vjp, wrapped)
+        end
+        if SciMLBase.has_paramjac(orig_f)
+            nf = @set nf.paramjac = BoundedWrapper{SciMLBase.isinplace(prob)}(
+                orig_f.paramjac, lb, ub, u_cache, u_prev_cache
+            )
+        end
+        nf
     else
         wrapped
     end

--- a/lib/NonlinearSolveBase/src/solve.jl
+++ b/lib/NonlinearSolveBase/src/solve.jl
@@ -411,11 +411,13 @@ function _solution_from_cache(cache::AbstractNonlinearSolveCache; transform_boun
     # BoundedWrapper, map the solution back from unbounded to bounded space.
     if transform_bounds && _has_bounded_wrapper(cache)
         bw = cache.prob.f.f
-        sol.u .= _from_unbounded.(sol.u, bw.lb, bw.ub)
+        u, u0 = sol.u, sol.prob.u0
+        @bb @. u = _from_unbounded(u, bw.lb, bw.ub)
+        @bb @. u0 = _from_unbounded(u0, bw.lb, bw.ub)
+        @set! sol.u = u
 
         # Reset the problem to the original fields that were overwritten
-        @set! sol.prob = remake(sol.prob; bw.f, bw.lb, bw.ub)
-        sol.prob.u0 .= _from_unbounded.(sol.prob.u0, bw.lb, bw.ub)
+        @set! sol.prob = remake(sol.prob; bw.f, bw.lb, bw.ub, u0)
     end
 
     return sol

--- a/lib/NonlinearSolveBase/test/bounds_transform.jl
+++ b/lib/NonlinearSolveBase/test/bounds_transform.jl
@@ -13,6 +13,16 @@ using NonlinearSolveBase: transform_bounded_problem, BoundedWrapper, _to_unbound
 # assume every algorithm exposes `autodiff`.
 struct NoAutodiffAlg end
 
+struct BoundsSolutionCache{P, U, F} <: NonlinearSolveBase.AbstractNonlinearSolveCache
+    prob::P
+    u::U
+    fu::F
+    alg::NoAutodiffAlg
+    retcode::ReturnCode.T
+    stats::SciMLBase.NLStats
+    trace::Nothing
+end
+
 @testset "bounds transform handles algorithms without an `autodiff` field" begin
     f(u, p) = u .^ 2 .- p
     prob = NonlinearProblem(f, [1.5, 1.5], [2.0, 2.0]; lb = [0.0, 0.0], ub = [3.0, 3.0])
@@ -25,6 +35,108 @@ struct NoAutodiffAlg end
         @test tprob.ub === nothing
         # u0 is mapped into unbounded space
         @test tprob.u0 ≈ _to_unbounded.(prob.u0, prob.lb, prob.ub)
+    end
+end
+
+@testset "analytic derivatives follow bounded coordinates" begin
+    using LinearAlgebra, SparseArrays
+
+    for iip in (false, true), sparse_jacobian in (false, true)
+        A = [1.0 2.0 0.0 0.0; 0.0 1.0 3.0 0.0; 2.0 0.0 1.0 4.0]
+        sparse_jacobian && (A = sparse(A))
+        f(u, p) = p .* (A * u .^ 2)
+        jac(u, p) = p .* A * Diagonal(2 .* u)
+        jvp(v, u, p) = p .* (A * (2 .* u .* v))
+        vjp(v, u, p) = 2p .* u .* (A' * v)
+        paramjac(u, p) = A * u .^ 2
+        f!(r, u, p) = (r .= f(u, p))
+        jac!(J, u, p) = (J .= jac(u, p))
+        jvp!(Jv, v, u, p) = (Jv .= jvp(v, u, p))
+        vjp!(Jv, v, u, p) = (Jv .= vjp(v, u, p))
+        paramjac!(Jp, u, p) = (Jp .= paramjac(u, p))
+        prototype = copy(A)
+        nf = if iip
+            NonlinearFunction{true}(
+                f!; jac = jac!, jvp = jvp!, vjp = vjp!, paramjac = paramjac!,
+                jac_prototype = prototype, resid_prototype = zeros(3)
+            )
+        else
+            NonlinearFunction{false}(
+                f; jac, jvp, vjp, paramjac, jac_prototype = prototype
+            )
+        end
+        prob = NonlinearLeastSquaresProblem(
+            nf, [0.7, 1.3, -0.4, 2.0], 1.7;
+            lb = [0.0, 0.0, -Inf, -Inf], ub = [2.0, Inf, 1.0, Inf]
+        )
+        transformed = transform_bounded_problem(prob, nothing)
+        @test transformed.f.jac_prototype === prototype
+        for t in (transformed.u0, transformed.u0 .+ 0.2), p in (1.7, 0.8)
+            residual(t) = if iip
+                r = similar(t, 3)
+                transformed.f(r, t, p)
+            else
+                transformed.f(t, p)
+            end
+            expected = ForwardDiff.jacobian(residual, t)
+            v = [0.2, -0.3, 0.5, 0.7]
+            w = [0.3, -0.2, 0.6]
+            expected_p = ForwardDiff.derivative(p) do q
+                if iip
+                    r = zeros(typeof(q), 3)
+                    transformed.f(r, t, q)
+                else
+                    transformed.f(t, q)
+                end
+            end
+            J, Jv, Jtw, Jp = if iip
+                J, Jv, Jtw, Jp = copy(prototype), zeros(3), zeros(4), zeros(3)
+                transformed.f.jac(J, t, p)
+                transformed.f.jvp(Jv, v, t, p)
+                transformed.f.vjp(Jtw, w, t, p)
+                transformed.f.paramjac(Jp, t, p)
+                J, Jv, Jtw, Jp
+            else
+                transformed.f.jac(t, p), transformed.f.jvp(v, t, p),
+                    transformed.f.vjp(w, t, p), transformed.f.paramjac(t, p)
+            end
+            @test J ≈ expected
+            @test Jv ≈ expected * v
+            @test Jtw ≈ expected' * w
+            @test Jp ≈ expected_p
+            @test issparse(J) == sparse_jacobian
+        end
+    end
+end
+
+@testset "scalar analytic derivatives follow bounded coordinates" begin
+    for (lb, ub) in ((0.0, 3.0), (0.0, nothing), (nothing, 3.0))
+        nf = NonlinearFunction{false}(
+            (u, p) -> p * u^2;
+            jac = (u, p) -> 2p * u,
+            jvp = (v, u, p) -> 2p * u * v,
+            vjp = (v, u, p) -> 2p * u * v,
+            paramjac = (u, p) -> u^2
+        )
+        prob = NonlinearProblem(nf, 1.2, 0.7; lb, ub)
+        transformed = transform_bounded_problem(prob, nothing)
+        t, p = transformed.u0, prob.p
+        @test t isa Number
+        @test transformed.f(t, p) ≈ prob.f(prob.u0, p)
+        expected = ForwardDiff.derivative(t -> transformed.f(t, p), t)
+        @test transformed.f.jac(t, p) ≈ expected
+        @test transformed.f.jvp(0.3, t, p) ≈ 0.3expected
+        @test transformed.f.vjp(0.3, t, p) ≈ 0.3expected
+        @test transformed.f.paramjac(t, p) ≈ prob.u0^2
+        cache = BoundsSolutionCache(
+            transformed, t, transformed.f(t, p), NoAutodiffAlg(),
+            ReturnCode.Success, SciMLBase.NLStats(0, 0, 0, 0, 0), nothing
+        )
+        sol = NonlinearSolveBase._solution_from_cache(cache; transform_bounds = true)
+        @test sol.u ≈ prob.u0
+        @test sol.prob.u0 ≈ prob.u0
+        @test sol.prob.lb == (isnothing(lb) ? -Inf : lb)
+        @test sol.prob.ub == (isnothing(ub) ? Inf : ub)
     end
 end
 

--- a/lib/NonlinearSolveBase/test/bounds_transform.jl
+++ b/lib/NonlinearSolveBase/test/bounds_transform.jl
@@ -109,6 +109,29 @@ end
     end
 end
 
+@testset "zero transform derivatives preserve sparse structure" begin
+    using LinearAlgebra, SparseArrays
+
+    A = sparse([2.0 1.0; 1.0 3.0])
+    f!(r, u, p) = mul!(r, A, u)
+    jac!(J, u, p) = (nonzeros(J) .= nonzeros(A))
+    nf = NonlinearFunction{true}(f!; jac = jac!, jac_prototype = copy(A))
+    prob = NonlinearProblem(nf, [0.5, 0.5]; lb = 0.0, ub = 1.0)
+    transformed = transform_bounded_problem(prob, nothing)
+    J = copy(A)
+    for t in ([-1000.0, 0.0], [0.0, 1000.0], [1000.0, -1000.0], [0.0, 0.0])
+        transformed.f.jac(J, t, prob.p)
+        @test J.colptr == A.colptr
+        @test rowvals(J) == rowvals(A)
+        @test nnz(J) == nnz(A)
+        expected = ForwardDiff.jacobian(t) do x
+            r = similar(x)
+            transformed.f(r, x, prob.p)
+        end
+        @test Matrix(J) ≈ expected
+    end
+end
+
 @testset "scalar analytic derivatives follow bounded coordinates" begin
     for (lb, ub) in ((0.0, 3.0), (0.0, nothing), (nothing, 3.0))
         nf = NonlinearFunction{false}(


### PR DESCRIPTION
Bounded problems transformed to unbounded coordinates passed the transformed state directly to analytic derivative callbacks and omitted the inverse-transform derivative. For `f(u) = u² - 4`, `u = 1`, and bounds `[0, 10]`, this produced a Jacobian of `-4.394449154672439` instead of `1.7999999999999992`.

Evaluate `jac`, `jvp`, `vjp`, and `paramjac` in physical coordinates and apply the chain rule to state derivatives. Sparse Jacobians retain their stored-zero structure even when transform derivatives vanish, supplied callbacks remain in use, and scalar states now work through transformation and solution reconstruction. The defect is present in the [original bounds-transform commit](https://github.com/SciML/NonlinearSolve.jl/commit/13d9059f8f28b5f147fb5979073b227d444bff2d); executing that original transform against current dependencies reproduces the incorrect Jacobian above.

Please ignore this PR until reviewed by @ChrisRackauckas.

### Verification

The same array-derivative regression tests were run on unmodified master and with the fix using Julia 1.13.0:

```text
# Unfixed (compiled-modules=no)
analytic derivatives follow bounded coordinates | 20 passed, 64 failed, 84 total
# Fixed
analytic derivatives follow bounded coordinates | 84 passed, 84 total
```

The complete focused file also covers scalar derivatives and scalar solution reconstruction:

```sh
julia +1.13.0 --compiled-modules=existing --project=. lib/NonlinearSolveBase/test/bounds_transform.jl
```

```text
bounds transform handles algorithms without an `autodiff` field |   8 /   8
analytic derivatives follow bounded coordinates               |  84 /  84
zero transform derivatives preserve sparse structure          |  16 /  16
scalar analytic derivatives follow bounded coordinates        |  30 /  30
```

The array cases cover in-place/out-of-place callbacks, dense/sparse rectangular Jacobians, all four bound configurations, JVP/VJP, parameter Jacobians, and repeated states/parameters.

```sh
GROUP=Core julia +1.13.0 --compiled-modules=existing --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
GROUP=QA julia +1.13.0 --compiled-modules=existing --project=lib/NonlinearSolveBase -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
```

Core: **523 assertions passed**; QA: **20 assertions passed**. Both end with `Testing NonlinearSolveBase tests passed`. Runic, typos, and `git diff --check` pass.

The root Core group passed **1,028 assertions** at [59ffc83c4](https://github.com/SciML/NonlinearSolve.jl/commit/59ffc83c4c9b2a0f3a6d151bc9003c89f62988e7), including 18 supplemental Newton assertions across dense, sparse, Krylov JVP/VJP, and scalar solves:

```sh
GROUP=Core julia +1.13.0 --compiled-modules=existing --project=. -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
```

Those integration tests are being carried by the dependent bounded-default PR, which raises the Base minimum version; this prerequisite keeps its regression tests inside Base's own suite.

A second regression test exercises derivative underflow at transformed coordinates `[-1000, 0]`. Broadcast scaling incorrectly removed stored zeros; public `rmul!(J, Diagonal(scale))` preserves the structure required by cached sparse symbolic factorizations:

```text
# Before structure-preserving scaling
colptr: [1, 1, 3] != [1, 3, 5]
rowvals: [1, 2] != [1, 2, 1, 2]
nnz: 2 != 4
zero transform derivatives preserve sparse structure | 1 passed, 3 failed, 1 error
# After
zero transform derivatives preserve sparse structure | 16 passed, 16 total
```

Three 1,024-variable sparse diffusion cases that previously threw `snlu! requires the same sparsity pattern as the analyzed matrix` now return solutions without exceptions. The root case returns `Success` with residual `3.06e-10`; the two active-bound least-squares cases return `MaxIters` with projected gradients `3.30e-13` and `3.94e-13`. These latter two remain benchmark failures under the successful-retcode criterion. The final structural-zero change was checked with the complete Base Core/QA groups and those three solver-level reproductions; root Core was not rerun for that follow-up.

GPU/downstream jobs and prerelease Julia were not run. Docs were not built because this changes private implementation only. Arbitrary custom operator-valued `jac` callbacks were not validated; the tested operator path uses JVP/VJP callbacks.

🤖 Generated with Codex CLI 0.154.0 (model: gpt-6-astra; session: local transcript `/home/crackauc/.codex/sessions/2026/09/12/rollout-2026-09-12T04-30-15-01a094bd-179a-7972-97ec-36badb9448cd.jsonl`).
