### PR TITLE
Respect active bounds in ForwardDiff least-squares sensitivities

### DIFF
--- a/lib/NonlinearSolveBase/src/autodiff.jl
+++ b/lib/NonlinearSolveBase/src/autodiff.jl
@@ -197,6 +197,26 @@ is_finite_differences_backend(::ADTypes.AutoFiniteDiff) = true
 is_finite_differences_backend(::ADTypes.AutoFiniteDifferences) = true
 
 function nlls_generate_vjp_function(prob::NonlinearLeastSquaresProblem, sol, uu)
+    gradient = nlls_generate_gradient_function(prob, sol, uu)
+    prob.lb === nothing && prob.ub === nothing && return gradient
+    lb = something(prob.lb, -Inf)
+    ub = something(prob.ub, Inf)
+    # The projected stationarity equation includes the active-bound KKT conditions.
+    if SciMLBase.isinplace(prob)
+        return @closure (du, u, p) -> begin
+            gradient(du, u, p)
+            @. du = u - clamp(u - du, lb, ub)
+            return nothing
+        end
+    else
+        return @closure (u, p) -> begin
+            g = gradient(u, p)
+            return @. u - clamp(u - g, lb, ub)
+        end
+    end
+end
+
+function nlls_generate_gradient_function(prob::NonlinearLeastSquaresProblem, sol, uu)
     # First check for custom `vjp` then custom `Jacobian` and if nothing is provided use
     # nested autodiff as the last resort
     return if SciMLBase.has_vjp(prob.f)
@@ -215,7 +235,8 @@ function nlls_generate_vjp_function(prob::NonlinearLeastSquaresProblem, sol, uu)
                 u, p,
             ) -> begin
                 resid = prob.f(u, p)
-                return reshape(2 .* prob.f.vjp(resid, u, p), size(u))
+                g = 2 .* prob.f.vjp(resid, u, p)
+                return u isa Number ? g : reshape(g, size(u))
             end
         end
     elseif SciMLBase.has_jac(prob.f)
@@ -235,7 +256,10 @@ function nlls_generate_vjp_function(prob::NonlinearLeastSquaresProblem, sol, uu)
                 u,
                 p,
             ) -> begin
-                return reshape(2 .* vec(prob.f(u, p))' * prob.f.jac(u, p), size(u))
+                resid = prob.f(u, p)
+                J = prob.f.jac(u, p)
+                u isa Number && return 2 * LinearAlgebra.dot(J, resid)
+                return reshape(2 .* vec(resid)' * J, size(u))
             end
         end
     else
@@ -268,6 +292,10 @@ function nlls_generate_vjp_function(prob::NonlinearLeastSquaresProblem, sol, uu)
                 end
             else
                 return @closure (u, p) -> begin
+                    if u isa Number
+                        J = DI.derivative(Base.Fix2(raw_f, p), autodiff, u)
+                        return 2 * LinearAlgebra.dot(J, raw_f(u, p))
+                    end
                     J = DI.jacobian(Base.Fix2(raw_f, p), autodiff, u)
                     return 2 .* (J' * raw_f(u, p))
                 end

--- a/lib/NonlinearSolveBase/src/public.jl
+++ b/lib/NonlinearSolveBase/src/public.jl
@@ -169,6 +169,11 @@ with parameter partials.
 This is developer API for solver packages that need to propagate dual-number sensitivities
 through specialized nonlinear solve implementations.
 
+For box-constrained least-squares problems, sensitivities use the projected stationarity
+equation, including active bounds. They assume parameter-independent bounds, a locally
+unchanged active set, and a nonsingular stationarity Jacobian on the free variables.
+A classical derivative need not exist where the active set changes.
+
 ### Arguments
 
   - `prob`: A SciML nonlinear problem whose parameters may carry ForwardDiff dual values.

--- a/test/Core/bounds_sensitivity_tests.jl
+++ b/test/Core/bounds_sensitivity_tests.jl
@@ -1,0 +1,79 @@
+using NonlinearSolve, SciMLBase, ForwardDiff, LinearAlgebra, Test
+
+@testset "Bounded least-squares implicit sensitivities" begin
+    # Test strictly active or interior solutions, where the active set is locally constant.
+    for inplace in (false, true), derivative in (:autodiff, :jac, :vjp)
+        f(u, p) = u .- p
+        f!(r, u, p) = (r .= u .- p; nothing)
+        jac(u, p) = Matrix{eltype(u)}(I, length(u), length(u))
+        jac!(J, u, p) = (J .= jac(u, p); nothing)
+        vjp(v, u, p) = v
+        vjp!(out, v, u, p) = (out .= v; nothing)
+        options = derivative === :jac ? (; jac = inplace ? jac! : jac) :
+            derivative === :vjp ? (; vjp = inplace ? vjp! : vjp) : (;)
+        nf = NonlinearFunction{inplace}(inplace ? f! : f; options...)
+        function solution(p; cached = false)
+            prob = NonlinearLeastSquaresProblem(
+                nf, [0.5, 0.5, 0.5, 0.5], p;
+                lb = [0.0, 0.0, 0.0, 0.5], ub = [1.0, 1.0, 1.0, 0.5]
+            )
+            if cached
+                cache = init(prob, BoundedTrustRegion(); abstol = 1.0e-10, reltol = 1.0e-10)
+                solve!(cache)
+                reinit!(cache; u0 = prob.u0, p = p .+ [3.0, -3.0, 0.0, 0.0])
+                return solve!(cache).u
+            end
+            return solve(prob, BoundedTrustRegion(); abstol = 1.0e-10, reltol = 1.0e-10).u
+        end
+        p = [-1.0, 2.0, 0.3, 2.0]
+        expected = diagm([0.0, 0.0, 1.0, 0.0])
+        @test solution(p) ≈ [0.0, 1.0, 0.3, 0.5] atol = 1.0e-8
+        @test ForwardDiff.jacobian(solution, p) ≈ expected atol = 1.0e-10
+        @test solution(p; cached = true) ≈ [1.0, 0.0, 0.3, 0.5] atol = 1.0e-8
+        @test ForwardDiff.jacobian(p -> solution(p; cached = true), p) ≈ expected atol = 1.0e-10
+    end
+    for (lb, ub, p, expected) in (
+            (nothing, 1.0, 2.0, 0.0), (0.0, nothing, -1.0, 0.0),
+            (0.0, 1.0, 0.3, 1.0), (0.5, 0.5, 2.0, 0.0),
+        )
+        scalar_parameter(p) = only(
+            solve(
+                NonlinearLeastSquaresProblem(
+                    (u, p) -> u .- p,
+                    [0.5], p; lb, ub
+                ), BoundedTrustRegion(); abstol = 1.0e-10, reltol = 1.0e-10
+            ).u
+        )
+        @test ForwardDiff.derivative(scalar_parameter, p) ≈ expected atol = 1.0e-10
+    end
+    for derivative in (:autodiff, :jac, :vjp), (p, expected) in ((2.0, 0.0), (0.3, 1.0))
+        options = derivative === :jac ? (; jac = (u, p) -> one(u)) :
+            derivative === :vjp ? (; vjp = (v, u, p) -> v) : (;)
+        nf = NonlinearFunction((u, p) -> u - p; options...)
+        scalar_state(p) = solve(
+            NonlinearLeastSquaresProblem(
+                nf, 0.5, p; lb = 0.0,
+                ub = 1.0
+            ), BoundedTrustRegion(); abstol = 1.0e-10, reltol = 1.0e-10
+        ).u
+        @test ForwardDiff.derivative(scalar_state, p) ≈ expected atol = 1.0e-10
+        function scalar_cached(p)
+            prob = NonlinearLeastSquaresProblem(nf, 0.5, p; lb = 0.0, ub = 1.0)
+            cache = init(prob, BoundedTrustRegion(); abstol = 1.0e-10, reltol = 1.0e-10)
+            solve!(cache)
+            reinit!(cache; u0 = 0.5, p)
+            return solve!(cache).u
+        end
+        @test ForwardDiff.derivative(scalar_cached, p) ≈ expected atol = 1.0e-10
+    end
+    A = [1.0 1.0; 0.0 1.0]
+    coupled(p) = solve(
+        NonlinearLeastSquaresProblem(
+            (u, p) -> A * u - p,
+            [0.5, 0.5], p; lb = [0.0, -Inf], ub = [1.0, Inf]
+        ), BoundedTrustRegion();
+        abstol = 1.0e-10, reltol = 1.0e-10
+    ).u
+    @test coupled([3.0, 0.0]) ≈ [1.0, 1.0] atol = 1.0e-8
+    @test ForwardDiff.jacobian(coupled, [3.0, 0.0]) ≈ [0.0 0.0; 0.5 0.5] atol = 1.0e-10
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,6 +67,7 @@ else
             @time @safetestset "Polyalgorithm Fallback Path: CurveFit.jl#76" include("Core/issue_tests__item2.jl")
             @time @safetestset "Polyalgorithm Cache solve!: Issue #779" include("Core/issue_tests__item3.jl")
             @time @safetestset "Bounds: NonlinearLeastSquaresProblem" include("Core/bounds_tests__item1.jl")
+            @time @safetestset "Bounds: implicit sensitivities" include("Core/bounds_sensitivity_tests.jl")
             @time @safetestset "Bounds: one-sided" include("Core/bounds_tests__item2.jl")
             @time @safetestset "Bounds: polyalgorithm and quasi-Newton algorithms" include("Core/bounds_tests__item4.jl")
             @time @safetestset "HomotopySweep construction + defaults" include("Core/homotopy_sweep_tests__item1.jl")


### PR DESCRIPTION
For `min (u-p)^2` with `0 ≤ u ≤ 1` and `p=2`, `BoundedTrustRegion()` returns `u=1`, but ForwardDiff currently reports `du/dp=1` instead of zero. Differentiate the projected stationarity equation in the shared least-squares sensitivity helper so active/fixed variables and coupled free variables satisfy the constrained system. Scalar-state sensitivities also preserve scalar shape and use a derivative instead of an array Jacobian.

This covers direct `solve` and cached `solve!`/`reinit!`, in-place and out-of-place residuals, nested AD and analytic Jacobian/VJP callbacks. The documented assumptions are parameter-independent bounds, a locally unchanged active set, and a nonsingular stationarity Jacobian on free variables; no derivative is claimed at active-set transitions.

## Verification

Julia 1.13.0, using `/home/crackauc/.juliaup/bin/julia +1.13.0 --compiled-modules=existing`. No dependencies or package versions changed.

The exact new regression file on the unfixed native solver introduction, https://github.com/SciML/NonlinearSolve.jl/commit/ab11738f30ea13464ca7891d8a8c2583f382ec7e:

```julia
julia --project -e 'include("test/Core/bounds_sensitivity_tests.jl")'
```
```text
Bounded least-squares implicit sensitivities | Pass  Fail  Error  Total
                                            |   14    16     12     42
```

The 16 assertion failures include active-bound derivatives of `1` versus expected `0`; the 12 errors are unsupported scalar `jacobian`, `vec`, or `reshape` calls. The native solver is absent from that commit's parent. Both relevant Base AD source files are identical between this introduction and current master, and the one-variable reproducer independently fails on clean current master with `derivative = 1.0`.

The identical regression file with this fix:

```text
Bounded least-squares implicit sensitivities | Pass  Total
                                            |   42     42
```

Full local checks:

```text
GROUP=Core julia --project -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
82 testsets, 1538 passing assertions, 89 pre-existing broken assertions
Bounds: implicit sensitivities | 42  42
Testing NonlinearSolve tests passed

GROUP=QA julia --project -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
QA | 28  28
Testing NonlinearSolve tests passed

GROUP=NonlinearSolveBase_QA julia --project -e 'using Pkg; Pkg.test(; julia_args=["--compiled-modules=existing"])'
QA | 20  20
Testing NonlinearSolveBase tests passed

julia --project=docs docs/make.jl
[ Info: RenderDocument: rendering document.
[ Info: Automatic `version="4.34.0"` for inventory from ../Project.toml
Exit 0
```

Runic, typos on changed files, and `git diff --check` passed. GPU, downstream packages, LTS, and reverse-mode sensitivities were not verified.

Please ignore this draft until reviewed by @ChrisRackauckas.

🤖 Generated with Codex CLI 0.154.0 (model: gpt-6-astra). Session: local transcript `/home/crackauc/.codex/sessions/2026/09/12/rollout-2026-09-12T04-30-15-01a094bd-179a-7972-97ec-36badb9448cd.jsonl`.
